### PR TITLE
feat(pulses): implement pulses scheduling system backend

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -24,6 +24,7 @@ import { providerRoutes } from './routes/providers';
 import { agentRoutes } from './routes/agents';
 import { runStreamRoutes } from './routes/runs';
 import { schedulerRoutes } from './routes/scheduler';
+import { pulseRoutes } from './routes/pulses';
 import { workspaceRoutes } from './routes/workspace';
 import { logRoutes } from './routes/logs';
 import { createMcpRoutesPlugin } from './routes/mcp';
@@ -177,11 +178,12 @@ export async function buildApp() {
   });
 
   // Create scheduler service if database is available
-  if (dbAdapter && jobsRepo && jobRunsRepo) {
+  if (dbAdapter && jobsRepo && jobRunsRepo && sessionsRepo) {
     scheduler = createSchedulerService(
       jobsRepo,
       jobRunsRepo,
       sessionService,
+      sessionsRepo,
       app.log,
       { pollIntervalMs: 5000 },
     );
@@ -274,6 +276,22 @@ export async function buildApp() {
     services.sessionsRepo
   ) {
     await app.register(schedulerRoutes, {
+      schedulerService: services.scheduler,
+      jobsRepo: services.jobsRepo,
+      jobRunsRepo: services.jobRunsRepo,
+      sessionsRepo: services.sessionsRepo,
+      authMiddleware,
+    });
+  }
+
+  // Register pulse routes (if database is available)
+  if (
+    services.scheduler &&
+    services.jobsRepo &&
+    services.jobRunsRepo &&
+    services.sessionsRepo
+  ) {
+    await app.register(pulseRoutes, {
       schedulerService: services.scheduler,
       jobsRepo: services.jobsRepo,
       jobRunsRepo: services.jobRunsRepo,

--- a/apps/server/src/pulses/utils.ts
+++ b/apps/server/src/pulses/utils.ts
@@ -1,0 +1,182 @@
+import type { ScheduledJob } from '@openaidy/db';
+import {
+  validateCronExpression,
+  calculateNextRun,
+  describeCronExpression,
+} from '../scheduler/cron-utils';
+
+/**
+ * Schedule input types - discriminated union for different scheduling options
+ */
+export type ScheduleInput =
+  | { every: '15m' | '30m' | '1h' | '6h' | '12h' | '1d' | '1w' }
+  | { daily: { hour: number; minute: number } }
+  | { cron: string; tz?: string }
+  | { at: string };
+
+/**
+ * Parsed schedule result
+ */
+export type ParsedSchedule = {
+  type: 'cron' | 'one-shot';
+  cronExpression?: string;
+  schedule?: Date;
+  nextRunAt: Date;
+};
+
+/**
+ * Mapping of 'every' values to cron expressions
+ */
+const EVERY_TO_CRON: Record<
+  '15m' | '30m' | '1h' | '6h' | '12h' | '1d' | '1w',
+  string
+> = {
+  '15m': '*/15 * * * *',
+  '30m': '*/30 * * * *',
+  '1h': '0 * * * *',
+  '6h': '0 */6 * * *',
+  '12h': '0 */12 * * *',
+  '1d': '0 0 * * *',
+  '1w': '0 0 * * 0',
+};
+
+/**
+ * Parse a schedule input into cron expression and next run time
+ */
+export function parseScheduleInput(schedule: ScheduleInput): ParsedSchedule {
+  // Handle 'every' schedules
+  if ('every' in schedule) {
+    const cronExpression = EVERY_TO_CRON[schedule.every];
+    if (!cronExpression) {
+      throw new Error(`Invalid every value: ${schedule.every}`);
+    }
+    validateCronExpression(cronExpression);
+    return {
+      type: 'cron',
+      cronExpression,
+      nextRunAt: calculateNextRun(cronExpression, new Date()),
+    };
+  }
+
+  // Handle 'daily' schedules
+  if ('daily' in schedule) {
+    const { hour, minute } = schedule.daily;
+
+    // Validate hour (0-23) and minute (0-59)
+    if (hour < 0 || hour > 23) {
+      throw new Error(`Invalid hour: ${hour}. Must be between 0 and 23.`);
+    }
+    if (minute < 0 || minute > 59) {
+      throw new Error(`Invalid minute: ${minute}. Must be between 0 and 59.`);
+    }
+
+    const cronExpression = `${minute} ${hour} * * *`;
+    validateCronExpression(cronExpression);
+    return {
+      type: 'cron',
+      cronExpression,
+      nextRunAt: calculateNextRun(cronExpression, new Date()),
+    };
+  }
+
+  // Handle 'cron' schedules
+  if ('cron' in schedule) {
+    const { cron: cronExpression, tz: _tz } = schedule;
+    // Note: timezone handling would require a timezone-aware cron parser
+    // For now, we validate and use UTC
+    validateCronExpression(cronExpression);
+    return {
+      type: 'cron',
+      cronExpression,
+      nextRunAt: calculateNextRun(cronExpression, new Date()),
+    };
+  }
+
+  // Handle 'at' schedules (one-shot)
+  if ('at' in schedule) {
+    const scheduleDate = new Date(schedule.at);
+
+    if (isNaN(scheduleDate.getTime())) {
+      throw new Error(`Invalid date format: ${schedule.at}`);
+    }
+
+    if (scheduleDate.getTime() <= Date.now()) {
+      throw new Error(`Schedule date must be in the future: ${schedule.at}`);
+    }
+
+    return {
+      type: 'one-shot',
+      schedule: scheduleDate,
+      nextRunAt: scheduleDate,
+    };
+  }
+
+  throw new Error('Invalid schedule input');
+}
+
+/**
+ * Pulse record type - the API response format for a pulse
+ */
+export type PulseRecord = {
+  id: string;
+  name: string;
+  prompt: string;
+  schedule: { cron?: string } | { at: string };
+  scheduleHuman: string;
+  status: 'active' | 'paused' | 'completed' | 'failed';
+  agentId?: string;
+  sessionId?: string;
+  lastRunAt?: Date;
+  nextRunAt: Date;
+  createdAt: Date;
+};
+
+/**
+ * Convert a ScheduledJob to a PulseRecord
+ */
+export function jobToPulse(job: ScheduledJob): PulseRecord {
+  const metadata = job.metadata as Record<string, unknown> | null;
+
+  // Extract name and prompt from metadata
+  const name = (metadata?.name as string | undefined) ?? 'Unnamed Pulse';
+  const prompt =
+    (metadata?.prompt as string | undefined) ??
+    (job.payload.message as string | undefined) ??
+    '';
+
+  // Derive schedule object
+  let schedule: PulseRecord['schedule'];
+  if (job.cronExpression) {
+    schedule = { cron: job.cronExpression };
+  } else if (job.schedule) {
+    schedule = { at: job.schedule.toISOString() };
+  } else {
+    // Default to cron if neither is set
+    schedule = { cron: job.cronExpression ?? '0 0 * * *' };
+  }
+
+  // Derive human-readable schedule
+  const scheduleHuman = job.cronExpression
+    ? describeCronExpression(job.cronExpression)
+    : job.schedule
+      ? `Once at ${job.schedule.toISOString()}`
+      : 'Unknown schedule';
+
+  const record: PulseRecord = {
+    id: job.id,
+    name,
+    prompt,
+    schedule,
+    scheduleHuman,
+    status: job.status,
+    nextRunAt: job.nextRunAt,
+    createdAt: job.createdAt,
+  };
+  const agentId = job.payload.agentId as string | undefined;
+  if (agentId !== undefined) record.agentId = agentId;
+  const sessionId = job.targetSessionId ?? undefined;
+  if (sessionId !== undefined) record.sessionId = sessionId;
+  const lastRunAt = job.lastRunAt ?? undefined;
+  if (lastRunAt !== undefined) record.lastRunAt = lastRunAt;
+  return record;
+}

--- a/apps/server/src/routes/pulses.ts
+++ b/apps/server/src/routes/pulses.ts
@@ -1,0 +1,488 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import type { SchedulerService } from '../scheduler/service';
+import type { JobsStore, JobRunsStore, SessionsStore } from '@openaidy/db';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import { requireAuth } from '../middleware/require-auth';
+import type { ScheduleInput } from '../pulses/utils';
+import { parseScheduleInput, jobToPulse } from '../pulses/utils';
+
+/**
+ * Validation schemas
+ */
+const createPulseSchema = z.object({
+  name: z.string().min(1),
+  prompt: z.string().min(1),
+  schedule: z.union([
+    z.object({
+      every: z.enum(['15m', '30m', '1h', '6h', '12h', '1d', '1w']),
+    }),
+    z.object({
+      daily: z.object({
+        hour: z.number().int().min(0).max(23),
+        minute: z.number().int().min(0).max(59),
+      }),
+    }),
+    z.object({
+      cron: z.object({
+        expression: z.string(),
+        tz: z.string().optional(),
+      }),
+    }),
+    z.object({
+      at: z.string(),
+    }),
+  ]),
+  agentId: z.string().optional(),
+  sessionId: z.string().uuid().optional(),
+});
+
+const updatePulseSchema = z.object({
+  name: z.string().min(1).optional(),
+  prompt: z.string().min(1).optional(),
+  schedule: z
+    .union([
+      z.object({
+        every: z.enum(['15m', '30m', '1h', '6h', '12h', '1d', '1w']),
+      }),
+      z.object({
+        daily: z.object({
+          hour: z.number().int().min(0).max(23),
+          minute: z.number().int().min(0).max(59),
+        }),
+      }),
+      z.object({
+        cron: z.object({
+          expression: z.string(),
+          tz: z.string().optional(),
+        }),
+      }),
+      z.object({
+        at: z.string(),
+      }),
+    ])
+    .optional(),
+  status: z.enum(['active', 'paused']).optional(),
+  agentId: z.string().optional(),
+  sessionId: z.string().uuid().optional(),
+});
+
+const listPulsesSchema = z.object({
+  status: z.enum(['active', 'paused', 'completed', 'failed']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const listRunsSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/**
+ * Pulse routes options
+ */
+export type PulseRoutesOptions = {
+  jobsRepo: JobsStore;
+  jobRunsRepo: JobRunsStore;
+  sessionsRepo: SessionsStore;
+  schedulerService: SchedulerService;
+  authMiddleware: AuthMiddleware;
+};
+
+/**
+ * Convert API schedule format to ScheduleInput
+ */
+function toScheduleInput(
+  schedule: z.infer<typeof createPulseSchema>['schedule'],
+): ScheduleInput {
+  if ('every' in schedule) {
+    return { every: schedule.every };
+  }
+  if ('daily' in schedule) {
+    return { daily: schedule.daily };
+  }
+  if ('cron' in schedule) {
+    const result: ScheduleInput = { cron: schedule.cron.expression };
+    if (schedule.cron.tz !== undefined) {
+      (result as { cron: string; tz?: string }).tz = schedule.cron.tz;
+    }
+    return result;
+  }
+  if ('at' in schedule) {
+    return { at: schedule.at };
+  }
+  throw new Error('Invalid schedule format');
+}
+
+/**
+ * Pulse routes
+ *
+ * Provides REST API for managing pulses (scheduled AI tasks).
+ */
+export const pulseRoutes: FastifyPluginAsync<PulseRoutesOptions> = async (
+  app,
+  options,
+) => {
+  const {
+    jobsRepo,
+    jobRunsRepo,
+    sessionsRepo,
+    schedulerService,
+    authMiddleware,
+  } = options;
+
+  app.addHook(
+    'preHandler',
+    requireAuth({ authMiddleware, requiredScope: '*' }),
+  );
+
+  /**
+   * POST /api/pulses
+   * Create a new pulse
+   */
+  app.post('/api/pulses', async (request, reply) => {
+    let parsed;
+    try {
+      parsed = createPulseSchema.parse(request.body);
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: 'validation.invalid_request',
+        message:
+          error instanceof Error ? error.message : 'Invalid request body',
+      };
+    }
+
+    // If sessionId provided, verify session exists
+    if (parsed.sessionId) {
+      const session = await sessionsRepo.findById(parsed.sessionId);
+      if (!session) {
+        reply.code(404);
+        return {
+          error: 'session.not_found',
+          message: 'Session not found',
+        };
+      }
+    }
+
+    // Parse schedule to get cron expression and next run time
+    const scheduleInput = toScheduleInput(parsed.schedule);
+    let parsedSchedule;
+    try {
+      parsedSchedule = parseScheduleInput(scheduleInput);
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: 'validation.invalid_schedule',
+        message: error instanceof Error ? error.message : 'Invalid schedule',
+      };
+    }
+
+    const createJobInput: Parameters<typeof jobsRepo.create>[0] = {
+      type: parsedSchedule.type,
+      targetType: 'isolated',
+      payload: {
+        message: parsed.prompt,
+        agentId: parsed.agentId,
+      },
+      status: 'active',
+      metadata: {
+        kind: 'pulse',
+        name: parsed.name,
+      },
+      nextRunAt: parsedSchedule.nextRunAt,
+    };
+    if (parsedSchedule.schedule !== undefined) {
+      createJobInput.schedule = parsedSchedule.schedule;
+    }
+    if (parsedSchedule.cronExpression !== undefined) {
+      createJobInput.cronExpression = parsedSchedule.cronExpression;
+    }
+    const job = await jobsRepo.create(createJobInput);
+
+    reply.code(201);
+    return jobToPulse(job);
+  });
+
+  /**
+   * GET /api/pulses
+   * List pulses with optional filters
+   */
+  app.get('/api/pulses', async (request, reply) => {
+    let parsed;
+    try {
+      parsed = listPulsesSchema.parse(request.query);
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: 'validation.invalid_request',
+        message:
+          error instanceof Error ? error.message : 'Invalid query parameters',
+      };
+    }
+
+    // Fetch all jobs and filter by pulse type (metadata.kind === 'pulse')
+    const listFilters: Parameters<typeof jobsRepo.list>[0] = { limit: 1000 };
+    if (parsed.status !== undefined) {
+      listFilters.status = parsed.status;
+    }
+    const allJobs = await jobsRepo.list(listFilters);
+
+    // Filter to only pulses
+    const pulses = allJobs.filter((job) => {
+      const metadata = job.metadata as Record<string, unknown> | null;
+      return metadata?.kind === 'pulse';
+    });
+
+    // Apply pagination
+    const total = pulses.length;
+    const paginatedPulses = pulses.slice(
+      parsed.offset,
+      parsed.offset + parsed.limit,
+    );
+
+    return {
+      pulses: paginatedPulses.map(jobToPulse),
+      total,
+      limit: parsed.limit,
+      offset: parsed.offset,
+    };
+  });
+
+  /**
+   * GET /api/pulses/:id
+   * Get pulse details
+   */
+  app.get('/api/pulses/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    const job = await jobsRepo.findById(id);
+    if (!job) {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const metadata = job.metadata as Record<string, unknown> | null;
+    if (metadata?.kind !== 'pulse') {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    return jobToPulse(job);
+  });
+
+  /**
+   * PATCH /api/pulses/:id
+   * Update pulse (pause/resume, update name, prompt, schedule, etc.)
+   */
+  app.patch('/api/pulses/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    let parsed;
+    try {
+      parsed = updatePulseSchema.parse(request.body);
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: 'validation.invalid_request',
+        message:
+          error instanceof Error ? error.message : 'Invalid request body',
+      };
+    }
+
+    // Check pulse exists
+    const existingJob = await jobsRepo.findById(id);
+    if (!existingJob) {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const existingMetadata = existingJob.metadata as Record<
+      string,
+      unknown
+    > | null;
+    if (existingMetadata?.kind !== 'pulse') {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    // Build updates
+    const updates: {
+      status?: 'active' | 'paused' | 'completed' | 'failed';
+      metadata?: Record<string, unknown>;
+      nextRunAt?: Date;
+      cronExpression?: string;
+      schedule?: Date;
+    } = {};
+
+    if (parsed.status !== undefined) {
+      updates.status = parsed.status;
+    }
+
+    // Handle schedule update
+    if (parsed.schedule !== undefined) {
+      const scheduleInput = toScheduleInput(parsed.schedule);
+      const parsedSchedule = parseScheduleInput(scheduleInput);
+      if (parsedSchedule.cronExpression !== undefined) {
+        updates.cronExpression = parsedSchedule.cronExpression;
+      }
+      if (parsedSchedule.schedule !== undefined) {
+        updates.schedule = parsedSchedule.schedule;
+      }
+      updates.nextRunAt = parsedSchedule.nextRunAt;
+    }
+
+    // Handle metadata updates (name, prompt changes)
+    if (parsed.name !== undefined || parsed.prompt !== undefined) {
+      const newMetadata = { ...existingMetadata };
+      if (parsed.name !== undefined) {
+        newMetadata.name = parsed.name;
+      }
+      updates.metadata = newMetadata;
+    }
+
+    const updatedJob = await jobsRepo.update(id, updates);
+
+    return jobToPulse(updatedJob);
+  });
+
+  /**
+   * DELETE /api/pulses/:id
+   * Delete pulse
+   */
+  app.delete('/api/pulses/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    // Check pulse exists
+    const existingJob = await jobsRepo.findById(id);
+    if (!existingJob) {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const metadata = existingJob.metadata as Record<string, unknown> | null;
+    if (metadata?.kind !== 'pulse') {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    await jobsRepo.delete(id);
+    reply.code(204);
+    return;
+  });
+
+  /**
+   * POST /api/pulses/:id/trigger
+   * Manually trigger pulse execution
+   */
+  app.post('/api/pulses/:id/trigger', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    // Check pulse exists
+    const existingJob = await jobsRepo.findById(id);
+    if (!existingJob) {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const metadata = existingJob.metadata as Record<string, unknown> | null;
+    if (metadata?.kind !== 'pulse') {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    try {
+      const run = await schedulerService.triggerJob(id);
+      const updatedRun = await jobRunsRepo.findById(run.id);
+      return { run: updatedRun || run };
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Job not found') {
+        reply.code(404);
+        return {
+          error: 'pulse.not_found',
+          message: 'Pulse not found',
+        };
+      }
+      throw error;
+    }
+  });
+
+  /**
+   * GET /api/pulses/:id/history
+   * List pulse execution history
+   */
+  app.get('/api/pulses/:id/history', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    let parsed;
+    try {
+      parsed = listRunsSchema.parse(request.query);
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: 'validation.invalid_request',
+        message:
+          error instanceof Error ? error.message : 'Invalid query parameters',
+      };
+    }
+
+    // Check pulse exists
+    const existingJob = await jobsRepo.findById(id);
+    if (!existingJob) {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const metadata = existingJob.metadata as Record<string, unknown> | null;
+    if (metadata?.kind !== 'pulse') {
+      reply.code(404);
+      return {
+        error: 'pulse.not_found',
+        message: 'Pulse not found',
+      };
+    }
+
+    const runs = await jobRunsRepo.listByJob(id, {
+      limit: parsed.limit,
+      offset: parsed.offset,
+    });
+
+    const total = runs.length;
+
+    return {
+      runs,
+      total,
+      limit: parsed.limit,
+      offset: parsed.offset,
+    };
+  });
+};
+
+export default pulseRoutes;

--- a/apps/server/src/scheduler/service.test.ts
+++ b/apps/server/src/scheduler/service.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { JobsRepository, JobRunsRepository } from '@openaidy/db';
 import type { ScheduledJob, JobRun } from '@openaidy/db';
-import { SchedulerService, createSchedulerService, type GenericLogger } from './service';
+import {
+  SchedulerService,
+  createSchedulerService,
+  type GenericLogger,
+} from './service';
 import type { SessionMessageService } from '../sessions/service';
 
 // Create mock functions
@@ -50,6 +54,17 @@ function createMockSessionService() {
   };
 }
 
+function createMockSessionsStore() {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    list: vi.fn(),
+    updateTitle: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
 // Helper to create a mock job
 function createMockJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
   return {
@@ -95,6 +110,7 @@ describe('SchedulerService', () => {
   let mockJobsRepo: ReturnType<typeof createMockJobsRepo>;
   let mockJobRunsRepo: ReturnType<typeof createMockJobRunsRepo>;
   let mockSessionService: ReturnType<typeof createMockSessionService>;
+  let mockSessionsStore: ReturnType<typeof createMockSessionsStore>;
   let mockLogger: GenericLogger;
 
   beforeEach(() => {
@@ -102,6 +118,7 @@ describe('SchedulerService', () => {
     mockJobsRepo = createMockJobsRepo();
     mockJobRunsRepo = createMockJobRunsRepo();
     mockSessionService = createMockSessionService();
+    mockSessionsStore = createMockSessionsStore();
     mockLogger = createMockLogger();
 
     // Cast to any to avoid complex type issues with mocks
@@ -109,8 +126,9 @@ describe('SchedulerService', () => {
       mockJobsRepo as unknown as JobsRepository,
       mockJobRunsRepo as unknown as JobRunsRepository,
       mockSessionService as unknown as SessionMessageService,
+      mockSessionsStore as unknown as SessionsStore,
       mockLogger,
-      { pollIntervalMs: 5000 }
+      { pollIntervalMs: 5000 },
     );
   });
 
@@ -136,7 +154,7 @@ describe('SchedulerService', () => {
       scheduler.start();
       expect(mockLogger.info).toHaveBeenCalledWith(
         { pollIntervalMs: 5000 },
-        'Scheduler started'
+        'Scheduler started',
       );
     });
   });
@@ -195,14 +213,20 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
         assistantMessage: {},
         run: {},
       });
-      mockJobsRepo.update.mockResolvedValue({ ...mockJob, status: 'completed' });
+      mockJobsRepo.update.mockResolvedValue({
+        ...mockJob,
+        status: 'completed',
+      });
 
       scheduler.start();
       const result = await scheduler.tick();
@@ -221,14 +245,20 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
         assistantMessage: {},
         run: {},
       });
-      mockJobsRepo.update.mockResolvedValue({ ...mockJob, status: 'completed' });
+      mockJobsRepo.update.mockResolvedValue({
+        ...mockJob,
+        status: 'completed',
+      });
 
       scheduler.start();
       await scheduler.tick();
@@ -245,14 +275,20 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
         assistantMessage: {},
         run: {},
       });
-      mockJobsRepo.update.mockResolvedValue({ ...mockJob, status: 'completed' });
+      mockJobsRepo.update.mockResolvedValue({
+        ...mockJob,
+        status: 'completed',
+      });
 
       scheduler.start();
       await scheduler.tick();
@@ -272,7 +308,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
@@ -290,7 +329,7 @@ describe('SchedulerService', () => {
           retryCount: 0,
           lastRunAt: expect.any(Date),
           nextRunAt: expect.any(Date),
-        })
+        }),
       );
     });
 
@@ -300,7 +339,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: false,
         error: { code: 'PROVIDER_ERROR', message: 'Provider failed' },
@@ -316,7 +358,7 @@ describe('SchedulerService', () => {
           status: 'failed',
           errorCode: expect.any(String),
           errorMessage: expect.any(String),
-        })
+        }),
       );
 
       expect(mockJobsRepo.update).toHaveBeenCalledWith(
@@ -324,7 +366,7 @@ describe('SchedulerService', () => {
         expect.objectContaining({
           retryCount: 1,
           nextRunAt: expect.any(Date),
-        })
+        }),
       );
     });
 
@@ -334,7 +376,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: false,
         error: { code: 'PROVIDER_ERROR', message: 'Provider failed' },
@@ -356,7 +401,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockJobsRepo.update.mockResolvedValue(mockJob);
 
       scheduler.start();
@@ -367,17 +415,80 @@ describe('SchedulerService', () => {
         expect.objectContaining({
           status: 'failed',
           errorMessage: 'Session job missing targetSessionId',
-        })
+        }),
       );
     });
 
-    it('throws error for isolated jobs (not implemented)', async () => {
-      const mockJob = createMockJob({ targetType: 'isolated', targetSessionId: null });
+    it('executes isolated jobs by creating a new session', async () => {
+      const mockJob = createMockJob({
+        targetType: 'isolated',
+        targetSessionId: null,
+        metadata: { name: 'Test Pulse' },
+      });
+      const mockRun = createMockRun();
+      const mockNewSession = {
+        id: 'new-session-id',
+        title: 'Pulse: Test Pulse',
+      };
+
+      mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
+      mockJobRunsRepo.create.mockResolvedValue(mockRun);
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
+      mockSessionsStore.create.mockResolvedValue(
+        mockNewSession as SessionsStore['create'] extends (
+          input: infer I,
+        ) => Promise<infer R>
+          ? R
+          : never,
+      );
+      mockSessionService.submitMessage.mockResolvedValue({
+        ok: true,
+        userMessage: {},
+        assistantMessage: {},
+        run: {},
+      });
+      mockJobsRepo.update.mockResolvedValue(mockJob);
+
+      scheduler.start();
+      await scheduler.tick();
+
+      expect(mockSessionsStore.create).toHaveBeenCalledWith({
+        title: 'Pulse: Test Pulse',
+      });
+      expect(mockSessionService.submitMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'new-session-id',
+          role: 'user',
+          content: 'Test message',
+        }),
+      );
+      expect(mockJobRunsRepo.updateStatus).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          status: 'succeeded',
+        }),
+      );
+    });
+
+    it('isolated job fails if session creation fails', async () => {
+      const mockJob = createMockJob({
+        targetType: 'isolated',
+        targetSessionId: null,
+      });
       const mockRun = createMockRun();
 
       mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
+      mockSessionsStore.create.mockRejectedValue(
+        new Error('Session creation failed'),
+      );
       mockJobsRepo.update.mockResolvedValue(mockJob);
 
       scheduler.start();
@@ -387,8 +498,48 @@ describe('SchedulerService', () => {
         'run-1',
         expect.objectContaining({
           status: 'failed',
-          errorMessage: 'Isolated job execution not yet implemented',
-        })
+          errorMessage: 'Session creation failed',
+        }),
+      );
+    });
+
+    it('isolated job fails if message submission fails', async () => {
+      const mockJob = createMockJob({
+        targetType: 'isolated',
+        targetSessionId: null,
+      });
+      const mockRun = createMockRun();
+      const mockNewSession = { id: 'new-session-id', title: 'Pulse: unnamed' };
+
+      mockJobsRepo.claimNextDueJob.mockResolvedValue(mockJob);
+      mockJobRunsRepo.create.mockResolvedValue(mockRun);
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
+      mockSessionsStore.create.mockResolvedValue(
+        mockNewSession as SessionsStore['create'] extends (
+          input: infer I,
+        ) => Promise<infer R>
+          ? R
+          : never,
+      );
+      mockSessionService.submitMessage.mockResolvedValue({
+        ok: false,
+        error: { code: 'PROVIDER_ERROR', message: 'Provider failed' },
+      });
+      mockJobsRepo.update.mockResolvedValue(mockJob);
+
+      scheduler.start();
+      await scheduler.tick();
+
+      expect(mockJobRunsRepo.updateStatus).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          status: 'failed',
+          errorMessage:
+            'Isolated job execution failed: PROVIDER_ERROR - Provider failed',
+        }),
       );
     });
   });
@@ -396,7 +547,9 @@ describe('SchedulerService', () => {
   describe('triggerJob()', () => {
     it('throws error if job not found', async () => {
       mockJobsRepo.findById.mockResolvedValue(null);
-      await expect(scheduler.triggerJob('non-existent')).rejects.toThrow('Job not found');
+      await expect(scheduler.triggerJob('non-existent')).rejects.toThrow(
+        'Job not found',
+      );
     });
 
     it('executes job immediately', async () => {
@@ -405,7 +558,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.findById.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'succeeded' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'succeeded',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
@@ -429,7 +585,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.findById.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'succeeded' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'succeeded',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: true,
         userMessage: {},
@@ -442,7 +601,7 @@ describe('SchedulerService', () => {
       expect(mockJobRunsRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           attemptNumber: 0,
-        })
+        }),
       );
     });
 
@@ -452,7 +611,10 @@ describe('SchedulerService', () => {
 
       mockJobsRepo.findById.mockResolvedValue(mockJob);
       mockJobRunsRepo.create.mockResolvedValue(mockRun);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'running' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'running',
+      });
       mockSessionService.submitMessage.mockResolvedValue({
         ok: false,
         error: { code: 'PROVIDER_ERROR', message: 'Provider failed' },
@@ -464,19 +626,25 @@ describe('SchedulerService', () => {
         'run-1',
         expect.objectContaining({
           status: 'failed',
-        })
+        }),
       );
     });
   });
 
   describe('recoverStuckJobs()', () => {
     it('recovers stuck runs on startup', async () => {
-      const mockRun = createMockRun({ status: 'running', startedAt: new Date() });
+      const mockRun = createMockRun({
+        status: 'running',
+        startedAt: new Date(),
+      });
       const mockJob = createMockJob();
 
       mockJobRunsRepo.listByStatus.mockResolvedValue([mockRun]);
       mockJobsRepo.findById.mockResolvedValue(mockJob);
-      mockJobRunsRepo.updateStatus.mockResolvedValue({ ...mockRun, status: 'failed' });
+      mockJobRunsRepo.updateStatus.mockResolvedValue({
+        ...mockRun,
+        status: 'failed',
+      });
       mockJobsRepo.update.mockResolvedValue(mockJob);
 
       await scheduler.recoverStuckJobs();
@@ -504,13 +672,15 @@ describe('createSchedulerService', () => {
     const mockJobsRepo = createMockJobsRepo();
     const mockJobRunsRepo = createMockJobRunsRepo();
     const mockSessionService = createMockSessionService();
+    const mockSessionsStore = createMockSessionsStore();
     const mockLogger = createMockLogger();
 
     const scheduler = createSchedulerService(
       mockJobsRepo as unknown as JobsRepository,
       mockJobRunsRepo as unknown as JobRunsRepository,
       mockSessionService as unknown as SessionMessageService,
-      mockLogger
+      mockSessionsStore as unknown as SessionsStore,
+      mockLogger,
     );
 
     expect(scheduler).toBeInstanceOf(SchedulerService);

--- a/apps/server/src/scheduler/service.ts
+++ b/apps/server/src/scheduler/service.ts
@@ -1,4 +1,4 @@
-import type { JobsStore, JobRunsStore } from '@openaidy/db';
+import type { JobsStore, JobRunsStore, SessionsStore } from '@openaidy/db';
 import type { ScheduledJob, JobRun } from '@openaidy/db';
 import type { SessionMessageService } from '../sessions/service';
 import { calculateNextRun } from './cron-utils';
@@ -46,6 +46,7 @@ export class SchedulerService {
     private readonly jobsRepo: JobsStore,
     private readonly jobRunsRepo: JobRunsStore,
     private readonly sessionMessageService: SessionMessageService,
+    private readonly sessionsStore: SessionsStore,
     private readonly logger: GenericLogger,
     options?: SchedulerServiceOptions,
   ) {
@@ -284,8 +285,33 @@ export class SchedulerService {
         );
       }
     } else {
-      // Isolated execution - not yet implemented
-      throw new Error('Isolated job execution not yet implemented');
+      // Isolated execution - create a fresh session for the pulse
+      const metadata = job.metadata as Record<string, unknown> | null;
+      const pulseName = (metadata?.name as string | undefined) ?? 'unnamed';
+
+      // Create a new session for this isolated execution
+      const newSession = await this.sessionsStore.create({
+        title: `Pulse: ${pulseName}`,
+      });
+
+      // Submit the message to the new session
+      const submitInput: Parameters<
+        typeof this.sessionMessageService.submitMessage
+      >[0] = {
+        sessionId: newSession.id,
+        role: 'user',
+        content: (job.payload.message as string) || 'Scheduled job execution',
+      };
+      const agentId = job.payload.agentId as string | undefined;
+      if (agentId !== undefined) submitInput.agentId = agentId;
+      const result =
+        await this.sessionMessageService.submitMessage(submitInput);
+
+      if (!result.ok) {
+        throw new Error(
+          `Isolated job execution failed: ${result.error.code} - ${result.error.message}`,
+        );
+      }
     }
   }
 
@@ -390,6 +416,7 @@ export function createSchedulerService(
   jobsRepo: JobsStore,
   jobRunsRepo: JobRunsStore,
   sessionMessageService: SessionMessageService,
+  sessionsStore: SessionsStore,
   logger: GenericLogger,
   options?: SchedulerServiceOptions,
 ): SchedulerService {
@@ -397,6 +424,7 @@ export function createSchedulerService(
     jobsRepo,
     jobRunsRepo,
     sessionMessageService,
+    sessionsStore,
     logger,
     options,
   );

--- a/apps/web/src/components/pages/PulsesPage.tsx
+++ b/apps/web/src/components/pages/PulsesPage.tsx
@@ -1,11 +1,222 @@
+/**
+ * PulsesPage Component
+ *
+ * Main page for managing pulses (scheduled AI prompt executions).
+ */
+
+import { createSignal, Show, For, onMount } from 'solid-js';
+import { Zap, Plus } from 'lucide-solid';
 import { Layout } from './Layout';
+import { PulseCard } from '../pulses/PulseCard';
+import { CreateEditPulseModal } from '../pulses/CreateEditPulseModal';
+import { PulseHistoryDrawer } from '../pulses/PulseHistoryDrawer';
+import {
+  listPulses,
+  createPulse,
+  updatePulse,
+  deletePulse,
+  triggerPulse,
+  type Pulse,
+  type CreatePulseBody,
+  type UpdatePulseBody,
+} from '../../lib/api';
+import { resolveToken } from '../../lib/auth-token';
 
 export function PulsesPage() {
+  const [pulses, setPulses] = createSignal<Pulse[]>([]);
+  const [isLoading, setIsLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+  const [actionLoadingId, setActionLoadingId] = createSignal<string | null>(
+    null,
+  );
+  const [historyPulseId, setHistoryPulseId] = createSignal<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = createSignal(false);
+  const [editingPulse, setEditingPulse] = createSignal<Pulse | undefined>(
+    undefined,
+  );
+
+  const token = () => resolveToken() ?? '';
+
+  const load = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await listPulses(token());
+      setPulses(data.pulses);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load pulses');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  onMount(() => {
+    void load();
+  });
+
+  const handleCreate = () => {
+    setEditingPulse(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleEdit = (pulse: Pulse) => {
+    setEditingPulse(pulse);
+    setIsModalOpen(true);
+  };
+
+  const handleHistory = (id: string) => {
+    setHistoryPulseId(id);
+  };
+
+  const handleTrigger = async (id: string) => {
+    setActionLoadingId(id);
+    try {
+      await triggerPulse(token(), id);
+      void load();
+    } catch (err) {
+      console.error('Failed to trigger pulse:', err);
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const handlePause = async (id: string) => {
+    setActionLoadingId(id);
+    try {
+      const result = await updatePulse(token(), id, { status: 'paused' });
+      setPulses((prev) => prev.map((p) => (p.id === id ? result.pulse : p)));
+    } catch (err) {
+      console.error('Failed to pause pulse:', err);
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const handleResume = async (id: string) => {
+    setActionLoadingId(id);
+    try {
+      const result = await updatePulse(token(), id, { status: 'active' });
+      setPulses((prev) => prev.map((p) => (p.id === id ? result.pulse : p)));
+    } catch (err) {
+      console.error('Failed to resume pulse:', err);
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this pulse?')) return;
+    setActionLoadingId(id);
+    try {
+      await deletePulse(token(), id);
+      setPulses((prev) => prev.filter((p) => p.id !== id));
+    } catch (err) {
+      console.error('Failed to delete pulse:', err);
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const handleModalSubmit = async (body: CreatePulseBody | UpdatePulseBody) => {
+    if (editingPulse()) {
+      // Edit mode - partial update
+      const updateBody = body as UpdatePulseBody;
+      const result = await updatePulse(token(), editingPulse()!.id, updateBody);
+      setPulses((prev) =>
+        prev.map((p) => (p.id === editingPulse()!.id ? result.pulse : p)),
+      );
+    } else {
+      // Create mode
+      const result = await createPulse(token(), body as CreatePulseBody);
+      setPulses((prev) => [result.pulse, ...prev]);
+    }
+    setIsModalOpen(false);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+
   return (
-    <Layout title="Pulses" description="Scheduled jobs and cron tasks">
-      <div class="flex items-center justify-center h-64">
-        <p class="text-text-tertiary">Scheduled pulses coming soon</p>
-      </div>
+    <Layout
+      title="Pulses"
+      description="Scheduled AI prompt executions"
+      actions={
+        <button
+          onClick={handleCreate}
+          class="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded-lg transition-colors text-sm font-medium"
+        >
+          <Plus class="w-4 h-4" />
+          New Pulse
+        </button>
+      }
+    >
+      <Show when={isLoading()}>
+        <div class="flex items-center justify-center h-64">
+          <div class="animate-pulse text-text-tertiary">Loading pulses...</div>
+        </div>
+      </Show>
+
+      <Show when={!isLoading() && error()}>
+        <div class="text-center py-12">
+          <p class="text-red-600 dark:text-red-400 mb-4">{error()}</p>
+          <button
+            onClick={() => void load()}
+            class="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded-lg transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
+
+      <Show when={!isLoading() && !error() && pulses().length === 0}>
+        <div class="text-center py-12">
+          <Zap class="w-12 h-12 mx-auto mb-4 text-text-muted" />
+          <h3 class="text-lg font-medium text-text-primary mb-2">
+            No pulses yet
+          </h3>
+          <p class="text-text-secondary mb-4">
+            Create your first pulse to schedule AI prompt executions
+          </p>
+          <button
+            onClick={handleCreate}
+            class="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded-lg transition-colors"
+          >
+            Create Pulse
+          </button>
+        </div>
+      </Show>
+
+      <Show when={!isLoading() && !error() && pulses().length > 0}>
+        <div class="grid gap-4">
+          <For each={pulses()}>
+            {(pulse) => (
+              <PulseCard
+                pulse={pulse}
+                onTrigger={handleTrigger}
+                onPause={handlePause}
+                onResume={handleResume}
+                onEdit={handleEdit}
+                onHistory={handleHistory}
+                onDelete={handleDelete}
+                isActionLoading={actionLoadingId() === pulse.id}
+              />
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <CreateEditPulseModal
+        isOpen={isModalOpen()}
+        onClose={handleModalClose}
+        onSubmit={handleModalSubmit}
+        pulse={editingPulse()}
+      />
+
+      <PulseHistoryDrawer
+        pulseId={historyPulseId()}
+        onClose={() => setHistoryPulseId(null)}
+      />
     </Layout>
   );
 }

--- a/apps/web/src/components/pulses/CreateEditPulseModal.tsx
+++ b/apps/web/src/components/pulses/CreateEditPulseModal.tsx
@@ -1,0 +1,313 @@
+/**
+ * CreateEditPulseModal Component
+ *
+ * Modal for creating and editing pulses with name, prompt, and schedule.
+ */
+
+import { createSignal, createEffect, Show, on } from 'solid-js';
+import { Modal } from '../ui/Modal';
+import type {
+  Pulse,
+  CreatePulseBody,
+  UpdatePulseBody,
+  ScheduleInput,
+} from '../../lib/api';
+
+export type CreateEditPulseModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (body: CreatePulseBody | UpdatePulseBody) => Promise<void>;
+  pulse?: Pulse;
+  isLoading?: boolean;
+};
+
+type ScheduleType = 'interval' | 'daily' | 'cron' | 'at';
+
+const INTERVAL_OPTIONS = [
+  { value: '15m', label: 'Every 15 minutes' },
+  { value: '30m', label: 'Every 30 minutes' },
+  { value: '1h', label: 'Every hour' },
+  { value: '6h', label: 'Every 6 hours' },
+  { value: '12h', label: 'Every 12 hours' },
+  { value: '1d', label: 'Every day' },
+  { value: '1w', label: 'Every week' },
+] as const;
+
+export function CreateEditPulseModal(props: CreateEditPulseModalProps) {
+  const [name, setName] = createSignal('');
+  const [prompt, setPrompt] = createSignal('');
+  const [scheduleType, setScheduleType] =
+    createSignal<ScheduleType>('interval');
+  const [interval, setInterval] = createSignal<
+    '15m' | '30m' | '1h' | '6h' | '12h' | '1d' | '1w'
+  >('1h');
+  const [dailyHour, setDailyHour] = createSignal(9);
+  const [dailyMinute, setDailyMinute] = createSignal(0);
+  const [cronExpression, setCronExpression] = createSignal('0 * * * *');
+  const [atDate, setAtDate] = createSignal('');
+  const [errors, setErrors] = createSignal<Record<string, string>>({});
+  const [submitting, setSubmitting] = createSignal(false);
+
+  // Reset form when modal opens or pulse changes
+  createEffect(
+    on(
+      () => [props.isOpen, props.pulse],
+      () => {
+        if (props.isOpen) {
+          if (props.pulse) {
+            // Edit mode - parse existing pulse
+            setName(props.pulse.name);
+            setPrompt(props.pulse.prompt);
+            // Try to detect schedule type from scheduleHuman or pulse data
+            // Default to interval for now
+            setScheduleType('interval');
+            setInterval('1h');
+          } else {
+            // Create mode
+            setName('');
+            setPrompt('');
+            setScheduleType('interval');
+            setInterval('1h');
+            setDailyHour(9);
+            setDailyMinute(0);
+            setCronExpression('0 * * * *');
+            setAtDate('');
+          }
+          setErrors({});
+        }
+      },
+      { defer: false },
+    ),
+  );
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!name().trim()) {
+      newErrors.name = 'Name is required';
+    }
+    if (!prompt().trim()) {
+      newErrors.prompt = 'Prompt is required';
+    }
+    if (scheduleType() === 'cron' && !cronExpression().trim()) {
+      newErrors.cron = 'Cron expression is required';
+    }
+    if (scheduleType() === 'at' && !atDate()) {
+      newErrors.at = 'Date is required';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const buildScheduleInput = (): ScheduleInput => {
+    switch (scheduleType()) {
+      case 'interval':
+        return { every: interval() };
+      case 'daily':
+        return { daily: { hour: dailyHour(), minute: dailyMinute() } };
+      case 'cron':
+        return { cron: cronExpression() };
+      case 'at':
+        return { at: atDate() };
+    }
+  };
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setSubmitting(true);
+    try {
+      const body = buildScheduleInput();
+      if (props.pulse) {
+        await props.onSubmit({
+          name: name(),
+          prompt: prompt(),
+          schedule: body,
+        } as UpdatePulseBody);
+      } else {
+        await props.onSubmit({
+          name: name(),
+          prompt: prompt(),
+          schedule: body,
+        } as CreatePulseBody);
+      }
+    } catch (err) {
+      setErrors({
+        submit: err instanceof Error ? err.message : 'Failed to save',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      title={props.pulse ? 'Edit Pulse' : 'Create Pulse'}
+      size="lg"
+    >
+      <form onSubmit={handleSubmit} class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium text-text-primary mb-1">
+            Name
+          </label>
+          <input
+            type="text"
+            value={name()}
+            onInput={(e) => setName(e.currentTarget.value)}
+            class={`w-full px-3 py-2 rounded-lg border ${errors().name ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'} bg-white dark:bg-gray-800 text-text-primary`}
+            placeholder="Daily AI digest"
+          />
+          <Show when={errors().name}>
+            <p class="text-sm text-red-500 mt-1">{errors().name}</p>
+          </Show>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-text-primary mb-1">
+            Prompt
+          </label>
+          <textarea
+            value={prompt()}
+            onInput={(e) => setPrompt(e.currentTarget.value)}
+            rows={4}
+            class={`w-full px-3 py-2 rounded-lg border ${errors().prompt ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'} bg-white dark:bg-gray-800 text-text-primary resize-none`}
+            placeholder="Summarize my conversations from today"
+          />
+          <Show when={errors().prompt}>
+            <p class="text-sm text-red-500 mt-1">{errors().prompt}</p>
+          </Show>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-text-primary mb-2">
+            Schedule
+          </label>
+          <div class="flex flex-wrap gap-2 mb-3">
+            <button
+              type="button"
+              onClick={() => setScheduleType('interval')}
+              class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${scheduleType() === 'interval' ? 'bg-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'}`}
+            >
+              Interval
+            </button>
+            <button
+              type="button"
+              onClick={() => setScheduleType('daily')}
+              class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${scheduleType() === 'daily' ? 'bg-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'}`}
+            >
+              Daily
+            </button>
+            <button
+              type="button"
+              onClick={() => setScheduleType('cron')}
+              class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${scheduleType() === 'cron' ? 'bg-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'}`}
+            >
+              Cron
+            </button>
+            <button
+              type="button"
+              onClick={() => setScheduleType('at')}
+              class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${scheduleType() === 'at' ? 'bg-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'}`}
+            >
+              One-time
+            </button>
+          </div>
+
+          <Show when={scheduleType() === 'interval'}>
+            <select
+              value={interval()}
+              onChange={(e) =>
+                setInterval(
+                  e.currentTarget.value as typeof interval extends () => infer T
+                    ? T
+                    : never,
+                )
+              }
+              class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-text-primary"
+            >
+              {INTERVAL_OPTIONS.map((opt) => (
+                <option value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </Show>
+
+          <Show when={scheduleType() === 'daily'}>
+            <div class="flex items-center gap-2">
+              <select
+                value={dailyHour()}
+                onChange={(e) => setDailyHour(Number(e.currentTarget.value))}
+                class="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-text-primary"
+              >
+                {Array.from({ length: 24 }, (_, i) => (
+                  <option value={i}>{i.toString().padStart(2, '0')}</option>
+                ))}
+              </select>
+              <span>:</span>
+              <select
+                value={dailyMinute()}
+                onChange={(e) => setDailyMinute(Number(e.currentTarget.value))}
+                class="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-text-primary"
+              >
+                {[0, 15, 30, 45].map((m) => (
+                  <option value={m}>{m.toString().padStart(2, '0')}</option>
+                ))}
+              </select>
+            </div>
+          </Show>
+
+          <Show when={scheduleType() === 'cron'}>
+            <input
+              type="text"
+              value={cronExpression()}
+              onInput={(e) => setCronExpression(e.currentTarget.value)}
+              placeholder="0 * * * *"
+              class={`w-full px-3 py-2 rounded-lg border ${errors().cron ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'} bg-white dark:bg-gray-800 text-text-primary`}
+            />
+            <Show when={errors().cron}>
+              <p class="text-sm text-red-500 mt-1">{errors().cron}</p>
+            </Show>
+          </Show>
+
+          <Show when={scheduleType() === 'at'}>
+            <input
+              type="datetime-local"
+              value={atDate()}
+              onInput={(e) => setAtDate(e.currentTarget.value)}
+              class={`w-full px-3 py-2 rounded-lg border ${errors().at ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'} bg-white dark:bg-gray-800 text-text-primary`}
+            />
+            <Show when={errors().at}>
+              <p class="text-sm text-red-500 mt-1">{errors().at}</p>
+            </Show>
+          </Show>
+        </div>
+
+        <Show when={errors().submit}>
+          <p class="text-sm text-red-500">{errors().submit}</p>
+        </Show>
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={props.onClose}
+            class="px-4 py-2 text-sm font-medium text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting()}
+            class="px-4 py-2 text-sm font-medium bg-primary hover:bg-primary-hover text-white rounded-lg transition-colors disabled:opacity-50"
+          >
+            {submitting()
+              ? 'Saving...'
+              : props.pulse
+                ? 'Save Changes'
+                : 'Create Pulse'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/pulses/PulseCard.tsx
+++ b/apps/web/src/components/pulses/PulseCard.tsx
@@ -1,0 +1,173 @@
+/**
+ * PulseCard Component
+ *
+ * Displays a single pulse with status, schedule, and action buttons.
+ */
+
+import { Show } from 'solid-js';
+import { Play, Pause, Edit2, History, Trash2, Zap } from 'lucide-solid';
+import type { Pulse } from '../../lib/api';
+
+export type PulseCardProps = {
+  pulse: Pulse;
+  onTrigger: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onEdit: (pulse: Pulse) => void;
+  onHistory: (id: string) => void;
+  onDelete: (id: string) => void;
+  isActionLoading?: boolean;
+};
+
+function formatRelativeTime(iso: string | null): string {
+  if (!iso) return 'Never';
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatNextRun(iso: string | null): string {
+  if (!iso) return 'Not scheduled';
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  if (diffMs < 0) return 'Due now';
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffMins < 60) return `In ${diffMins}m`;
+  if (diffHours < 24) return `In ${diffHours}h`;
+  return `In ${diffDays}d`;
+}
+
+const STATUS_STYLES: Record<Pulse['status'], string> = {
+  active:
+    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  paused:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  completed: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export function PulseCard(props: PulseCardProps) {
+  return (
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm">
+      <div class="flex items-start justify-between mb-3">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-1">
+            <Zap class="w-4 h-4 text-primary flex-shrink-0" />
+            <h3 class="text-base font-semibold text-text-primary truncate">
+              {props.pulse.name}
+            </h3>
+          </div>
+          <p class="text-sm text-text-secondary truncate px-6">
+            {props.pulse.prompt}
+          </p>
+        </div>
+        <span
+          class={`ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${STATUS_STYLES[props.pulse.status]}`}
+        >
+          {props.pulse.status}
+        </span>
+      </div>
+
+      <div class="flex items-center gap-4 text-xs text-text-tertiary mb-3">
+        <span title="Schedule">{props.pulse.scheduleHuman}</span>
+        <span title="Next run">{formatNextRun(props.pulse.nextRunAt)}</span>
+        <span title="Last run">
+          Last: {formatRelativeTime(props.pulse.lastRunAt)}
+        </span>
+      </div>
+
+      <div class="flex items-center gap-1 border-t border-gray-100 dark:border-gray-700 pt-3">
+        <Show when={props.pulse.status === 'active'}>
+          <button
+            onClick={() => props.onTrigger(props.pulse.id)}
+            disabled={props.isActionLoading}
+            class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50"
+            title="Run now"
+          >
+            <Play class="w-3.5 h-3.5" />
+            Run
+          </button>
+          <button
+            onClick={() => props.onPause(props.pulse.id)}
+            disabled={props.isActionLoading}
+            class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-yellow-700 dark:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-yellow-900/20 rounded transition-colors disabled:opacity-50"
+            title="Pause"
+          >
+            <Pause class="w-3.5 h-3.5" />
+            Pause
+          </button>
+        </Show>
+
+        <Show when={props.pulse.status === 'paused'}>
+          <button
+            onClick={() => props.onResume(props.pulse.id)}
+            disabled={props.isActionLoading}
+            class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-green-700 dark:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20 rounded transition-colors disabled:opacity-50"
+            title="Resume"
+          >
+            <Play class="w-3.5 h-3.5" />
+            Resume
+          </button>
+        </Show>
+
+        <Show
+          when={
+            props.pulse.status === 'completed' ||
+            props.pulse.status === 'failed'
+          }
+        >
+          <button
+            onClick={() => props.onTrigger(props.pulse.id)}
+            disabled={props.isActionLoading}
+            class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50"
+            title="Run now"
+          >
+            <Play class="w-3.5 h-3.5" />
+            Run
+          </button>
+        </Show>
+
+        <button
+          onClick={() => props.onEdit(props.pulse)}
+          class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          title="Edit"
+        >
+          <Edit2 class="w-3.5 h-3.5" />
+          Edit
+        </button>
+
+        <button
+          onClick={() => props.onHistory(props.pulse.id)}
+          class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          title="History"
+        >
+          <History class="w-3.5 h-3.5" />
+          History
+        </button>
+
+        <div class="flex-1" />
+
+        <button
+          onClick={() => props.onDelete(props.pulse.id)}
+          class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+          title="Delete"
+        >
+          <Trash2 class="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pulses/PulseHistoryDrawer.tsx
+++ b/apps/web/src/components/pulses/PulseHistoryDrawer.tsx
@@ -1,0 +1,164 @@
+/**
+ * PulseHistoryDrawer Component
+ *
+ * Right-side drawer showing execution history for a pulse.
+ */
+
+import { createSignal, Show, For, onMount } from 'solid-js';
+import { X, CheckCircle, XCircle, Clock, Loader } from 'lucide-solid';
+import { getPulseHistory, type PulseRun } from '../../lib/api';
+import { resolveToken } from '../../lib/auth-token';
+
+export type PulseHistoryDrawerProps = {
+  pulseId: string | null;
+  onClose: () => void;
+};
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+function formatDuration(
+  startedAt: string | null,
+  finishedAt: string | null,
+): string {
+  if (!startedAt || !finishedAt) return '—';
+  const start = new Date(startedAt).getTime();
+  const end = new Date(finishedAt).getTime();
+  const diffMs = end - start;
+  if (diffMs < 1000) return '<1s';
+  const diffSecs = Math.floor(diffMs / 1000);
+  if (diffSecs < 60) return `${diffSecs}s`;
+  const diffMins = Math.floor(diffSecs / 60);
+  return `${diffMins}m ${diffSecs % 60}s`;
+}
+
+const STATUS_ICONS: Record<PulseRun['status'], typeof CheckCircle> = {
+  succeeded: CheckCircle,
+  failed: XCircle,
+  queued: Clock,
+  running: Loader,
+};
+
+const STATUS_STYLES: Record<PulseRun['status'], string> = {
+  succeeded: 'text-green-500',
+  failed: 'text-red-500',
+  queued: 'text-yellow-500',
+  running: 'text-blue-500 animate-spin',
+};
+
+export function PulseHistoryDrawer(props: PulseHistoryDrawerProps) {
+  const [runs, setRuns] = createSignal<PulseRun[]>([]);
+  const [isLoading, setIsLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const token = () => resolveToken() ?? '';
+
+  const load = async () => {
+    if (!props.pulseId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getPulseHistory(token(), props.pulseId, 20);
+      setRuns(data.runs);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load history');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  onMount(() => {
+    void load();
+  });
+
+  // Reload when pulseId changes
+  if (props.pulseId) {
+    void load();
+  }
+
+  return (
+    <Show when={props.pulseId}>
+      <div class="fixed inset-0 z-50 flex">
+        {/* Backdrop */}
+        <div class="absolute inset-0 bg-black/30" onClick={props.onClose} />
+
+        {/* Drawer */}
+        <div class="ml-auto relative w-full max-w-md bg-white dark:bg-gray-800 shadow-xl flex flex-col h-full">
+          {/* Header */}
+          <div class="flex items-center justify-between px-4 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2 class="text-lg font-semibold text-text-primary">Run History</h2>
+            <button
+              onClick={props.onClose}
+              class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            >
+              <X class="w-5 h-5 text-text-tertiary" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div class="flex-1 overflow-y-auto p-4">
+            <Show when={isLoading()}>
+              <div class="flex items-center justify-center py-8">
+                <div class="animate-pulse text-text-tertiary">Loading...</div>
+              </div>
+            </Show>
+
+            <Show when={error()}>
+              <p class="text-red-500 text-sm">{error()}</p>
+            </Show>
+
+            <Show when={!isLoading() && !error() && runs().length === 0}>
+              <p class="text-text-tertiary text-sm text-center py-8">
+                No runs yet
+              </p>
+            </Show>
+
+            <Show when={!isLoading() && !error() && runs().length > 0}>
+              <div class="space-y-3">
+                <For each={runs()}>
+                  {(run) => {
+                    const Icon = STATUS_ICONS[run.status];
+                    return (
+                      <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-100 dark:border-gray-700">
+                        <div class="flex items-center justify-between mb-2">
+                          <div class="flex items-center gap-2">
+                            <Icon
+                              class={`w-4 h-4 ${STATUS_STYLES[run.status]}`}
+                            />
+                            <span class="text-sm font-medium text-text-primary capitalize">
+                              {run.status}
+                            </span>
+                          </div>
+                          <span class="text-xs text-text-tertiary">
+                            #{run.attemptNumber}
+                          </span>
+                        </div>
+                        <div class="grid grid-cols-2 gap-2 text-xs text-text-secondary">
+                          <div>
+                            <span class="text-text-tertiary">Started:</span>{' '}
+                            {formatDateTime(run.startedAt)}
+                          </div>
+                          <div>
+                            <span class="text-text-tertiary">Duration:</span>{' '}
+                            {formatDuration(run.startedAt, run.finishedAt)}
+                          </div>
+                        </div>
+                        <Show when={run.errorMessage}>
+                          <p class="text-xs text-red-500 mt-2">
+                            {run.errorCode}: {run.errorMessage}
+                          </p>
+                        </Show>
+                      </div>
+                    );
+                  }}
+                </For>
+              </div>
+            </Show>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -876,6 +876,178 @@ export async function uninstallAddon(token: string, id: string): Promise<void> {
   }
 }
 
+// ============================================================================
+// Pulse API types
+// ============================================================================
+
+export type Pulse = {
+  id: string;
+  name: string;
+  prompt: string;
+  scheduleHuman: string;
+  status: 'active' | 'paused' | 'completed' | 'failed';
+  agentId: string | null;
+  sessionId: string | null;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  createdAt: string;
+};
+
+export type PulseRun = {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  attemptNumber: number;
+  startedAt: string | null;
+  finishedAt: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export type ScheduleInput =
+  | { every: '15m' | '30m' | '1h' | '6h' | '12h' | '1d' | '1w' }
+  | { daily: { hour: number; minute: number } }
+  | { cron: string; tz?: string }
+  | { at: string };
+
+export type CreatePulseBody = {
+  name: string;
+  prompt: string;
+  schedule: ScheduleInput;
+  agentId?: string;
+  sessionId?: string;
+};
+
+export type UpdatePulseBody = {
+  name?: string;
+  prompt?: string;
+  schedule?: ScheduleInput;
+  status?: 'active' | 'paused' | 'completed' | 'failed';
+  agentId?: string;
+  sessionId?: string;
+};
+
+// ============================================================================
+// Pulse API functions
+// ============================================================================
+
+/**
+ * List all pulses
+ */
+export async function listPulses(
+  token: string,
+): Promise<{ pulses: Pulse[]; total: number }> {
+  const response = await apiFetch(`${API_BASE}/api/pulses`, {
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to list pulses: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Create a new pulse
+ */
+export async function createPulse(
+  token: string,
+  body: CreatePulseBody,
+): Promise<{ pulse: Pulse }> {
+  const response = await apiFetch(`${API_BASE}/api/pulses`, {
+    method: 'POST',
+    headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create pulse: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Get a pulse by ID
+ */
+export async function getPulse(
+  token: string,
+  id: string,
+): Promise<{ pulse: Pulse }> {
+  const response = await apiFetch(`${API_BASE}/api/pulses/${id}`, {
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to get pulse: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Update a pulse
+ */
+export async function updatePulse(
+  token: string,
+  id: string,
+  body: UpdatePulseBody,
+): Promise<{ pulse: Pulse }> {
+  const response = await apiFetch(`${API_BASE}/api/pulses/${id}`, {
+    method: 'PATCH',
+    headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update pulse: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Delete a pulse
+ */
+export async function deletePulse(token: string, id: string): Promise<void> {
+  const response = await apiFetch(`${API_BASE}/api/pulses/${id}`, {
+    method: 'DELETE',
+    headers: authHeaders(token),
+  });
+  if (!response.ok && response.status !== 204) {
+    throw new Error(`Failed to delete pulse: ${response.statusText}`);
+  }
+}
+
+/**
+ * Trigger a pulse manually
+ */
+export async function triggerPulse(
+  token: string,
+  id: string,
+): Promise<{ run: PulseRun }> {
+  const response = await apiFetch(`${API_BASE}/api/pulses/${id}/trigger`, {
+    method: 'POST',
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to trigger pulse: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Get pulse execution history
+ */
+export async function getPulseHistory(
+  token: string,
+  id: string,
+  limit?: number,
+): Promise<{ runs: PulseRun[]; total: number }> {
+  const url = limit
+    ? `${API_BASE}/api/pulses/${id}/history?limit=${limit}`
+    : `${API_BASE}/api/pulses/${id}/history`;
+  const response = await apiFetch(url, {
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to get pulse history: ${response.statusText}`);
+  }
+  return response.json();
+}
+
 /**
  * Verify an auth token against the server
  */


### PR DESCRIPTION
## Pulses Implementation

Complete pulses scheduling system for openaidy.

### Backend Changes
- **SessionsStore injection** into SchedulerService (#239)
- **Isolated session execution** for pulses - creates fresh session per run (#240)
- **app.ts wiring** - passes SessionsStore to scheduler (#241)
- **ScheduleInput & parseScheduleInput** - supports interval/daily/cron/at (#242)
- **jobToPulse mapper** - maps ScheduledJob to PulseRecord (#243)
- **Full CRUD routes** - POST/GET/PATCH/DELETE /api/pulses (#245-249)
- **Trigger endpoint** - POST /api/pulses/:id/trigger (#250)
- **Route registration** in app.ts (#251)

### Frontend Changes
- **Pulse API types** - Pulse, PulseRun, ScheduleInput, CreatePulseBody, UpdatePulseBody (#253)
- **API client functions** - listPulses, createPulse, getPulse, updatePulse, deletePulse, triggerPulse, getPulseHistory (#254)
- **PulsesPage** - main page with loading/empty states (#255)
- **PulseCard** - displays pulse info + action buttons (#256)
- **CreateEditPulseModal** - create/edit modal with schedule types (#257)
- **PulseHistoryDrawer** - execution history drawer (#258)

### Features
- **Schedule types**: interval (15m-1w), daily, cron expression, one-shot
- **Isolated execution**: each pulse run gets its own fresh session
- **Full lifecycle management**: pause, resume, trigger, delete
- **Execution history**: view all runs with status, timing, errors
- **28 scheduler tests pass** including isolated job execution tests

Closes #239, #240, #241, #242, #243, #244, #245, #246, #247, #248, #249, #250, #251, #253, #254, #255, #256, #257, #258