### PR TITLE
feat(skills): complete skills system implementation

### DIFF
--- a/apps/server/src/agents/registry.test.ts
+++ b/apps/server/src/agents/registry.test.ts
@@ -406,6 +406,148 @@ describe('AgentRegistry', () => {
       // Config file in tempDir remains unchanged (only written in beforeEach for other tests)
     });
   });
+
+  describe('updateAgentSkills', () => {
+    let configPath: string;
+
+    function writeConfig(agents: Array<{ id: string; skills?: string[] }>) {
+      const dir = path.join(tempDir, 'config');
+      fs.mkdirSync(dir, { recursive: true });
+      configPath = path.join(dir, 'openaidy.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          defaults: { providerId: 'openai', modelId: 'gpt-4o-mini' },
+          providers: [
+            {
+              id: 'openai',
+              type: 'openai-compatible',
+              enabled: true,
+              vendorFamily: 'openai-compatible',
+              models: [{ id: 'gpt-4' }],
+            },
+          ],
+          agents,
+        }),
+        'utf-8',
+      );
+    }
+
+    beforeEach(() => {
+      configPath = path.join(tempDir, 'openaidy.json');
+      writeConfig([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          skills: ['skill-a'],
+        },
+      ]);
+    });
+
+    it('updates skills in memory and returns updated summary', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          skills: ['skill-a'],
+          version: 1,
+        },
+      ]);
+
+      const result = registry.updateAgentSkills('agent1', [
+        'skill-a',
+        'skill-b',
+      ]);
+
+      expect(result).toBeDefined();
+      expect(registry.getAgent('agent1')?.skills).toEqual([
+        'skill-a',
+        'skill-b',
+      ]);
+    });
+
+    it('persists skills to the config file on disk', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          skills: ['skill-a'],
+          version: 1,
+        },
+      ]);
+
+      registry.updateAgentSkills('agent1', ['skill-b', 'skill-c']);
+
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<{ id: string; skills?: string[] }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'agent1');
+      expect(agent?.skills).toEqual(['skill-b', 'skill-c']);
+    });
+
+    it('removes the skills key from the config file when clearing all skills', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          skills: ['skill-a'],
+          version: 1,
+        },
+      ]);
+
+      registry.updateAgentSkills('agent1', []);
+
+      expect(registry.getAgent('agent1')?.skills).toBeUndefined();
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<{ id: string; skills?: string[] }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'agent1');
+      expect(agent).not.toHaveProperty('skills');
+    });
+
+    it('returns undefined for an unknown agent id', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([]);
+
+      const result = registry.updateAgentSkills('ghost', ['skill-a']);
+      expect(result).toBeUndefined();
+    });
+
+    it('updates memory but skips disk when configPath is not set', () => {
+      const registry = new AgentRegistry(); // no configPath
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          version: 1,
+        },
+      ]);
+
+      const result = registry.updateAgentSkills('agent1', ['skill-x']);
+
+      expect(result).toBeDefined();
+      expect(registry.getAgent('agent1')?.skills).toEqual(['skill-x']);
+    });
+  });
 });
 
 describe('createAgentRegistry', () => {

--- a/apps/server/src/agents/registry.test.ts
+++ b/apps/server/src/agents/registry.test.ts
@@ -410,7 +410,16 @@ describe('AgentRegistry', () => {
   describe('updateAgentSkills', () => {
     let configPath: string;
 
-    function writeConfig(agents: Array<{ id: string; skills?: string[] }>) {
+    function writeConfig(
+      agents: Array<{
+        id: string;
+        name?: string;
+        enabled?: boolean;
+        systemPrompt?: string;
+        model?: string;
+        skills?: string[];
+      }>,
+    ) {
       const dir = path.join(tempDir, 'config');
       fs.mkdirSync(dir, { recursive: true });
       configPath = path.join(dir, 'openaidy.json');

--- a/apps/server/src/agents/registry.ts
+++ b/apps/server/src/agents/registry.ts
@@ -295,6 +295,55 @@ export class AgentRegistry {
   }
 
   /**
+   * Update the skills list for an agent.
+   * Patches both the in-memory registry and the main openaidy.json config file on disk.
+   * Returns the updated AgentSummary or undefined if the agent was not found.
+   */
+  updateAgentSkills(
+    agentId: string,
+    skills: string[],
+  ): AgentSummary | undefined {
+    this.ensureLoaded();
+
+    const agent = this.agents.get(agentId);
+    if (!agent) {
+      return undefined;
+    }
+
+    const updated: Agent = {
+      ...agent,
+      skills: skills.length > 0 ? skills : undefined,
+    };
+    this.agents.set(agentId, updated);
+
+    if (this.configPath && fs.existsSync(this.configPath)) {
+      const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8')) as {
+        agents?: Array<Record<string, unknown>>;
+      };
+
+      if (Array.isArray(raw.agents)) {
+        const idx = raw.agents.findIndex((a) => a['id'] === agentId);
+        if (idx !== -1) {
+          if (skills.length > 0) {
+            raw.agents[idx]!['skills'] = skills;
+          } else {
+            delete raw.agents[idx]!['skills'];
+          }
+          const tempPath = `${this.configPath}.tmp`;
+          fs.writeFileSync(
+            tempPath,
+            JSON.stringify(raw, null, 2) + '\n',
+            'utf-8',
+          );
+          fs.renameSync(tempPath, this.configPath);
+        }
+      }
+    }
+
+    return toAgentSummary(updated);
+  }
+
+  /**
    * Get the number of loaded agents
    */
   get size(): number {

--- a/apps/server/src/agents/schema.ts
+++ b/apps/server/src/agents/schema.ts
@@ -95,6 +95,10 @@ export const AgentSchema = z.object({
   // Example: ["workspace_read", "workspace_list", "workspace_write", "workspace_delete"]
   tools: z.array(z.string()).optional(),
 
+  // Skill IDs assigned to this agent.
+  // These are loaded from .openaidy/skills/ and appended to the system prompt at dispatch time.
+  skills: z.array(z.string()).optional(),
+
   tags: z.array(z.string()).optional(),
   metadata: z.record(z.unknown()).optional(),
   version: z.number().int().positive().default(1),
@@ -123,6 +127,7 @@ export type AgentSummary = {
   enabled: boolean;
   tags: string[] | undefined;
   tools: string[] | undefined;
+  skills: string[] | undefined;
   mcpServers: McpServerRef[] | undefined;
   model: string; // Format: "providerId/modelId"
   workspace?: WorkspaceConfig | undefined;
@@ -190,6 +195,7 @@ export function toAgentSummary(agent: Agent): AgentSummary {
     enabled: agent.enabled,
     tags: agent.tags,
     tools: agent.tools,
+    skills: agent.skills,
     mcpServers: agent.mcpServers,
     model: agent.model,
     workspace: agent.workspace,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -197,6 +197,7 @@ export async function buildApp() {
     agents: agentRegistry,
     mcp: mcpService,
     builtinTools: builtinToolRegistry,
+    skills: skillRegistry,
     getDefaultAgentId: () => configService.getConfig().defaults.agentId,
     repositories: dbAdapter
       ? {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -51,6 +51,10 @@ import { createWorkspaceService, WorkspaceService } from './workspace';
 import { createExecService } from './exec/service';
 import { createBuiltinToolRegistry } from './tools';
 import { toolRoutes } from './routes/tools';
+import { createSkillRegistry, SkillRegistry } from './skills';
+import { skillRoutes } from './routes/skills';
+import fs from 'node:fs';
+import path from 'node:path';
 
 /**
  * Application services container
@@ -76,6 +80,7 @@ export type AppServices = {
   accessTokensRepo: AccessTokensStore | undefined;
   workspace: WorkspaceService;
   mcpService: McpClientService;
+  skills: SkillRegistry;
 };
 
 /**
@@ -140,6 +145,29 @@ export async function buildApp() {
     initialAgents: [],
     configPath: env.APP_CONFIG_PATH,
   });
+  // Seed default skills from config/skills to .openaidy/skills (if not already present)
+  const skillsSourceDir = path.join(process.cwd(), 'config', 'skills');
+  const seedSkills = (sourceDir: string, targetDir: string): void => {
+    if (!fs.existsSync(sourceDir)) return;
+    fs.mkdirSync(targetDir, { recursive: true });
+    for (const id of fs.readdirSync(sourceDir)) {
+      const src = path.join(sourceDir, id);
+      if (!fs.statSync(src).isDirectory()) continue;
+      const dest = path.join(targetDir, id);
+      fs.mkdirSync(dest, { recursive: true });
+      for (const file of fs.readdirSync(src)) {
+        const destFile = path.join(dest, file);
+        if (!fs.existsSync(destFile)) {
+          fs.copyFileSync(path.join(src, file), destFile);
+        }
+      }
+    }
+  };
+  seedSkills(skillsSourceDir, env.SKILLS_DIR);
+
+  const skillRegistry = createSkillRegistry({ skillsDir: env.SKILLS_DIR });
+  skillRegistry.load();
+
   const configService = createAppConfigService({
     configPath: env.APP_CONFIG_PATH,
     templatePath: env.APP_CONFIG_TEMPLATE_PATH,
@@ -221,6 +249,7 @@ export async function buildApp() {
     accessTokensRepo,
     workspace: workspaceService,
     mcpService,
+    skills: skillRegistry,
   };
 
   // Decorate the app with services for access in routes/plugins
@@ -273,6 +302,13 @@ export async function buildApp() {
 
   // Register agent routes
   await app.register(agentRoutes, {
+    agentRegistry: services.agents,
+    authMiddleware,
+  });
+
+  // Register skill routes
+  await app.register(skillRoutes, {
+    skillRegistry: services.skills,
     agentRegistry: services.agents,
     authMiddleware,
   });

--- a/apps/server/src/dispatch/service.test.ts
+++ b/apps/server/src/dispatch/service.test.ts
@@ -6,6 +6,7 @@ import { DispatchService, createDispatchService } from './service';
 import { createAgentRegistry, type AgentRegistry } from '../agents';
 import { createProviderServices, type ProviderServices } from '../providers';
 import { RunEventEmitter, type RunEvent } from './events';
+import { createSkillRegistry, type SkillRegistry } from '../skills';
 import type { McpClientService } from '../mcp';
 import type {
   ModelProvider,
@@ -786,6 +787,256 @@ describe('DispatchService streaming', () => {
           expect(result.error).toContain('Tool failed');
         }
       });
+    });
+  });
+
+  describe('skill injection', () => {
+    let skillTempDir: string;
+    let skillRegistry: SkillRegistry;
+
+    beforeEach(() => {
+      // Create temp directory for skills
+      skillTempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'test-dispatch-skills-'),
+      );
+
+      // Create skill directories
+      fs.mkdirSync(path.join(skillTempDir, 'skill-a'));
+      fs.mkdirSync(path.join(skillTempDir, 'skill-b'));
+      fs.mkdirSync(path.join(skillTempDir, 'skill-c'));
+
+      // Create SKILL.md files
+      fs.writeFileSync(
+        path.join(skillTempDir, 'skill-a', 'SKILL.md'),
+        [
+          '---',
+          'name: Skill A',
+          'description: First skill',
+          '---',
+          'Skill A body content.',
+        ].join('\n'),
+      );
+
+      fs.writeFileSync(
+        path.join(skillTempDir, 'skill-b', 'SKILL.md'),
+        [
+          '---',
+          'name: Skill B',
+          'description: Second skill',
+          '---',
+          'Skill B body content.',
+        ].join('\n'),
+      );
+
+      fs.writeFileSync(
+        path.join(skillTempDir, 'skill-c', 'SKILL.md'),
+        [
+          '---',
+          'name: Skill C',
+          'description: Third skill',
+          '---',
+          'Skill C body content.',
+        ].join('\n'),
+      );
+
+      // Create skill registry
+      skillRegistry = createSkillRegistry({ skillsDir: skillTempDir });
+      skillRegistry.load();
+    });
+
+    afterEach(() => {
+      fs.rmSync(skillTempDir, { recursive: true, force: true });
+    });
+
+    it('appends skill body to system prompt when agent.skills is set', async () => {
+      // Create agent with skills
+      fs.writeFileSync(
+        path.join(tempDir, 'skill-agent.json'),
+        JSON.stringify({
+          id: 'skill-agent',
+          name: 'Skill Agent',
+          enabled: true,
+          systemPrompt: 'You are a helpful assistant.',
+          model: 'mock-provider/mock-model',
+          skills: ['skill-a'],
+          defaults: {
+            providerId: 'mock-provider',
+            modelId: 'mock-model',
+          },
+        }),
+      );
+      agentRegistry.reload();
+
+      // Create dispatch service with skill registry
+      const serviceWithSkills = createDispatchService({
+        agents: agentRegistry,
+        providers,
+        skills: skillRegistry,
+        systemDefaults: {
+          providerId: 'mock-provider',
+          modelId: 'mock-model',
+        },
+      });
+
+      // Use buildMessages directly via resolveConfig and dispatch
+      const agent = agentRegistry.getAgent('skill-agent');
+      const config = serviceWithSkills.resolveConfig('skill-agent');
+
+      expect('error' in config).toBe(false);
+      if ('error' in config) return;
+
+      // Verify the dispatch would include skill body in messages
+      // Since dispatch requires a session, we verify via the internal buildMessages method
+      const dispatchInstance = serviceWithSkills as DispatchService;
+      const messages = dispatchInstance.buildMessages(
+        [],
+        config.systemPrompt,
+        agent?.skills,
+      );
+
+      expect(messages[0]?.role).toBe('system');
+      expect(messages[0]?.content).toContain('Skill A body content.');
+      expect(messages[0]?.content).toContain('You are a helpful assistant.');
+    });
+
+    it('does not modify system prompt when agent.skills is empty', async () => {
+      // Create agent without skills
+      fs.writeFileSync(
+        path.join(tempDir, 'no-skill-agent.json'),
+        JSON.stringify({
+          id: 'no-skill-agent',
+          name: 'No Skill Agent',
+          enabled: true,
+          systemPrompt: 'You are a helpful assistant.',
+          model: 'mock-provider/mock-model',
+          defaults: {
+            providerId: 'mock-provider',
+            modelId: 'mock-model',
+          },
+        }),
+      );
+      agentRegistry.reload();
+
+      const serviceWithSkills = createDispatchService({
+        agents: agentRegistry,
+        providers,
+        skills: skillRegistry,
+        systemDefaults: {
+          providerId: 'mock-provider',
+          modelId: 'mock-model',
+        },
+      });
+
+      const config = serviceWithSkills.resolveConfig('no-skill-agent');
+      expect('error' in config).toBe(false);
+      if ('error' in config) return;
+
+      const dispatchInstance = serviceWithSkills as DispatchService;
+      const messages = dispatchInstance.buildMessages(
+        [],
+        config.systemPrompt,
+        undefined,
+      );
+
+      expect(messages[0]?.role).toBe('system');
+      expect(messages[0]?.content).toBe('You are a helpful assistant.');
+    });
+
+    it('silently skips unknown skill IDs', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'unknown-skill-agent.json'),
+        JSON.stringify({
+          id: 'unknown-skill-agent',
+          name: 'Unknown Skill Agent',
+          enabled: true,
+          systemPrompt: 'You are a helpful assistant.',
+          model: 'mock-provider/mock-model',
+          skills: ['skill-a', 'nonexistent', 'skill-b'],
+          defaults: {
+            providerId: 'mock-provider',
+            modelId: 'mock-model',
+          },
+        }),
+      );
+      agentRegistry.reload();
+
+      const serviceWithSkills = createDispatchService({
+        agents: agentRegistry,
+        providers,
+        skills: skillRegistry,
+        systemDefaults: {
+          providerId: 'mock-provider',
+          modelId: 'mock-model',
+        },
+      });
+
+      const agent = agentRegistry.getAgent('unknown-skill-agent');
+      const config = serviceWithSkills.resolveConfig('unknown-skill-agent');
+      expect('error' in config).toBe(false);
+      if ('error' in config) return;
+
+      const dispatchInstance = serviceWithSkills as DispatchService;
+      const messages = dispatchInstance.buildMessages(
+        [],
+        config.systemPrompt,
+        agent?.skills,
+      );
+
+      expect(messages[0]?.role).toBe('system');
+      expect(messages[0]?.content).toContain('Skill A body content.');
+      expect(messages[0]?.content).toContain('Skill B body content.');
+      expect(messages[0]?.content).not.toContain('nonexistent');
+      expect(messages[0]?.content).not.toContain('Skill C body content.');
+    });
+
+    it('appends multiple skills in order', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'multi-skill-agent.json'),
+        JSON.stringify({
+          id: 'multi-skill-agent',
+          name: 'Multi Skill Agent',
+          enabled: true,
+          systemPrompt: 'You are a helpful assistant.',
+          model: 'mock-provider/mock-model',
+          skills: ['skill-c', 'skill-a', 'skill-b'],
+          defaults: {
+            providerId: 'mock-provider',
+            modelId: 'mock-model',
+          },
+        }),
+      );
+      agentRegistry.reload();
+
+      const serviceWithSkills = createDispatchService({
+        agents: agentRegistry,
+        providers,
+        skills: skillRegistry,
+        systemDefaults: {
+          providerId: 'mock-provider',
+          modelId: 'mock-model',
+        },
+      });
+
+      const agent = agentRegistry.getAgent('multi-skill-agent');
+      const config = serviceWithSkills.resolveConfig('multi-skill-agent');
+      expect('error' in config).toBe(false);
+      if ('error' in config) return;
+
+      const dispatchInstance = serviceWithSkills as DispatchService;
+      const messages = dispatchInstance.buildMessages(
+        [],
+        config.systemPrompt,
+        agent?.skills,
+      );
+
+      expect(messages[0]?.role).toBe('system');
+      const content = messages[0]?.content as string;
+      // Skills should be in the same order as specified in agent.skills
+      const skillCIndex = content.indexOf('Skill C body content.');
+      const skillAIndex = content.indexOf('Skill A body content.');
+      const skillBIndex = content.indexOf('Skill B body content.');
+      expect(skillCIndex).toBeLessThan(skillAIndex);
+      expect(skillAIndex).toBeLessThan(skillBIndex);
     });
   });
 });

--- a/apps/server/src/dispatch/service.test.ts
+++ b/apps/server/src/dispatch/service.test.ts
@@ -887,7 +887,13 @@ describe('DispatchService streaming', () => {
 
       // Verify the dispatch would include skill body in messages
       // Since dispatch requires a session, we verify via the internal buildMessages method
-      const dispatchInstance = serviceWithSkills as DispatchService;
+      const dispatchInstance = serviceWithSkills as unknown as {
+        buildMessages: (
+          history: unknown[],
+          systemPrompt: string,
+          skillIds?: string[],
+        ) => ReturnType<DispatchService['buildMessages']>;
+      };
       const messages = dispatchInstance.buildMessages(
         [],
         config.systemPrompt,
@@ -931,7 +937,13 @@ describe('DispatchService streaming', () => {
       expect('error' in config).toBe(false);
       if ('error' in config) return;
 
-      const dispatchInstance = serviceWithSkills as DispatchService;
+      const dispatchInstance = serviceWithSkills as unknown as {
+        buildMessages: (
+          history: unknown[],
+          systemPrompt: string,
+          skillIds?: string[],
+        ) => ReturnType<DispatchService['buildMessages']>;
+      };
       const messages = dispatchInstance.buildMessages(
         [],
         config.systemPrompt,
@@ -975,7 +987,13 @@ describe('DispatchService streaming', () => {
       expect('error' in config).toBe(false);
       if ('error' in config) return;
 
-      const dispatchInstance = serviceWithSkills as DispatchService;
+      const dispatchInstance = serviceWithSkills as unknown as {
+        buildMessages: (
+          history: unknown[],
+          systemPrompt: string,
+          skillIds?: string[],
+        ) => ReturnType<DispatchService['buildMessages']>;
+      };
       const messages = dispatchInstance.buildMessages(
         [],
         config.systemPrompt,
@@ -1022,7 +1040,13 @@ describe('DispatchService streaming', () => {
       expect('error' in config).toBe(false);
       if ('error' in config) return;
 
-      const dispatchInstance = serviceWithSkills as DispatchService;
+      const dispatchInstance = serviceWithSkills as unknown as {
+        buildMessages: (
+          history: unknown[],
+          systemPrompt: string,
+          skillIds?: string[],
+        ) => ReturnType<DispatchService['buildMessages']>;
+      };
       const messages = dispatchInstance.buildMessages(
         [],
         config.systemPrompt,

--- a/apps/server/src/dispatch/service.ts
+++ b/apps/server/src/dispatch/service.ts
@@ -9,6 +9,7 @@ import type { AgentRegistry } from '../agents';
 import type { RunEvent, RunEventEmitter } from './events';
 import type { McpClientService } from '../mcp';
 import type { McpToolDefinition } from '../mcp/client';
+import type { SkillRegistry } from '../skills';
 import {
   type SessionsStore,
   type SessionMessagesStore,
@@ -113,6 +114,8 @@ export type DispatchServiceOptions = {
   systemDefaults?: SystemDefaults;
   /** Optional event emitter for streaming run events */
   runEvents?: RunEventEmitter;
+  /** Optional skill registry for injecting skill bodies into system prompts */
+  skills?: SkillRegistry;
 };
 
 /**
@@ -141,12 +144,14 @@ export class DispatchService {
   private readonly runsRepo: SessionRunsStore | undefined;
   private readonly systemDefaults: SystemDefaults;
   private readonly runEvents: RunEventEmitter | undefined;
+  private readonly skills: SkillRegistry | undefined;
 
   constructor(options: DispatchServiceOptions) {
     this.agents = options.agents;
     this.providers = options.providers;
     this.mcp = options.mcp;
     this.runEvents = options.runEvents;
+    this.skills = options.skills;
 
     // Default system defaults
     this.systemDefaults = options.systemDefaults ?? {
@@ -309,11 +314,13 @@ export class DispatchService {
     // 5. Mark run as running
     await this.markRunRunning(run.id);
 
-    // 6. Build messages with agent system prompt
+    // 6. Build messages with agent system prompt + skills
     const history = await this.listMessages(input.sessionId);
+    const agent = this.agents.getAgent(config.agentId);
     const messages: Message[] = this.buildMessages(
       history,
       config.systemPrompt,
+      agent?.skills,
     );
 
     // 7. Invoke provider
@@ -462,11 +469,13 @@ export class DispatchService {
       yield startedEvent;
     }
 
-    // 6. Build messages with agent system prompt
+    // 6. Build messages with agent system prompt + skills
     const history = await this.listMessages(input.sessionId);
+    const agent = this.agents.getAgent(config.agentId);
     const messages: Message[] = this.buildMessages(
       history,
       config.systemPrompt,
+      agent?.skills,
     );
 
     // 7. Invoke provider with streaming
@@ -670,18 +679,33 @@ export class DispatchService {
   }
 
   /**
-   * Build messages array with system prompt
+   * Build messages array with system prompt and optional skill bodies.
+   * Skill bodies are appended to the system prompt with "---" separators.
    */
   private buildMessages(
     history: SessionMessageRecord[] | SessionMessage[],
     systemPrompt: string,
+    skillIds?: string[],
   ): Message[] {
     const messages: Message[] = [];
+
+    // Build full system prompt with skill bodies appended
+    let fullSystemPrompt = systemPrompt;
+    if (skillIds?.length && this.skills) {
+      const bodies = this.skills
+        .getSkillsForAgent(skillIds)
+        .map((s) => s.body)
+        .filter(Boolean)
+        .join('\n\n---\n\n');
+      if (bodies) {
+        fullSystemPrompt += '\n\n---\n\n' + bodies;
+      }
+    }
 
     // Add system prompt first
     messages.push({
       role: 'system',
-      content: systemPrompt,
+      content: fullSystemPrompt,
     });
 
     // Add conversation history
@@ -945,9 +969,7 @@ export class DispatchService {
     prefixedToolName: string,
     args: Record<string, unknown>,
     agentId: string,
-  ): Promise<
-    { ok: true; content: string } | { ok: false; error: string }
-  > {
+  ): Promise<{ ok: true; content: string } | { ok: false; error: string }> {
     if (!this.mcp) {
       return { ok: false, error: 'MCP service not available' };
     }
@@ -1003,9 +1025,7 @@ export class DispatchService {
 
       // Extract content from result
       const content =
-        typeof result === 'string'
-          ? result
-          : JSON.stringify(result, null, 2);
+        typeof result === 'string' ? result : JSON.stringify(result, null, 2);
 
       return { ok: true, content };
     } catch (error) {

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -69,6 +69,8 @@ const envSchema = z
       .default(31536000000),
     // Workspace configuration
     WORKSPACE_BASE_DIR: z.string().optional(),
+    // Skills configuration
+    SKILLS_DIR: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.DB_KIND === 'postgres' && !value.DATABASE_URL) {
@@ -92,6 +94,8 @@ const envSchema = z
       WORKSPACE_BASE_DIR:
         value.WORKSPACE_BASE_DIR ??
         resolveOpenAidyPath(openAidyHome, 'workspaces'),
+      SKILLS_DIR:
+        value.SKILLS_DIR ?? resolveOpenAidyPath(openAidyHome, 'skills'),
     };
   });
 

--- a/apps/server/src/routes/agents.test.ts
+++ b/apps/server/src/routes/agents.test.ts
@@ -118,6 +118,12 @@ describe('Agent Routes', () => {
       accessTokensRepo: undefined,
       workspace: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       mcpService: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      skills: {
+        load: () => {},
+        listSkills: () => [],
+        getSkill: () => undefined,
+        getSkillsForAgent: () => [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     });
 
     await app.register(cors, { origin: '*' });

--- a/apps/server/src/routes/skills.test.ts
+++ b/apps/server/src/routes/skills.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import sensible from '@fastify/sensible';
+import websocket from '@fastify/websocket';
+import { skillRoutes } from './skills';
+import { AuthMiddleware } from '../websocket/middleware/auth';
+import { createAgentRegistry } from '../agents';
+import type { AppConfigService } from '../config/service';
+import { createProviderServices } from '../providers';
+import { SessionMessageService } from '../sessions/service';
+import { RunEventEmitter } from '../dispatch/events';
+import { createSkillRegistry } from '../skills';
+
+const mockAuthMiddleware = {
+  validateToken: async () => ({
+    sub: 'test',
+    scopes: ['*'],
+    type: 'access' as const,
+    iat: 0,
+    exp: 9999999999,
+  }),
+  extractFromHeader: (_h: string) => 'test-token',
+  hasCapability: () => true,
+} as unknown as AuthMiddleware;
+
+describe('Skill Routes', () => {
+  let app: FastifyInstance;
+  let tempAgentsDir: string;
+  let tempSkillsDir: string;
+
+  beforeEach(async () => {
+    // Create temp directories
+    tempAgentsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'test-agents-skills-'),
+    );
+    tempSkillsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'test-skills-routes-'),
+    );
+
+    // Create test skill directories
+    fs.mkdirSync(path.join(tempSkillsDir, 'skill-a'));
+    fs.mkdirSync(path.join(tempSkillsDir, 'skill-b'));
+
+    // Create SKILL.md files
+    fs.writeFileSync(
+      path.join(tempSkillsDir, 'skill-a', 'SKILL.md'),
+      [
+        '---',
+        'name: Skill A',
+        'description: First test skill',
+        '---',
+        'This is skill A body content.',
+      ].join('\n'),
+    );
+
+    fs.writeFileSync(
+      path.join(tempSkillsDir, 'skill-b', 'SKILL.md'),
+      [
+        '---',
+        'name: Skill B',
+        'description: Second test skill',
+        '---',
+        'This is skill B body content.',
+      ].join('\n'),
+    );
+
+    // Create test agent
+    fs.writeFileSync(
+      path.join(tempAgentsDir, 'default.json'),
+      JSON.stringify({
+        id: 'default',
+        name: 'Default Agent',
+        description: 'The default agent',
+        enabled: true,
+        systemPrompt: 'You are helpful.',
+        model: 'openai/gpt-4',
+        defaults: { providerId: 'openai', modelId: 'gpt-4' },
+      }),
+    );
+
+    // Create registries
+    const agentRegistry = createAgentRegistry({ agentsDir: tempAgentsDir });
+    const skillRegistry = createSkillRegistry({ skillsDir: tempSkillsDir });
+    skillRegistry.load();
+
+    // Build app
+    const providerServices = createProviderServices();
+    const sessionService = new SessionMessageService({
+      providers: providerServices,
+    });
+    const runEvents = new RunEventEmitter();
+
+    const configServiceStub = {
+      getConfig: () => ({
+        version: 1,
+        defaults: {
+          agentId: 'default',
+          providerId: 'openai',
+          modelId: 'gpt-4o-mini',
+        },
+        providers: [],
+        agents: [],
+      }),
+      getStatus: () => ({ issues: [] }),
+    } as unknown as AppConfigService;
+
+    app = Fastify({ logger: false });
+
+    app.decorate('services', {
+      config: configServiceStub,
+      providers: providerServices,
+      sessions: sessionService,
+      agents: agentRegistry,
+      runEvents,
+      dbAdapter: undefined,
+      scheduler: undefined,
+      jobsRepo: undefined,
+      jobRunsRepo: undefined,
+      sessionsRepo: undefined,
+      bootstrapAdmin: undefined,
+      pairingRequestsRepo: undefined,
+      devicesRepo: undefined,
+      accessTokensRepo: undefined,
+      workspace: undefined as unknown as AppServices['workspace'],
+      mcpService: undefined as unknown as AppServices['mcpService'],
+      skills: skillRegistry,
+    });
+
+    await app.register(cors, { origin: '*' });
+    await app.register(sensible);
+    await app.register(websocket);
+    await app.register(skillRoutes, {
+      skillRegistry,
+      agentRegistry,
+      authMiddleware: mockAuthMiddleware,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    fs.rmSync(tempAgentsDir, { recursive: true, force: true });
+    fs.rmSync(tempSkillsDir, { recursive: true, force: true });
+  });
+
+  describe('GET /skills', () => {
+    it('returns 200 with skill items', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/skills',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.items).toBeInstanceOf(Array);
+      expect(body.items.length).toBe(2);
+
+      const ids = body.items.map((s: { id: string }) => s.id).sort();
+      expect(ids).toEqual(['skill-a', 'skill-b']);
+    });
+
+    it('returns skill summaries with id, name, description', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/skills',
+      });
+
+      const body = response.json();
+      const skillA = body.items.find((s: { id: string }) => s.id === 'skill-a');
+      expect(skillA).toBeDefined();
+      expect(skillA.name).toBe('Skill A');
+      expect(skillA.description).toBe('First test skill');
+    });
+
+    it('returns empty items when no skills installed', async () => {
+      // Create a registry with an empty skills dir
+      const emptySkillsDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'empty-skills-'),
+      );
+      const emptySkillRegistry = createSkillRegistry({
+        skillsDir: emptySkillsDir,
+      });
+      emptySkillRegistry.load();
+
+      // Register new routes with empty registry
+      const agentRegistry = createAgentRegistry({ agentsDir: tempAgentsDir });
+
+      const tempApp = Fastify({ logger: false });
+      tempApp.decorate('services', {
+        config: {},
+        providers: {},
+        sessions: {},
+        agents: agentRegistry,
+        runEvents: {},
+        dbAdapter: undefined,
+        scheduler: undefined,
+        jobsRepo: undefined,
+        jobRunsRepo: undefined,
+        sessionsRepo: undefined,
+        bootstrapAdmin: undefined,
+        pairingRequestsRepo: undefined,
+        devicesRepo: undefined,
+        accessTokensRepo: undefined,
+        workspace: undefined,
+        mcpService: undefined,
+        skills: emptySkillRegistry,
+      } as unknown as AppServices);
+
+      await tempApp.register(skillRoutes, {
+        skillRegistry: emptySkillRegistry,
+        agentRegistry,
+        authMiddleware: mockAuthMiddleware,
+      });
+
+      const response = await tempApp.inject({
+        method: 'GET',
+        url: '/skills',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.items).toEqual([]);
+
+      await tempApp.close();
+      fs.rmSync(emptySkillsDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('PATCH /agents/:agentId/skills', () => {
+    it('returns 200 when updating agent skills with valid array', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/agents/default/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: ['skill-a'] },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.skills).toEqual(['skill-a']);
+    });
+
+    it('returns 200 when clearing agent skills with empty array', async () => {
+      // First set skills
+      await app.inject({
+        method: 'PATCH',
+        url: '/agents/default/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: ['skill-a'] },
+      });
+
+      // Then clear them
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/agents/default/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: [] },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      // Empty array clears skills (removes the field entirely)
+      expect(body.skills).toBeUndefined();
+    });
+
+    it('returns 400 when skills is not an array', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/agents/default/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: 'not-an-array' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body.error).toContain('must be an array of strings');
+    });
+
+    it('returns 400 when skills contains non-strings', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/agents/default/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: ['valid', 123, 'also-valid'] },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body.error).toContain('must be an array of strings');
+    });
+
+    it('returns 404 when agent does not exist', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/agents/ghost/skills',
+        headers: { 'content-type': 'application/json' },
+        payload: { skills: ['skill-a'] },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json();
+      expect(body.error).toContain('Agent not found');
+    });
+  });
+});
+
+// Type augmentation for AppServices
+type AppServices = {
+  config: AppConfigService;
+  providers: ReturnType<typeof createProviderServices>;
+  sessions: SessionMessageService;
+  agents: ReturnType<typeof createAgentRegistry>;
+  runEvents: RunEventEmitter;
+  dbAdapter: unknown;
+  scheduler: unknown;
+  jobsRepo: unknown;
+  jobRunsRepo: unknown;
+  sessionsRepo: unknown;
+  bootstrapAdmin: unknown;
+  pairingRequestsRepo: unknown;
+  devicesRepo: unknown;
+  accessTokensRepo: unknown;
+  workspace: unknown;
+  mcpService: unknown;
+  skills: ReturnType<typeof createSkillRegistry>;
+};

--- a/apps/server/src/routes/skills.ts
+++ b/apps/server/src/routes/skills.ts
@@ -1,0 +1,66 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { AgentRegistry } from '../agents/registry';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import type { SkillRegistry } from '../skills';
+import { requireAuth } from '../middleware/require-auth';
+
+/**
+ * Skill routes options
+ */
+export type SkillRoutesOptions = {
+  skillRegistry: SkillRegistry;
+  agentRegistry: AgentRegistry;
+  authMiddleware: AuthMiddleware;
+};
+
+export const skillRoutes: FastifyPluginAsync<SkillRoutesOptions> = async (
+  app,
+  options,
+) => {
+  const { skillRegistry, agentRegistry, authMiddleware } = options;
+
+  /**
+   * GET /skills
+   * List all installed skills.
+   */
+  app.get('/skills', async () => {
+    const skills = skillRegistry.listSkills();
+    return { items: skills };
+  });
+
+  app.addHook(
+    'preHandler',
+    requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
+  );
+
+  /**
+   * PATCH /agents/:agentId/skills
+   * Assign (or clear) skills for an agent.
+   * Body: { skills: string[] }
+   */
+  app.patch('/agents/:agentId/skills', async (request, reply) => {
+    const { agentId } = request.params as { agentId: string };
+    const body = request.body as { skills?: unknown };
+
+    if (
+      !Array.isArray(body?.skills) ||
+      body.skills.some((t) => typeof t !== 'string')
+    ) {
+      reply.code(400);
+      return {
+        error: 'Invalid request: skills must be an array of strings',
+      };
+    }
+
+    const result = agentRegistry.updateAgentSkills(
+      agentId,
+      body.skills as string[],
+    );
+    if (!result) {
+      reply.code(404);
+      return { error: 'Agent not found', agentId };
+    }
+
+    return result;
+  });
+};

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -63,6 +63,7 @@ export class SessionMessageService {
   private readonly sessionsRepo: SessionsStore | undefined;
   private readonly messagesRepo: SessionMessagesStore | undefined;
   private readonly runsRepo: SessionRunsStore | undefined;
+  private readonly skillRegistry: import('../skills').SkillRegistry | undefined;
 
   constructor(options: SessionMessageServiceOptions) {
     this.providers = options.providers;
@@ -70,6 +71,7 @@ export class SessionMessageService {
     this.mcp = options.mcp;
     this.builtinTools = options.builtinTools;
     this.getDefaultAgentId = options.getDefaultAgentId;
+    this.skillRegistry = options.skills;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -246,7 +248,7 @@ export class SessionMessageService {
 
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
-    const messages: Message[] = history.map((m) => {
+    const historyMessages: Message[] = history.map((m) => {
       // Map to proper Message type - both types have these properties
       const msgRole = (m as { role: string }).role;
       const msgContent = (m as { content: string }).content;
@@ -264,6 +266,15 @@ export class SessionMessageService {
         content: msgContent,
       } as Message;
     });
+
+    // Build system prompt with skill bodies injected
+    const systemPrompt = this.buildAgentSystemPrompt(
+      agent?.systemPrompt ?? '',
+      agent?.skills,
+    );
+    const messages: Message[] = systemPrompt
+      ? [{ role: 'system' as const, content: systemPrompt }, ...historyMessages]
+      : historyMessages;
 
     // 6. Invoke provider
     const modelRequest: ModelRequest = {
@@ -376,7 +387,7 @@ export class SessionMessageService {
 
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
-    const messages: Message[] = history.map((m) => {
+    const historyMessages: Message[] = history.map((m) => {
       const msgRole = (m as { role: string }).role;
       const msgContent = (m as { content: string }).content;
       const msgToolCallId = (m as { toolCallId?: string }).toolCallId;
@@ -405,6 +416,15 @@ export class SessionMessageService {
         content: msgContent,
       } as Message;
     });
+
+    // Build system prompt with skill bodies injected
+    const systemPrompt = this.buildAgentSystemPrompt(
+      agent?.systemPrompt ?? '',
+      agent?.skills,
+    );
+    const messages: Message[] = systemPrompt
+      ? [{ role: 'system' as const, content: systemPrompt }, ...historyMessages]
+      : historyMessages;
 
     // 6. Invoke provider with streaming (agentic tool-call loop)
     const mcpTools = this.buildMcpTools(agentId);
@@ -710,6 +730,28 @@ export class SessionMessageService {
       return this.messagesRepo.append(appendInput);
     }
     return appendMessageRecord(input);
+  }
+
+  /**
+   * Build the full system prompt for an agent, with skill bodies appended.
+   * Returns the system prompt string with skills injected if any are assigned.
+   */
+  private buildAgentSystemPrompt(
+    systemPrompt: string,
+    skillIds?: string[],
+  ): string {
+    if (!skillIds?.length || !this.skillRegistry) {
+      return systemPrompt;
+    }
+    const bodies = this.skillRegistry
+      .getSkillsForAgent(skillIds)
+      .map((s) => s.body)
+      .filter(Boolean)
+      .join('\n\n---\n\n');
+    if (!bodies) {
+      return systemPrompt;
+    }
+    return systemPrompt + '\n\n---\n\n' + bodies;
   }
 
   /**

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -56,6 +56,7 @@ import type { ProviderServices } from '../providers';
 import type { AgentRegistry } from '../agents';
 import type { McpClientService } from '../mcp/client';
 import type { BuiltinToolRegistry } from '../tools';
+import type { SkillRegistry } from '../skills';
 import type {
   SessionsStore,
   SessionMessagesStore,
@@ -71,6 +72,8 @@ export type SessionMessageServiceOptions = {
   mcp?: McpClientService;
   /** Registry of native (in-process) builtin tools — separate from MCP */
   builtinTools?: BuiltinToolRegistry;
+  /** Registry of skills for skill injection into system prompt */
+  skills?: SkillRegistry;
   getDefaultAgentId?: () => string | undefined;
   repositories?:
     | {

--- a/apps/server/src/skills/index.ts
+++ b/apps/server/src/skills/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Skills module barrel export
+ */
+
+export { SkillRegistry, createSkillRegistry } from './registry.js';
+export type { SkillRegistryOptions, SkillSummary } from './registry.js';
+export { parseSkillMd } from './parser.js';
+export type { SkillDefinition, SkillParseError } from './parser.js';

--- a/apps/server/src/skills/parser.test.ts
+++ b/apps/server/src/skills/parser.test.ts
@@ -133,7 +133,6 @@ describe('parseSkillMd', () => {
       '---',
       'name: One Delimiter',
       'description: Only one dash',
-      '---',
       'Some body content without closing delimiter',
     ].join('\n');
 

--- a/apps/server/src/skills/parser.test.ts
+++ b/apps/server/src/skills/parser.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import { parseSkillMd } from './parser.js';
+
+describe('parseSkillMd', () => {
+  it('parses a valid SKILL.md with all fields', () => {
+    const content = [
+      '---',
+      'name: Git Workflow',
+      'description: Step-by-step git workflow for branching and committing',
+      '---',
+      'Always create a feature branch before making changes:',
+      '',
+      '```bash',
+      'git checkout -b feat/<short-description>',
+      '```',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'git-workflow', '/path/to/SKILL.md');
+
+    expect(result).toEqual({
+      id: 'git-workflow',
+      name: 'Git Workflow',
+      description: 'Step-by-step git workflow for branching and committing',
+      body: 'Always create a feature branch before making changes:\n\n```bash\ngit checkout -b feat/<short-description>\n```',
+    });
+  });
+
+  it('parses skill with empty body', () => {
+    const content = [
+      '---',
+      'name: Empty Skill',
+      'description: A skill with no body',
+      '---',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'empty-skill', '/path/to/SKILL.md');
+
+    expect(result).toEqual({
+      id: 'empty-skill',
+      name: 'Empty Skill',
+      description: 'A skill with no body',
+      body: '',
+    });
+  });
+
+  it('parses skill with description having quotes', () => {
+    const content = [
+      '---',
+      'name: SQL Expert',
+      'description: Best practices for writing and reviewing SQL queries',
+      '---',
+      'Always use uppercase SQL keywords.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'sql-expert', '/path/to/SKILL.md');
+
+    expect(result).toEqual({
+      id: 'sql-expert',
+      name: 'SQL Expert',
+      description: 'Best practices for writing and reviewing SQL queries',
+      body: 'Always use uppercase SQL keywords.',
+    });
+  });
+
+  it('returns error when name is missing', () => {
+    const content = [
+      '---',
+      'description: A skill without a name',
+      '---',
+      'Some body content.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'no-name', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      errors: expect.arrayContaining([
+        { message: expect.stringContaining('name') },
+      ]),
+    });
+  });
+
+  it('returns error when description is missing', () => {
+    const content = [
+      '---',
+      'name: No Description Skill',
+      '---',
+      'Some body content.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'no-desc', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      errors: expect.arrayContaining([
+        { message: expect.stringContaining('description') },
+      ]),
+    });
+  });
+
+  it('returns error when both name and description are missing', () => {
+    const content = ['---', '---', 'Some body content.'].join('\n');
+
+    const result = parseSkillMd(content, 'no-frontmatter', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      errors: expect.arrayContaining([
+        { message: expect.stringContaining('name') },
+        { message: expect.stringContaining('description') },
+      ]),
+    });
+  });
+
+  it('returns error when frontmatter delimiters are missing', () => {
+    const content = [
+      'name: No Delimiters',
+      'description: Missing the --- delimiters',
+      '---',
+      'Some body content.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'no-delims', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      errors: expect.arrayContaining([
+        {
+          message: expect.stringContaining('---'),
+        },
+      ]),
+    });
+  });
+
+  it('returns error when only one frontmatter delimiter exists', () => {
+    const content = [
+      '---',
+      'name: One Delimiter',
+      'description: Only one dash',
+      '---',
+      'Some body content without closing delimiter',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'one-delim', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      errors: expect.arrayContaining([
+        {
+          message: expect.stringContaining('---'),
+        },
+      ]),
+    });
+  });
+
+  it('parses skill with multi-line description', () => {
+    const content = [
+      '---',
+      'name: Multi-line',
+      'description: This is a longer description that might',
+      '  span multiple lines in the YAML',
+      '---',
+      'Body here.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'multiline', '/path/to/SKILL.md');
+
+    // The parser extracts description by taking everything after "description:"
+    expect(result).toMatchObject({
+      id: 'multiline',
+      name: 'Multi-line',
+    });
+  });
+
+  it('preserves markdown formatting in body', () => {
+    const content = [
+      '---',
+      'name: Formatted Skill',
+      'description: A skill with complex body formatting',
+      '---',
+      '## Rules',
+      '',
+      '- Bullet one',
+      '- Bullet two',
+      '',
+      '```typescript',
+      'const x = 1;',
+      '```',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'formatted', '/path/to/SKILL.md');
+
+    expect(result).toEqual({
+      id: 'formatted',
+      name: 'Formatted Skill',
+      description: 'A skill with complex body formatting',
+      body: '## Rules\n\n- Bullet one\n- Bullet two\n\n```typescript\nconst x = 1;\n```',
+    });
+  });
+
+  it('trims leading/trailing whitespace from body', () => {
+    const content = [
+      '---',
+      'name: Trim Skill',
+      'description: Trims whitespace',
+      '---',
+      '   \n  Body with whitespace.  \n   ',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'trim', '/path/to/SKILL.md') as {
+      body: string;
+    };
+
+    expect(result.body).toBe('Body with whitespace.');
+  });
+
+  it('uses the id parameter as skill id, not frontmatter name', () => {
+    const content = [
+      '---',
+      'name: Different Name',
+      'description: The ID comes from directory',
+      '---',
+      'Body.',
+    ].join('\n');
+
+    const result = parseSkillMd(
+      content,
+      'my-custom-id',
+      '/path/to/SKILL.md',
+    ) as { id: string; name: string };
+
+    expect(result.id).toBe('my-custom-id');
+    expect(result.name).toBe('Different Name');
+  });
+});

--- a/apps/server/src/skills/parser.ts
+++ b/apps/server/src/skills/parser.ts
@@ -1,0 +1,109 @@
+/**
+ * Skills parser
+ *
+ * Parses a SKILL.md file content into a structured SkillDefinition.
+ * Uses simple line scanning instead of a full YAML parser since only
+ * 'name' and 'description' keys are needed.
+ */
+
+export type SkillDefinition = {
+  /** Directory name — the canonical skill ID */
+  id: string;
+  /** From frontmatter 'name' field */
+  name: string;
+  /** From frontmatter 'description' field */
+  description: string;
+  /** Everything after the closing --- delimiter, trimmed */
+  body: string;
+};
+
+export type SkillParseError = {
+  filePath: string;
+  errors: Array<{ message: string }>;
+};
+
+/**
+ * Parse a SKILL.md content string into a SkillDefinition.
+ *
+ * Algorithm:
+ * 1. Split content on the first two '---' lines
+ * 2. Section 0 (before first '---'): ignored
+ * 3. Section 1 (between '---' lines): YAML frontmatter — extract name and description by line scan
+ * 4. Section 2 (after closing '---'): the body, trimmed
+ * 5. Return SkillParseError if name or description is missing
+ */
+export function parseSkillMd(
+  content: string,
+  id: string,
+  filePath: string,
+): SkillDefinition | SkillParseError {
+  const errors: Array<{ message: string }> = [];
+
+  const lines = content.split('\n');
+
+  // Find first two '---' lines
+  const dashesIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line && line.trim() === '---') {
+      dashesIndices.push(i);
+      if (dashesIndices.length === 2) break;
+    }
+  }
+
+  // Need at least 2 '---' delimiters
+  if (dashesIndices.length < 2) {
+    return {
+      filePath,
+      errors: [
+        {
+          message:
+            'Invalid SKILL.md format: missing frontmatter delimiters (---). Expected --- delimiters around YAML frontmatter.',
+        },
+      ],
+    };
+  }
+
+  const firstDash = dashesIndices[0]!;
+  const secondDash = dashesIndices[1]!;
+  const frontmatterStart = firstDash + 1;
+  const frontmatterEnd = secondDash - 1;
+
+  // Extract name and description from frontmatter lines
+  let name: string | undefined;
+  let description: string | undefined;
+
+  for (let i = frontmatterStart; i <= frontmatterEnd; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    if (line.startsWith('name:')) {
+      name = line.substring('name:'.length).trim();
+    } else if (line.startsWith('description:')) {
+      description = line.substring('description:'.length).trim();
+    }
+  }
+
+  if (!name) {
+    errors.push({ message: 'Missing required frontmatter field: name' });
+  }
+  if (!description) {
+    errors.push({
+      message: 'Missing required frontmatter field: description',
+    });
+  }
+
+  if (errors.length > 0) {
+    return { filePath, errors };
+  }
+
+  // Body is everything after the closing ---
+  const bodyLines = lines.slice(secondDash + 1);
+  const body = bodyLines.join('\n').trim();
+
+  return {
+    id,
+    name: name!,
+    description: description!,
+    body,
+  };
+}

--- a/apps/server/src/skills/registry.test.ts
+++ b/apps/server/src/skills/registry.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SkillRegistry } from './registry.js';
+import type { SkillDefinition } from './parser.js';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+
+function createTmpSkill(name: string): SkillDefinition {
+  return {
+    id: name,
+    name: `${name} name`,
+    description: `${name} description`,
+    body: `This is the ${name} body.`,
+  };
+}
+
+describe('SkillRegistry', () => {
+  let tmpSkillDir: string;
+
+  beforeEach(() => {
+    tmpSkillDir = join(tmpdir(), `skill-registry-test-${Date.now()}`);
+    mkdirSync(tmpSkillDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpSkillDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  describe('load()', () => {
+    it('loads skills from the skills directory', () => {
+      // Create skill directories
+      mkdirSync(join(tmpSkillDir, 'skill-a'), { recursive: true });
+      mkdirSync(join(tmpSkillDir, 'skill-b'), { recursive: true });
+
+      writeFileSync(
+        join(tmpSkillDir, 'skill-a/SKILL.md'),
+        [
+          '---',
+          'name: Skill A',
+          'description: Description A',
+          '---',
+          'Body A',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(tmpSkillDir, 'skill-b/SKILL.md'),
+        [
+          '---',
+          'name: Skill B',
+          'description: Description B',
+          '---',
+          'Body B',
+        ].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.listSkills();
+      expect(skills).toHaveLength(2);
+      expect(skills).toContainEqual({
+        id: 'skill-a',
+        name: 'Skill A',
+        description: 'Description A',
+      });
+      expect(skills).toContainEqual({
+        id: 'skill-b',
+        name: 'Skill B',
+        description: 'Description B',
+      });
+    });
+
+    it('skips directories without SKILL.md', () => {
+      mkdirSync(join(tmpSkillDir, 'valid-skill'), { recursive: true });
+      mkdirSync(join(tmpSkillDir, 'no-skill-file'), { recursive: true });
+
+      writeFileSync(
+        join(tmpSkillDir, 'valid-skill/SKILL.md'),
+        ['---', 'name: Valid', 'description: Has SKILL.md', '---', 'Body'].join(
+          '\n',
+        ),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.listSkills();
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.id).toBe('valid-skill');
+    });
+
+    it('skips invalid SKILL.md files and logs warning', () => {
+      mkdirSync(join(tmpSkillDir, 'bad-skill'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'bad-skill/SKILL.md'),
+        ['---', '---', 'Missing name and description'].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.listSkills();
+      expect(skills).toHaveLength(0);
+    });
+
+    it('loads from initialSkills when provided (bypasses filesystem)', () => {
+      const initialSkills = [
+        createTmpSkill('init-a'),
+        createTmpSkill('init-b'),
+      ];
+      const registry = new SkillRegistry({
+        skillsDir: tmpSkillDir,
+        initialSkills,
+      });
+      registry.load();
+
+      const skills = registry.listSkills();
+      expect(skills).toHaveLength(2);
+      expect(skills).toContainEqual({
+        id: 'init-a',
+        name: 'init-a name',
+        description: 'init-a description',
+      });
+    });
+
+    it('handles missing skills directory gracefully', () => {
+      const nonExistentDir = join(tmpdir(), 'this-dir-does-not-exist-xyz');
+      const registry = new SkillRegistry({ skillsDir: nonExistentDir });
+      registry.load(); // Should not throw
+
+      expect(registry.listSkills()).toHaveLength(0);
+    });
+
+    it('only loads once when called multiple times', () => {
+      mkdirSync(join(tmpSkillDir, 'once-skill'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'once-skill/SKILL.md'),
+        ['---', 'name: Once', 'description: Once only', '---', 'Body'].join(
+          '\n',
+        ),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+      registry.load();
+      registry.load();
+
+      expect(registry.listSkills()).toHaveLength(1);
+    });
+  });
+
+  describe('listSkills()', () => {
+    it('returns empty array when no skills loaded', () => {
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+      expect(registry.listSkills()).toHaveLength(0);
+    });
+
+    it('returns SkillSummary objects with id, name, description', () => {
+      mkdirSync(join(tmpSkillDir, 'summary-test'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'summary-test/SKILL.md'),
+        [
+          '---',
+          'name: Summary Test',
+          'description: A test summary',
+          '---',
+          'Body',
+        ].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.listSkills();
+      expect(skills[0]).toEqual({
+        id: 'summary-test',
+        name: 'Summary Test',
+        description: 'A test summary',
+      });
+    });
+  });
+
+  describe('getSkill()', () => {
+    it('returns full SkillDefinition for known ID', () => {
+      mkdirSync(join(tmpSkillDir, 'full-skill'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'full-skill/SKILL.md'),
+        [
+          '---',
+          'name: Full Skill',
+          'description: Full desc',
+          '---',
+          'Full body content',
+        ].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skill = registry.getSkill('full-skill');
+      expect(skill).toEqual({
+        id: 'full-skill',
+        name: 'Full Skill',
+        description: 'Full desc',
+        body: 'Full body content',
+      });
+    });
+
+    it('returns undefined for unknown ID', () => {
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      expect(registry.getSkill('does-not-exist')).toBeUndefined();
+    });
+  });
+
+  describe('getSkillsForAgent()', () => {
+    it('returns matching SkillDefinitions for given IDs', () => {
+      mkdirSync(join(tmpSkillDir, 'agent-skill-1'), { recursive: true });
+      mkdirSync(join(tmpSkillDir, 'agent-skill-2'), { recursive: true });
+
+      writeFileSync(
+        join(tmpSkillDir, 'agent-skill-1/SKILL.md'),
+        [
+          '---',
+          'name: Agent Skill 1',
+          'description: Desc 1',
+          '---',
+          'Body 1',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(tmpSkillDir, 'agent-skill-2/SKILL.md'),
+        [
+          '---',
+          'name: Agent Skill 2',
+          'description: Desc 2',
+          '---',
+          'Body 2',
+        ].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.getSkillsForAgent([
+        'agent-skill-1',
+        'agent-skill-2',
+      ]);
+      expect(skills).toHaveLength(2);
+      expect(skills[0]!.id).toBe('agent-skill-1');
+      expect(skills[1]!.id).toBe('agent-skill-2');
+    });
+
+    it('silently skips unknown IDs', () => {
+      mkdirSync(join(tmpSkillDir, 'real-skill'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'real-skill/SKILL.md'),
+        ['---', 'name: Real', 'description: Real desc', '---', 'Body'].join(
+          '\n',
+        ),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.getSkillsForAgent([
+        'real-skill',
+        'unknown-id',
+        'another-fake',
+      ]);
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.id).toBe('real-skill');
+    });
+
+    it('returns empty array when no IDs provided', () => {
+      mkdirSync(join(tmpSkillDir, 'some-skill'), { recursive: true });
+      writeFileSync(
+        join(tmpSkillDir, 'some-skill/SKILL.md'),
+        ['---', 'name: Some', 'description: Some desc', '---', 'Body'].join(
+          '\n',
+        ),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      expect(registry.getSkillsForAgent([])).toHaveLength(0);
+    });
+
+    it('returns skills in the order of the input IDs', () => {
+      mkdirSync(join(tmpSkillDir, 'first'), { recursive: true });
+      mkdirSync(join(tmpSkillDir, 'second'), { recursive: true });
+
+      writeFileSync(
+        join(tmpSkillDir, 'first/SKILL.md'),
+        [
+          '---',
+          'name: First',
+          'description: First desc',
+          '---',
+          'First body',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(tmpSkillDir, 'second/SKILL.md'),
+        [
+          '---',
+          'name: Second',
+          'description: Second desc',
+          '---',
+          'Second body',
+        ].join('\n'),
+      );
+
+      const registry = new SkillRegistry({ skillsDir: tmpSkillDir });
+      registry.load();
+
+      const skills = registry.getSkillsForAgent(['second', 'first']);
+      expect(skills).toHaveLength(2);
+      expect(skills[0]!.id).toBe('second');
+      expect(skills[1]!.id).toBe('first');
+    });
+  });
+});

--- a/apps/server/src/skills/registry.ts
+++ b/apps/server/src/skills/registry.ts
@@ -1,0 +1,142 @@
+/**
+ * Skill registry
+ *
+ * Loads, caches, and exposes skills from the filesystem.
+ * Follows the AgentRegistry lazy-load pattern.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseSkillMd } from './parser.js';
+import type { SkillDefinition } from './parser.js';
+
+export type SkillSummary = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type SkillRegistryOptions = {
+  /** Directory to scan for skills */
+  skillsDir: string;
+  /**
+   * Initial skills to seed the registry with (for testing — bypasses filesystem).
+   * When provided, load() is a no-op and these skills are used directly.
+   */
+  initialSkills?: SkillDefinition[] | undefined;
+};
+
+export class SkillRegistry {
+  private skills: Map<string, SkillDefinition> = new Map();
+  private loaded = false;
+  private readonly skillsDir: string;
+  private readonly initialSkills?: SkillDefinition[];
+
+  constructor(options: SkillRegistryOptions) {
+    this.skillsDir = options.skillsDir;
+    this.initialSkills = options.initialSkills;
+  }
+
+  /**
+   * Scan skillsDir and cache all valid skills.
+   * Safe to call multiple times — only loads once.
+   */
+  load(): void {
+    if (this.loaded) return;
+
+    if (this.initialSkills) {
+      for (const skill of this.initialSkills) {
+        this.skills.set(skill.id, skill);
+      }
+    } else {
+      this.loadFromDir();
+    }
+
+    this.loaded = true;
+  }
+
+  private loadFromDir(): void {
+    if (!existsSync(this.skillsDir)) {
+      return;
+    }
+
+    let subdirs: string[];
+    try {
+      subdirs = readdirSync(this.skillsDir);
+    } catch {
+      return;
+    }
+
+    for (const id of subdirs) {
+      const skillPath = join(this.skillsDir, id);
+      const skillFile = join(skillPath, 'SKILL.md');
+
+      // Skip files — only process directories
+      if (!existsSync(skillFile)) continue;
+
+      let content: string;
+      try {
+        content = readFileSync(skillFile, 'utf-8');
+      } catch {
+        // Skip unreadable files
+        continue;
+      }
+
+      const result = parseSkillMd(content, id, skillFile);
+
+      if ('errors' in result) {
+        // Log warning and skip invalid skill
+        console.warn(
+          `[SkillRegistry] Skipping invalid skill "${id}": ${result.errors.map((e) => e.message).join(', ')}`,
+        );
+        continue;
+      }
+
+      this.skills.set(id, result);
+    }
+  }
+
+  /** Return summaries of all loaded skills */
+  listSkills(): SkillSummary[] {
+    this.ensureLoaded();
+    return Array.from(this.skills.values()).map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+    }));
+  }
+
+  /** Return full definition for a skill by ID, or undefined */
+  getSkill(id: string): SkillDefinition | undefined {
+    this.ensureLoaded();
+    return this.skills.get(id);
+  }
+
+  /**
+   * Return full definitions for the given IDs.
+   * Unknown IDs are silently skipped.
+   */
+  getSkillsForAgent(skillIds: string[]): SkillDefinition[] {
+    this.ensureLoaded();
+    const result: SkillDefinition[] = [];
+    for (const id of skillIds) {
+      const skill = this.skills.get(id);
+      if (skill) {
+        result.push(skill);
+      }
+    }
+    return result;
+  }
+
+  private ensureLoaded(): void {
+    if (!this.loaded) {
+      this.load();
+    }
+  }
+}
+
+export function createSkillRegistry(
+  options: SkillRegistryOptions,
+): SkillRegistry {
+  return new SkillRegistry(options);
+}

--- a/apps/server/src/skills/registry.ts
+++ b/apps/server/src/skills/registry.ts
@@ -23,7 +23,7 @@ export type SkillRegistryOptions = {
    * Initial skills to seed the registry with (for testing — bypasses filesystem).
    * When provided, load() is a no-op and these skills are used directly.
    */
-  initialSkills?: SkillDefinition[] | undefined;
+  initialSkills?: SkillDefinition[];
 };
 
 export class SkillRegistry {
@@ -34,7 +34,9 @@ export class SkillRegistry {
 
   constructor(options: SkillRegistryOptions) {
     this.skillsDir = options.skillsDir;
-    this.initialSkills = options.initialSkills;
+    if (options.initialSkills) {
+      this.initialSkills = options.initialSkills;
+    }
   }
 
   /**

--- a/apps/server/src/websocket/integration/config-presence-integration.test.ts
+++ b/apps/server/src/websocket/integration/config-presence-integration.test.ts
@@ -81,6 +81,12 @@ const createMockServices = (_authMiddleware: AuthMiddleware): AppServices => ({
   } as unknown as AppServices['runEvents'],
   workspace: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   mcpService: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  skills: {
+    load: () => {},
+    listSkills: () => [],
+    getSkill: () => undefined,
+    getSkillsForAgent: () => [],
+  } as unknown as AppServices['skills'],
 });
 
 // ============================================================================

--- a/apps/server/src/websocket/integration/e2e.test.ts
+++ b/apps/server/src/websocket/integration/e2e.test.ts
@@ -244,6 +244,12 @@ const createMockServices = (_authMiddleware: AuthMiddleware): AppServices => ({
   } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   workspace: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   mcpService: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  skills: {
+    load: () => {},
+    listSkills: () => [],
+    getSkill: () => undefined,
+    getSkillsForAgent: () => [],
+  } as unknown as AppServices['skills'],
 });
 
 // ============================================================================

--- a/apps/server/src/websocket/integration/node-pairing-integration.test.ts
+++ b/apps/server/src/websocket/integration/node-pairing-integration.test.ts
@@ -86,6 +86,12 @@ const createMockServices = (_authMiddleware: AuthMiddleware): AppServices =>
     } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     workspace: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     mcpService: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    skills: {
+      load: () => {},
+      listSkills: () => [],
+      getSkill: () => undefined,
+      getSkillsForAgent: () => [],
+    } as unknown as AppServices['skills'],
   }) as AppServices;
 
 // ============================================================================

--- a/apps/server/src/websocket/integration/production-grade.test.ts
+++ b/apps/server/src/websocket/integration/production-grade.test.ts
@@ -211,6 +211,7 @@ const createMockServices = (_authMiddleware: AuthMiddleware): AppServices => ({
   runEvents: createMockRunEvents() as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   workspace: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   mcpService: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  skills: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
 });
 
 // ============================================================================

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -7,13 +7,24 @@ import {
   onCleanup,
   onMount,
 } from 'solid-js';
-import { Bot, Folder, FileText, Wrench, Power, PowerOff } from 'lucide-solid';
+import {
+  Bot,
+  Folder,
+  FileText,
+  Wrench,
+  Power,
+  PowerOff,
+  Lightbulb,
+} from 'lucide-solid';
 import {
   listAgents,
   listBuiltinTools,
   updateAgentTools,
+  listSkills,
+  updateAgentSkills,
   type Agent,
   type BuiltinToolInfo,
+  type SkillInfo,
 } from '../../lib/api';
 import {
   FileExplorer,
@@ -28,7 +39,7 @@ export function AgentsPage() {
     null,
   );
   const [activeTab, setActiveTab] = createSignal<
-    'overview' | 'workspace' | 'tools'
+    'overview' | 'workspace' | 'tools' | 'skills'
   >('overview');
   const [error, setError] = createSignal<string | null>(null);
   const [selectedWorkspaceFile, setSelectedWorkspaceFile] =
@@ -39,6 +50,10 @@ export function AgentsPage() {
     [],
   );
   const [toolsUpdating, setToolsUpdating] = createSignal<Set<string>>(
+    new Set(),
+  );
+  const [allSkills, setAllSkills] = createSignal<SkillInfo[]>([]);
+  const [skillsUpdating, setSkillsUpdating] = createSignal<Set<string>>(
     new Set(),
   );
 
@@ -84,7 +99,9 @@ export function AgentsPage() {
     setHasUnsavedWorkspaceChanges(false);
   };
 
-  const handleTabChange = (tab: 'overview' | 'workspace' | 'tools') => {
+  const handleTabChange = (
+    tab: 'overview' | 'workspace' | 'tools' | 'skills',
+  ) => {
     if (activeTab() === tab) {
       return;
     }
@@ -150,12 +167,16 @@ export function AgentsPage() {
 
   onMount(async () => {
     try {
-      const [agentsResponse, toolsResponse] = await Promise.all([
-        listAgents(),
-        listBuiltinTools().catch(() => ({ items: [] as BuiltinToolInfo[] })),
-      ]);
+      const [agentsResponse, toolsResponse, skillsResponse] = await Promise.all(
+        [
+          listAgents(),
+          listBuiltinTools().catch(() => ({ items: [] as BuiltinToolInfo[] })),
+          listSkills().catch(() => ({ items: [] as SkillInfo[] })),
+        ],
+      );
       setAgents(agentsResponse.items);
       setAllBuiltinTools(toolsResponse.items);
+      setAllSkills(skillsResponse.items);
       if (agentsResponse.items.length > 0) {
         setSelectedAgentId(agentsResponse.items[0].id);
       }
@@ -188,6 +209,33 @@ export function AgentsPage() {
       setToolsUpdating((prev) => {
         const next = new Set(prev);
         next.delete(toolName);
+        return next;
+      });
+    }
+  };
+
+  const handleToggleSkill = async (skillId: string) => {
+    const agent = selectedAgent();
+    if (!agent) return;
+
+    setSkillsUpdating((prev) => new Set([...prev, skillId]));
+    try {
+      const currentSkills = agent.skills ?? [];
+      const nextSkills = currentSkills.includes(skillId)
+        ? currentSkills.filter((s) => s !== skillId)
+        : [...currentSkills, skillId];
+
+      await updateAgentSkills(agent.id, nextSkills);
+
+      setAgents((prev) =>
+        prev.map((a) => (a.id === agent.id ? { ...a, skills: nextSkills } : a)),
+      );
+    } catch {
+      // leave state unchanged on error
+    } finally {
+      setSkillsUpdating((prev) => {
+        const next = new Set(prev);
+        next.delete(skillId);
         return next;
       });
     }
@@ -373,6 +421,20 @@ export function AgentsPage() {
                     <span class="flex items-center gap-2">
                       <Wrench class="w-4 h-4" />
                       Tools
+                    </span>
+                  </button>
+
+                  <button
+                    class={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab() === 'skills'
+                        ? 'border-primary text-primary'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+                    }`}
+                    onClick={() => handleTabChange('skills')}
+                  >
+                    <span class="flex items-center gap-2">
+                      <Lightbulb class="w-4 h-4" />
+                      Skills
                     </span>
                   </button>
                 </nav>
@@ -637,6 +699,77 @@ export function AgentsPage() {
                                   </div>
                                   <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
                                     {tool.description}
+                                  </p>
+                                </div>
+                              </button>
+                            );
+                          }}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
+                </Show>
+
+                {/* Skills Tab */}
+                <Show when={activeTab() === 'skills'}>
+                  <div class="space-y-4">
+                    <Show when={allSkills().length === 0}>
+                      <div class="flex items-center justify-center h-32">
+                        <p class="text-text-tertiary">No skills available</p>
+                      </div>
+                    </Show>
+                    <Show when={allSkills().length > 0}>
+                      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <For each={allSkills()}>
+                          {(skill) => {
+                            const isEnabled = () =>
+                              selectedAgent()!.skills?.includes(skill.id) ??
+                              false;
+                            const isUpdating = () =>
+                              skillsUpdating().has(skill.id);
+                            return (
+                              <button
+                                onClick={() => handleToggleSkill(skill.id)}
+                                disabled={isUpdating()}
+                                class={`w-full text-left p-3 border rounded-lg flex items-start gap-3 transition-colors ${
+                                  isEnabled()
+                                    ? 'border-primary/50 bg-primary/5 dark:bg-primary/10 hover:bg-primary/10 dark:hover:bg-primary/15'
+                                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+                                } ${isUpdating() ? 'opacity-60 cursor-wait' : 'cursor-pointer'}`}
+                              >
+                                <div class="mt-0.5 flex-shrink-0">
+                                  <Lightbulb
+                                    class={`w-4 h-4 ${
+                                      isEnabled()
+                                        ? 'text-primary'
+                                        : 'text-gray-400 dark:text-gray-500'
+                                    }`}
+                                  />
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                  <div class="flex items-center justify-between gap-2">
+                                    <span class="font-medium text-sm text-gray-900 dark:text-gray-100">
+                                      {skill.name}
+                                    </span>
+                                    {/* Toggle switch */}
+                                    <div
+                                      class={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                                        isEnabled()
+                                          ? 'bg-primary'
+                                          : 'bg-gray-200 dark:bg-gray-600'
+                                      }`}
+                                    >
+                                      <span
+                                        class={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                                          isEnabled()
+                                            ? 'translate-x-4'
+                                            : 'translate-x-0'
+                                        }`}
+                                      />
+                                    </div>
+                                  </div>
+                                  <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                                    {skill.description}
                                   </p>
                                 </div>
                               </button>

--- a/apps/web/src/components/pages/SkillsPage.tsx
+++ b/apps/web/src/components/pages/SkillsPage.tsx
@@ -1,11 +1,101 @@
+import { For, Show, createSignal, onMount } from 'solid-js';
+import { Lightbulb } from 'lucide-solid';
 import { Layout } from './Layout';
+import { listSkills, type SkillInfo } from '../../lib/api';
+
+function SkillCard(props: { skill: SkillInfo }) {
+  return (
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 flex flex-col gap-3">
+      <div class="flex items-start justify-between gap-2">
+        <div class="flex items-center gap-2 min-w-0">
+          <Lightbulb class="w-4 h-4 text-primary flex-shrink-0" />
+          <span class="font-medium text-sm text-text-primary truncate">
+            {props.skill.name}
+          </span>
+        </div>
+        <code class="text-xs text-text-tertiary font-mono bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded flex-shrink-0">
+          {props.skill.id}
+        </code>
+      </div>
+      <p class="text-sm text-text-secondary">{props.skill.description}</p>
+    </div>
+  );
+}
 
 export function SkillsPage() {
+  const [skills, setSkills] = createSignal<SkillInfo[]>([]);
+  const [isLoading, setIsLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const load = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await listSkills();
+      setSkills(data.items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load skills');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  onMount(() => {
+    void load();
+  });
+
   return (
-    <Layout title="Skills" description="Reusable agent capabilities and tools">
-      <div class="flex items-center justify-center h-64">
-        <p class="text-text-tertiary">Skills management coming soon</p>
-      </div>
+    <Layout
+      title="Skills"
+      description="Reusable agent capabilities and tools"
+      actions={
+        <button
+          onClick={() => void load()}
+          disabled={isLoading()}
+          class="flex items-center gap-2 px-3 py-2 text-sm text-text-secondary border border-border rounded-lg hover:text-text-primary hover:border-gray-400 transition-colors disabled:opacity-50"
+        >
+          <div
+            class={`w-4 h-4 border-b-2 border-current rounded-full ${isLoading() ? 'animate-spin' : ''}`}
+          />
+          Refresh
+        </button>
+      }
+    >
+      {/* Loading state */}
+      <Show when={isLoading()}>
+        <div class="flex items-center justify-center h-48">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      </Show>
+
+      {/* Error state */}
+      <Show when={!isLoading() && error()}>
+        <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+          <p class="text-sm text-red-700 dark:text-red-400">{error()}</p>
+        </div>
+      </Show>
+
+      {/* Empty state */}
+      <Show when={!isLoading() && !error() && skills().length === 0}>
+        <div class="flex flex-col items-center justify-center h-64 text-center">
+          <Lightbulb class="w-12 h-12 text-text-tertiary mb-4" />
+          <p class="text-text-secondary font-medium">No skills installed</p>
+          <p class="text-sm text-text-tertiary mt-1">
+            Skills are automatically seeded from{' '}
+            <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">
+              config/skills/
+            </code>{' '}
+            on first boot.
+          </p>
+        </div>
+      </Show>
+
+      {/* Skills grid */}
+      <Show when={!isLoading() && skills().length > 0}>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <For each={skills()}>{(skill) => <SkillCard skill={skill} />}</For>
+        </div>
+      </Show>
     </Layout>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -133,6 +133,7 @@ export type Agent = {
   model: string; // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini"
   tags?: string[];
   tools?: string[];
+  skills?: string[];
   defaults: {
     providerId?: string;
     modelId?: string;
@@ -249,6 +250,44 @@ export async function updateAgentTools(
   });
   if (!response.ok) {
     throw new Error(`Failed to update agent tools: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Skill info returned by GET /skills
+ */
+export type SkillInfo = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+/**
+ * List all available skills registered on the server
+ */
+export async function listSkills(): Promise<{ items: SkillInfo[] }> {
+  const response = await apiFetch(`${API_BASE}/skills`);
+  if (!response.ok) {
+    throw new Error(`Failed to list skills: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Update the skills list for an agent
+ */
+export async function updateAgentSkills(
+  agentId: string,
+  skills: string[],
+): Promise<Agent> {
+  const response = await apiFetch(`${API_BASE}/agents/${agentId}/skills`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ skills }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update agent skills: ${response.statusText}`);
   }
   return response.json();
 }

--- a/config/skills/example-skill/SKILL.md
+++ b/config/skills/example-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: Concise Responder
+description: Instructs the agent to keep all responses brief, structured, and direct
+---
+
+Always respond concisely. Avoid unnecessary preamble or filler phrases.
+
+Structure your responses with:
+
+- A direct answer or action first
+- Supporting details only if necessary
+- Bullet points for lists, never inline commas
+
+Never start a response with phrases like "Great question!" or "Certainly!".


### PR DESCRIPTION
## Summary

Implements a complete skills system for OpenAidy that is extensible, maintainable, and scalable.

### Steps Implemented

All 15 steps implemented including:
- Skill MD parser, registry, and barrel exports
- Skills field in Agent schema
- System prompt assembly with skills
- Boot-time seeding and wiring
- API routes and frontend integration
- SkillsPage UI and Skills tab on AgentsPage
- Bundled example skill
- Full test suite (91 tests passing)

### Test Coverage

- parser.test.ts: 12 tests
- registry.test.ts: 14 tests
- skills.test.ts: 8 tests
- agents/registry.test.ts: 29 tests (5 new for updateAgentSkills)
- dispatch/service.test.ts: 28 tests (4 new for skill injection)

**Total: 91 tests all passing**