### PR TITLE
feat(mcp): full MCP server management UI

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -415,7 +415,9 @@ export async function buildApp() {
   }
 
   // Register MCP routes (config CRUD + runtime connect/disconnect)
-  await app.register(createMcpRoutesPlugin({ mcpService, configService }));
+  await app.register(
+    createMcpRoutesPlugin({ mcpService, configService, authMiddleware }),
+  );
 
   // Start scheduler after server is ready
   app.addHook('onReady', async () => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -414,8 +414,8 @@ export async function buildApp() {
     });
   }
 
-  // Register MCP routes
-  await app.register(createMcpRoutesPlugin({ mcpService }));
+  // Register MCP routes (config CRUD + runtime connect/disconnect)
+  await app.register(createMcpRoutesPlugin({ mcpService, configService }));
 
   // Start scheduler after server is ready
   app.addHook('onReady', async () => {

--- a/apps/server/src/routes/mcp.test.ts
+++ b/apps/server/src/routes/mcp.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import sensible from '@fastify/sensible';
+import websocket from '@fastify/websocket';
+import { registerMcpRoutes } from './mcp';
+import type { McpClientService } from '../mcp/client';
+import type { AppConfigService } from '../config/service';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import type { McpServerConfig } from '@openaidy/config';
+
+// ---------------------------------------------------------------------------
+// Helpers / stubs
+// ---------------------------------------------------------------------------
+
+const mockAuthMiddleware = {
+  validateToken: async () => ({
+    sub: 'test',
+    scopes: ['*'],
+    type: 'access' as const,
+    iat: 0,
+    exp: 9999999999,
+  }),
+  extractFromHeader: (_h: string) => 'test-token',
+  hasCapability: () => true,
+} as unknown as AuthMiddleware;
+
+const noAuthMiddleware = {
+  validateToken: async () => null,
+  extractFromHeader: (_h: string) => null,
+  hasCapability: () => false,
+} as unknown as AuthMiddleware;
+
+function makeServerConfig(
+  overrides: Partial<McpServerConfig> = {},
+): McpServerConfig {
+  return {
+    id: 'test-server',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-everything'],
+    ...overrides,
+  } as McpServerConfig;
+}
+
+function makeMcpService(
+  _servers: McpServerConfig[] = [],
+  connected: string[] = [],
+): McpClientService {
+  return {
+    isConnected: vi.fn((id: string) => connected.includes(id)),
+    getConnectedServers: vi.fn(() => connected),
+    getTools: vi.fn((_id: string) => [
+      {
+        name: 'tool-one',
+        description: 'Does one',
+        inputSchema: { type: 'object' },
+      },
+    ]),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    callTool: vi.fn(),
+  } as unknown as McpClientService;
+}
+
+function makeConfigService(servers: McpServerConfig[] = []): AppConfigService {
+  let currentServers = [...servers];
+  return {
+    getConfig: vi.fn(() => ({
+      version: 1,
+      defaults: { providerId: 'openai', modelId: 'gpt-4o-mini' },
+      providers: [],
+      agents: [],
+      mcpServers: currentServers,
+    })),
+    getMcpServers: vi.fn(() => currentServers),
+    getMcpServer: vi.fn((id: string) =>
+      currentServers.find((s) => s.id === id),
+    ),
+    save: vi.fn(async (cfg: { mcpServers?: McpServerConfig[] }) => {
+      currentServers = cfg.mcpServers ?? [];
+      return cfg;
+    }),
+  } as unknown as AppConfigService;
+}
+
+async function buildApp(
+  mcpService: McpClientService,
+  configService: AppConfigService,
+  authMiddleware: AuthMiddleware = mockAuthMiddleware,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(cors, { origin: '*' });
+  await app.register(sensible);
+  await app.register(websocket);
+  await app.register(async (instance) => {
+    await registerMcpRoutes(instance, {
+      mcpService,
+      configService,
+      authMiddleware,
+    });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MCP Routes', () => {
+  let app: FastifyInstance;
+  let mcpService: McpClientService;
+  let configService: AppConfigService;
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  // -------------------------------------------------------------------------
+  describe('GET /mcp/servers', () => {
+    beforeEach(async () => {
+      const servers = [
+        makeServerConfig({ id: 'srv-a' }),
+        makeServerConfig({ id: 'srv-b' }),
+      ];
+      mcpService = makeMcpService(servers, ['srv-a']);
+      configService = makeConfigService(servers);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 with all configured servers', async () => {
+      const res = await app.inject({ method: 'GET', url: '/mcp/servers' });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.servers).toHaveLength(2);
+    });
+
+    it('reflects live connection status', async () => {
+      const res = await app.inject({ method: 'GET', url: '/mcp/servers' });
+      const body = res.json();
+      const a = body.servers.find((s: { id: string }) => s.id === 'srv-a');
+      const b = body.servers.find((s: { id: string }) => s.id === 'srv-b');
+      expect(a.connected).toBe(true);
+      expect(b.connected).toBe(false);
+    });
+
+    it('includes toolCount for connected servers', async () => {
+      const res = await app.inject({ method: 'GET', url: '/mcp/servers' });
+      const body = res.json();
+      const a = body.servers.find((s: { id: string }) => s.id === 'srv-a');
+      expect(a.toolCount).toBe(1);
+    });
+
+    it('requires no auth (public endpoint)', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'GET',
+        url: '/mcp/servers',
+      });
+      expect(res.statusCode).toBe(200);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('GET /mcp/servers/:id', () => {
+    beforeEach(async () => {
+      const servers = [makeServerConfig({ id: 'srv-a' })];
+      mcpService = makeMcpService(servers, ['srv-a']);
+      configService = makeConfigService(servers);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 with server record', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/mcp/servers/srv-a',
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.server.id).toBe('srv-a');
+      expect(body.server.connected).toBe(true);
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/mcp/servers/ghost',
+      });
+      expect(res.statusCode).toBe(404);
+      const body = res.json();
+      expect(body.error).toBe('NOT_FOUND');
+    });
+
+    it('requires no auth (public endpoint)', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'GET',
+        url: '/mcp/servers/srv-a',
+      });
+      expect(res.statusCode).toBe(200);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('GET /mcp/servers/:id/tools', () => {
+    beforeEach(async () => {
+      const servers = [
+        makeServerConfig({ id: 'connected-srv' }),
+        makeServerConfig({ id: 'disconnected-srv' }),
+      ];
+      mcpService = makeMcpService(servers, ['connected-srv']);
+      configService = makeConfigService(servers);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 with tools for a connected server', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/mcp/servers/connected-srv/tools',
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.tools).toHaveLength(1);
+      expect(body.tools[0].name).toBe('tool-one');
+      expect(body.tools[0].inputSchema).toBeDefined();
+    });
+
+    it('returns 503 (not 409) when server is not connected', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/mcp/servers/disconnected-srv/tools',
+      });
+      expect(res.statusCode).toBe(503);
+      const body = res.json();
+      expect(body.error).toBe('NOT_CONNECTED');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('POST /mcp/servers', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService([], []);
+      configService = makeConfigService([]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 201 and creates a new server', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          config: { id: 'new-srv', transport: 'stdio', command: 'npx' },
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.server.id).toBe('new-srv');
+    });
+
+    it('returns 409 when server id already exists', async () => {
+      configService = makeConfigService([makeServerConfig({ id: 'existing' })]);
+      app = await buildApp(mcpService, configService);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers',
+        headers: { 'content-type': 'application/json' },
+        payload: { config: { id: 'existing', transport: 'stdio' } },
+      });
+      expect(res.statusCode).toBe(409);
+      const body = res.json();
+      expect(body.error).toBe('CONFLICT');
+    });
+
+    it('persists the new server config via configService.save', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/mcp/servers',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          config: { id: 'saved-srv', transport: 'stdio', command: 'echo' },
+        },
+      });
+      expect(configService.save).toHaveBeenCalled();
+    });
+
+    it('returns 401 when no auth token provided', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'POST',
+        url: '/mcp/servers',
+        headers: { 'content-type': 'application/json' },
+        payload: { config: { id: 'new-srv', transport: 'stdio' } },
+      });
+      expect(res.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('PATCH /mcp/servers/:id', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService([makeServerConfig({ id: 'srv-a' })], []);
+      configService = makeConfigService([
+        makeServerConfig({ id: 'srv-a', name: 'Old Name' }),
+      ]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 with updated server', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/mcp/servers/srv-a',
+        headers: { 'content-type': 'application/json' },
+        payload: { name: 'New Name' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.server.id).toBe('srv-a');
+    });
+
+    it('returns 404 for unknown server', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/mcp/servers/ghost',
+        headers: { 'content-type': 'application/json' },
+        payload: { name: 'New Name' },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('persists the update via configService.save', async () => {
+      await app.inject({
+        method: 'PATCH',
+        url: '/mcp/servers/srv-a',
+        headers: { 'content-type': 'application/json' },
+        payload: { name: 'Updated' },
+      });
+      expect(configService.save).toHaveBeenCalled();
+    });
+
+    it('returns 401 without auth', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'PATCH',
+        url: '/mcp/servers/srv-a',
+        headers: { 'content-type': 'application/json' },
+        payload: { name: 'X' },
+      });
+      expect(res.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('DELETE /mcp/servers/:id', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService(
+        [makeServerConfig({ id: 'srv-a' })],
+        ['srv-a'],
+      );
+      configService = makeConfigService([makeServerConfig({ id: 'srv-a' })]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 204 and removes the server', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/mcp/servers/srv-a',
+      });
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('disconnects the server if connected', async () => {
+      await app.inject({ method: 'DELETE', url: '/mcp/servers/srv-a' });
+      expect(mcpService.disconnect).toHaveBeenCalledWith('srv-a');
+    });
+
+    it('returns 404 for unknown server', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/mcp/servers/ghost',
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('persists removal via configService.save', async () => {
+      await app.inject({ method: 'DELETE', url: '/mcp/servers/srv-a' });
+      expect(configService.save).toHaveBeenCalled();
+    });
+
+    it('returns 401 without auth', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'DELETE',
+        url: '/mcp/servers/srv-a',
+      });
+      expect(res.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('POST /mcp/servers/:id/connect', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService([makeServerConfig({ id: 'srv-a' })], []);
+      configService = makeConfigService([makeServerConfig({ id: 'srv-a' })]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 and connects successfully', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers/srv-a/connect',
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.connected).toBe(true);
+      expect(mcpService.connect).toHaveBeenCalled();
+    });
+
+    it('returns immediately if already connected (idempotent)', async () => {
+      mcpService = makeMcpService(
+        [makeServerConfig({ id: 'srv-a' })],
+        ['srv-a'],
+      );
+      configService = makeConfigService([makeServerConfig({ id: 'srv-a' })]);
+      app = await buildApp(mcpService, configService);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers/srv-a/connect',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mcpService.connect).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 for unknown server', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers/ghost/connect',
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 401 without auth', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'POST',
+        url: '/mcp/servers/srv-a/connect',
+      });
+      expect(res.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('POST /mcp/servers/:id/disconnect', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService(
+        [makeServerConfig({ id: 'srv-a' })],
+        ['srv-a'],
+      );
+      configService = makeConfigService([makeServerConfig({ id: 'srv-a' })]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('returns 200 and disconnects', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers/srv-a/disconnect',
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.disconnected).toBe(true);
+      expect(mcpService.disconnect).toHaveBeenCalledWith('srv-a');
+    });
+
+    it('returns 404 for unknown server', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp/servers/ghost/disconnect',
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 401 without auth', async () => {
+      const unauthApp = await buildApp(
+        mcpService,
+        configService,
+        noAuthMiddleware,
+      );
+      const res = await unauthApp.inject({
+        method: 'POST',
+        url: '/mcp/servers/srv-a/disconnect',
+      });
+      expect(res.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+});

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -1,18 +1,29 @@
 /**
  * MCP Server Routes
  *
- * REST API endpoints for MCP server operations.
+ * REST API endpoints for MCP server lifecycle management:
+ * - Config CRUD (stored in config/openaidy.json)
+ * - Runtime connect/disconnect
+ * - Tool discovery
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { McpClientService } from '../mcp/client';
+import type { AppConfigService } from '../config/service';
 import type { McpServerConfig } from '@openaidy/config';
+import {
+  type McpServerRecord,
+  type McpToolWithSchema,
+  type CreateMcpServerRequest,
+  type UpdateMcpServerRequest,
+} from '@openaidy/shared-types';
 
 /**
  * MCP routes options
  */
 export type McpRoutesOptions = {
   mcpService: McpClientService;
+  configService: AppConfigService;
 };
 
 /**
@@ -22,35 +33,443 @@ export async function registerMcpRoutes(
   fastify: FastifyInstance,
   options: McpRoutesOptions,
 ): Promise<void> {
-  const { mcpService } = options;
+  const { mcpService, configService } = options;
 
   /**
    * GET /mcp/servers
    *
-   * List all configured MCP servers and their status
+   * List all configured MCP servers (from config) with their live runtime status.
+   * Shows both persisted config and current connection state.
    */
   fastify.get(
     '/mcp/servers',
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      const connectedServers = mcpService.getConnectedServers();
+      const configuredServers = configService.getMcpServers();
 
-      const servers = connectedServers.map((id) => ({
-        id,
-        connected: true,
-        tools: mcpService.getTools(id).map((t) => ({
-          name: t.name,
-          description: t.description,
-        })),
-      }));
+      const servers: McpServerRecord[] = configuredServers.map(
+        (serverConfig) => {
+          const connected = mcpService.isConnected(serverConfig.id);
+          const tools = connected
+            ? mcpService.getTools(serverConfig.id).map((t) => ({
+                name: t.name,
+                description: t.description,
+              }))
+            : [];
+
+          return {
+            id: serverConfig.id,
+            name: serverConfig.name,
+            transport: serverConfig.transport,
+            command: serverConfig.command,
+            args: serverConfig.args,
+            env: serverConfig.env,
+            url: serverConfig.url,
+            headers: serverConfig.headers,
+            connected,
+            toolCount: tools.length,
+            tools,
+          };
+        },
+      );
 
       return { servers };
     },
   );
 
   /**
+   * GET /mcp/servers/:id
+   *
+   * Get a single MCP server config + runtime status by ID.
+   */
+  fastify.get(
+    '/mcp/servers/:id',
+    async (
+      request: FastifyRequest<{ Params: { id: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+      const serverConfig = configService.getMcpServer(id);
+      if (!serverConfig) {
+        return reply.status(404).send({
+          error: 'NOT_FOUND',
+          message: `MCP server "${id}" not found in config`,
+        });
+      }
+
+      const connected = mcpService.isConnected(id);
+      const tools = connected
+        ? mcpService.getTools(id).map((t) => ({
+            name: t.name,
+            description: t.description,
+          }))
+        : [];
+
+      const record: McpServerRecord = {
+        id: serverConfig.id,
+        name: serverConfig.name,
+        transport: serverConfig.transport,
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: serverConfig.env,
+        url: serverConfig.url,
+        headers: serverConfig.headers,
+        connected,
+        toolCount: tools.length,
+        tools,
+      };
+
+      return { server: record };
+    },
+  );
+
+  /**
+   * GET /mcp/servers/:id/tools
+   *
+   * Get full tool definitions with input schemas from a connected server.
+   */
+  fastify.get(
+    '/mcp/servers/:id/tools',
+    async (
+      request: FastifyRequest<{ Params: { id: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+      if (!mcpService.isConnected(id)) {
+        return reply.status(409).send({
+          error: 'NOT_CONNECTED',
+          message: `MCP server "${id}" is not connected`,
+        });
+      }
+
+      const tools: McpToolWithSchema[] = mcpService.getTools(id).map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      }));
+
+      return { tools };
+    },
+  );
+
+  /**
+   * POST /mcp/servers
+   *
+   * Add a new MCP server config and connect to it.
+   * The config is persisted to config/openaidy.json.
+   */
+  fastify.post<{
+    Body: { config: CreateMcpServerRequest };
+  }>(
+    '/mcp/servers',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['config'],
+          properties: {
+            config: {
+              type: 'object',
+              required: ['id', 'transport'],
+              properties: {
+                id: { type: 'string', minLength: 1 },
+                name: { type: 'string' },
+                transport: { type: 'string', enum: ['stdio', 'http'] },
+                command: { type: 'string' },
+                args: { type: 'array', items: { type: 'string' } },
+                env: {
+                  type: 'object',
+                  additionalProperties: { type: 'string' },
+                },
+                url: { type: 'string' },
+                headers: {
+                  type: 'object',
+                  additionalProperties: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Body: { config: CreateMcpServerRequest } }>,
+      reply: FastifyReply,
+    ) => {
+      const { config } = request.body;
+
+      const existing = configService.getMcpServer(config.id);
+      if (existing) {
+        return reply.status(409).send({
+          error: 'CONFLICT',
+          message: `MCP server "${config.id}" already exists in config`,
+        });
+      }
+
+      // Persist to config
+      const fullConfig = configService.getConfig();
+      const newServers = [
+        ...(fullConfig.mcpServers ?? []),
+        config as McpServerConfig,
+      ];
+      await configService.save({ ...fullConfig, mcpServers: newServers });
+
+      // Attempt connection (non-fatal if it fails)
+      let connected = false;
+      try {
+        await mcpService.connect(config as McpServerConfig);
+        connected = true;
+      } catch (error) {
+        fastify.log.warn(
+          {
+            serverId: config.id,
+            err: error instanceof Error ? error.message : String(error),
+          },
+          'MCP server saved but initial connection failed',
+        );
+      }
+
+      const tools = connected
+        ? mcpService.getTools(config.id).map((t) => ({
+            name: t.name,
+            description: t.description,
+          }))
+        : [];
+
+      return reply.status(201).send({
+        server: {
+          id: config.id,
+          name: config.name,
+          transport: config.transport,
+          command: config.command,
+          args: config.args,
+          env: config.env,
+          url: config.url,
+          headers: config.headers,
+          connected,
+          toolCount: tools.length,
+          tools,
+        },
+      });
+    },
+  );
+
+  /**
+   * PATCH /mcp/servers/:id
+   *
+   * Update an existing MCP server config.
+   * If the server is connected, changes take effect on next restart.
+   */
+  fastify.patch<{
+    Params: { id: string };
+    Body: UpdateMcpServerRequest;
+  }>(
+    '/mcp/servers/:id',
+    {
+      schema: {
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string', minLength: 1 } },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            transport: { type: 'string', enum: ['stdio', 'http'] },
+            command: { type: 'string' },
+            args: { type: 'array', items: { type: 'string' } },
+            env: { type: 'object', additionalProperties: { type: 'string' } },
+            url: { type: 'string' },
+            headers: {
+              type: 'object',
+              additionalProperties: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{
+        Params: { id: string };
+        Body: UpdateMcpServerRequest;
+      }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+      const patch = request.body;
+
+      const existing = configService.getMcpServer(id);
+      if (!existing) {
+        return reply.status(404).send({
+          error: 'NOT_FOUND',
+          message: `MCP server "${id}" not found in config`,
+        });
+      }
+
+      // Build updated config (merge patch into existing)
+      const updated: McpServerConfig = {
+        ...existing,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.transport !== undefined
+          ? { transport: patch.transport }
+          : {}),
+        ...(patch.command !== undefined ? { command: patch.command } : {}),
+        ...(patch.args !== undefined ? { args: patch.args } : {}),
+        ...(patch.env !== undefined ? { env: patch.env } : {}),
+        ...(patch.url !== undefined ? { url: patch.url } : {}),
+        ...(patch.headers !== undefined ? { headers: patch.headers } : {}),
+      };
+
+      // Persist to config
+      const fullConfig = configService.getConfig();
+      const newServers = (fullConfig.mcpServers ?? []).map((s) =>
+        s.id === id ? updated : s,
+      );
+      await configService.save({ ...fullConfig, mcpServers: newServers });
+
+      const connected = mcpService.isConnected(id);
+      const tools = connected
+        ? mcpService.getTools(id).map((t) => ({
+            name: t.name,
+            description: t.description,
+          }))
+        : [];
+
+      return {
+        server: {
+          id: updated.id,
+          name: updated.name,
+          transport: updated.transport,
+          command: updated.command,
+          args: updated.args,
+          env: updated.env,
+          url: updated.url,
+          headers: updated.headers,
+          connected,
+          toolCount: tools.length,
+          tools,
+        },
+      };
+    },
+  );
+
+  /**
+   * DELETE /mcp/servers/:id
+   *
+   * Remove an MCP server config and disconnect if connected.
+   */
+  fastify.delete(
+    '/mcp/servers/:id',
+    async (
+      request: FastifyRequest<{ Params: { id: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+
+      const existing = configService.getMcpServer(id);
+      if (!existing) {
+        return reply.status(404).send({
+          error: 'NOT_FOUND',
+          message: `MCP server "${id}" not found in config`,
+        });
+      }
+
+      // Disconnect if connected (ignore errors)
+      if (mcpService.isConnected(id)) {
+        try {
+          await mcpService.disconnect(id);
+        } catch (error) {
+          fastify.log.warn(
+            {
+              serverId: id,
+              err: error instanceof Error ? error.message : String(error),
+            },
+            'Error disconnecting MCP server during delete',
+          );
+        }
+      }
+
+      // Remove from config
+      const fullConfig = configService.getConfig();
+      const newServers = (fullConfig.mcpServers ?? []).filter(
+        (s) => s.id !== id,
+      );
+      await configService.save({ ...fullConfig, mcpServers: newServers });
+
+      return reply.status(204).send();
+    },
+  );
+
+  /**
+   * POST /mcp/servers/:id/connect
+   *
+   * Manually connect to an MCP server (starts from saved config).
+   */
+  fastify.post(
+    '/mcp/servers/:id/connect',
+    async (
+      request: FastifyRequest<{ Params: { id: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+
+      const serverConfig = configService.getMcpServer(id);
+      if (!serverConfig) {
+        return reply.status(404).send({
+          error: 'NOT_FOUND',
+          message: `MCP server "${id}" not found in config`,
+        });
+      }
+
+      if (mcpService.isConnected(id)) {
+        return { serverId: id, connected: true };
+      }
+
+      try {
+        await mcpService.connect(serverConfig);
+        return { serverId: id, connected: true };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error';
+        return reply.status(500).send({
+          error: 'CONNECTION_FAILED',
+          message: `Failed to connect to MCP server "${id}": ${message}`,
+        });
+      }
+    },
+  );
+
+  /**
+   * POST /mcp/servers/:id/disconnect
+   *
+   * Manually disconnect from an MCP server.
+   */
+  fastify.post(
+    '/mcp/servers/:id/disconnect',
+    async (
+      request: FastifyRequest<{ Params: { id: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { id } = request.params;
+
+      try {
+        await mcpService.disconnect(id);
+        return { serverId: id, disconnected: true };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error';
+        return reply.status(500).send({
+          error: 'INTERNAL_ERROR',
+          message: `Failed to disconnect MCP server "${id}": ${message}`,
+        });
+      }
+    },
+  );
+
+  /**
    * POST /mcp/call
    *
-   * Execute an MCP tool call
+   * Execute an MCP tool call (legacy — prefer /mcp/servers/:id/call)
    */
   fastify.post<{
     Body: {
@@ -83,16 +502,7 @@ export async function registerMcpRoutes(
       }>,
       reply: FastifyReply,
     ) => {
-      // Fastify now validates the body with the schema above, so we can use request.body directly
-      const {
-        serverId,
-        tool,
-        arguments: args,
-      } = request.body as {
-        serverId: string;
-        tool: string;
-        arguments?: Record<string, unknown>;
-      };
+      const { serverId, tool, arguments: args } = request.body;
       const toolArgs = args ?? {};
 
       if (!mcpService.isConnected(serverId)) {
@@ -103,155 +513,14 @@ export async function registerMcpRoutes(
       }
 
       try {
-        const startTime = Date.now();
         const result = await mcpService.callTool(serverId, tool, toolArgs);
-        const duration = Date.now() - startTime;
-
-        fastify.log.info(
-          { serverId, tool, duration, success: true },
-          'MCP tool call completed',
-        );
-
         return { result };
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Unknown error';
-        fastify.log.error(
-          { serverId, tool, error: message },
-          'MCP tool call failed',
-        );
         return reply.status(500).send({
           error: 'INTERNAL_ERROR',
           message: `Failed to call MCP tool: ${message}`,
-        });
-      }
-    },
-  );
-
-  /**
-   * POST /mcp/connect
-   *
-   * Connect to an MCP server
-   */
-  fastify.post<{
-    Body: {
-      config: {
-        id: string;
-        transport: 'stdio' | 'http';
-        command?: string;
-        args?: string[];
-        env?: Record<string, string>;
-        url?: string;
-        headers?: Record<string, string>;
-      };
-    };
-  }>(
-    '/mcp/connect',
-    {
-      schema: {
-        body: {
-          type: 'object',
-          required: ['config'],
-          properties: {
-            config: {
-              type: 'object',
-              required: ['id', 'transport'],
-              properties: {
-                id: { type: 'string', minLength: 1 },
-                transport: { type: 'string', enum: ['stdio', 'http'] },
-                command: { type: 'string' },
-                args: { type: 'array', items: { type: 'string' } },
-                env: {
-                  type: 'object',
-                  additionalProperties: { type: 'string' },
-                },
-                url: { type: 'string' },
-                headers: {
-                  type: 'object',
-                  additionalProperties: { type: 'string' },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    async (
-      request: FastifyRequest<{
-        Body: {
-          config: {
-            id: string;
-            transport: 'stdio' | 'http';
-            command?: string;
-            args?: string[];
-            env?: Record<string, string>;
-            url?: string;
-            headers?: Record<string, string>;
-          };
-        };
-      }>,
-      _reply: FastifyReply,
-    ) => {
-      const { config } = request.body as {
-        config: McpServerConfig;
-      };
-
-      // Check if already connected
-      if (mcpService.isConnected(config.id)) {
-        return { serverId: config.id, connected: true };
-      }
-
-      try {
-        await mcpService.connect(config);
-        return { serverId: config.id, connected: true };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unknown error';
-        return _reply.status(500).send({
-          error: 'INTERNAL_ERROR',
-          message: `Failed to connect to MCP server: ${message}`,
-        });
-      }
-    },
-  );
-
-  /**
-   * POST /mcp/disconnect
-   *
-   * Disconnect from an MCP server
-   */
-  fastify.post<{
-    Body: { serverId: string };
-  }>(
-    '/mcp/disconnect',
-    {
-      schema: {
-        body: {
-          type: 'object',
-          required: ['serverId'],
-          properties: {
-            serverId: { type: 'string', minLength: 1 },
-          },
-        },
-      },
-    },
-    async (
-      request: FastifyRequest<{
-        Body: { serverId: string };
-      }>,
-      _reply: FastifyReply,
-    ) => {
-      const { serverId } = request.body as { serverId: string };
-
-      try {
-        await mcpService.disconnect(serverId);
-        return { serverId, disconnected: true };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unknown error';
-        return _reply.status(500).send({
-          error: 'INTERNAL_ERROR',
-          message: `Failed to disconnect from MCP server: ${message}`,
         });
       }
     },

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -10,6 +10,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { McpClientService } from '../mcp/client';
 import type { AppConfigService } from '../config/service';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
 import type { McpServerConfig } from '@openaidy/config';
 import {
   type McpServerRecord,
@@ -17,6 +18,7 @@ import {
   type CreateMcpServerRequest,
   type UpdateMcpServerRequest,
 } from '@openaidy/shared-types';
+import { requireAuth } from '../middleware/require-auth';
 
 /**
  * MCP routes options
@@ -24,6 +26,7 @@ import {
 export type McpRoutesOptions = {
   mcpService: McpClientService;
   configService: AppConfigService;
+  authMiddleware: AuthMiddleware;
 };
 
 /**
@@ -33,7 +36,7 @@ export async function registerMcpRoutes(
   fastify: FastifyInstance,
   options: McpRoutesOptions,
 ): Promise<void> {
-  const { mcpService, configService } = options;
+  const { mcpService, configService, authMiddleware } = options;
 
   /**
    * GET /mcp/servers
@@ -135,7 +138,7 @@ export async function registerMcpRoutes(
     ) => {
       const { id } = request.params;
       if (!mcpService.isConnected(id)) {
-        return reply.status(409).send({
+        return reply.status(503).send({
           error: 'NOT_CONNECTED',
           message: `MCP server "${id}" is not connected`,
         });
@@ -151,380 +154,400 @@ export async function registerMcpRoutes(
     },
   );
 
-  /**
-   * POST /mcp/servers
-   *
-   * Add a new MCP server config and connect to it.
-   * The config is persisted to config/openaidy.json.
-   */
-  fastify.post<{
-    Body: { config: CreateMcpServerRequest };
-  }>(
-    '/mcp/servers',
-    {
-      schema: {
-        body: {
-          type: 'object',
-          required: ['config'],
-          properties: {
-            config: {
-              type: 'object',
-              required: ['id', 'transport'],
-              properties: {
-                id: { type: 'string', minLength: 1 },
-                name: { type: 'string' },
-                transport: { type: 'string', enum: ['stdio', 'http'] },
-                command: { type: 'string' },
-                args: { type: 'array', items: { type: 'string' } },
-                env: {
-                  type: 'object',
-                  additionalProperties: { type: 'string' },
-                },
-                url: { type: 'string' },
-                headers: {
-                  type: 'object',
-                  additionalProperties: { type: 'string' },
+  // -----------------------------------------------------------------------
+  // All routes below require authentication.
+  // Registered in a nested plugin so the preHandler hook is scoped only
+  // to write operations, leaving the GET routes above public.
+  // -----------------------------------------------------------------------
+  await fastify.register(async (authRequired) => {
+    authRequired.addHook(
+      'preHandler',
+      requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
+    );
+
+    /**
+     * POST /mcp/servers
+     *
+     * Add a new MCP server config and connect to it.
+     * The config is persisted to config/openaidy.json.
+     */
+    authRequired.post<{
+      Body: { config: CreateMcpServerRequest };
+    }>(
+      '/mcp/servers',
+      {
+        schema: {
+          body: {
+            type: 'object',
+            required: ['config'],
+            properties: {
+              config: {
+                type: 'object',
+                required: ['id', 'transport'],
+                properties: {
+                  id: { type: 'string', minLength: 1 },
+                  name: { type: 'string' },
+                  transport: { type: 'string', enum: ['stdio', 'http'] },
+                  command: { type: 'string' },
+                  args: { type: 'array', items: { type: 'string' } },
+                  env: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                  },
+                  url: { type: 'string' },
+                  headers: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                  },
                 },
               },
             },
           },
         },
       },
-    },
-    async (
-      request: FastifyRequest<{ Body: { config: CreateMcpServerRequest } }>,
-      reply: FastifyReply,
-    ) => {
-      const { config } = request.body;
+      async (
+        request: FastifyRequest<{ Body: { config: CreateMcpServerRequest } }>,
+        reply: FastifyReply,
+      ) => {
+        const { config } = request.body;
 
-      const existing = configService.getMcpServer(config.id);
-      if (existing) {
-        return reply.status(409).send({
-          error: 'CONFLICT',
-          message: `MCP server "${config.id}" already exists in config`,
-        });
-      }
+        const existing = configService.getMcpServer(config.id);
+        if (existing) {
+          return reply.status(409).send({
+            error: 'CONFLICT',
+            message: `MCP server "${config.id}" already exists in config`,
+          });
+        }
 
-      // Persist to config
-      const fullConfig = configService.getConfig();
-      const newServers = [
-        ...(fullConfig.mcpServers ?? []),
-        config as McpServerConfig,
-      ];
-      await configService.save({ ...fullConfig, mcpServers: newServers });
+        // Persist to config
+        const fullConfig = configService.getConfig();
+        const newServers = [
+          ...(fullConfig.mcpServers ?? []),
+          config as McpServerConfig,
+        ];
+        await configService.save({ ...fullConfig, mcpServers: newServers });
 
-      // Attempt connection (non-fatal if it fails)
-      let connected = false;
-      try {
-        await mcpService.connect(config as McpServerConfig);
-        connected = true;
-      } catch (error) {
-        fastify.log.warn(
-          {
-            serverId: config.id,
-            err: error instanceof Error ? error.message : String(error),
-          },
-          'MCP server saved but initial connection failed',
-        );
-      }
-
-      const tools = connected
-        ? mcpService.getTools(config.id).map((t) => ({
-            name: t.name,
-            description: t.description,
-          }))
-        : [];
-
-      return reply.status(201).send({
-        server: {
-          id: config.id,
-          name: config.name,
-          transport: config.transport,
-          command: config.command,
-          args: config.args,
-          env: config.env,
-          url: config.url,
-          headers: config.headers,
-          connected,
-          toolCount: tools.length,
-          tools,
-        },
-      });
-    },
-  );
-
-  /**
-   * PATCH /mcp/servers/:id
-   *
-   * Update an existing MCP server config.
-   * If the server is connected, changes take effect on next restart.
-   */
-  fastify.patch<{
-    Params: { id: string };
-    Body: UpdateMcpServerRequest;
-  }>(
-    '/mcp/servers/:id',
-    {
-      schema: {
-        params: {
-          type: 'object',
-          required: ['id'],
-          properties: { id: { type: 'string', minLength: 1 } },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            transport: { type: 'string', enum: ['stdio', 'http'] },
-            command: { type: 'string' },
-            args: { type: 'array', items: { type: 'string' } },
-            env: { type: 'object', additionalProperties: { type: 'string' } },
-            url: { type: 'string' },
-            headers: {
-              type: 'object',
-              additionalProperties: { type: 'string' },
-            },
-          },
-        },
-      },
-    },
-    async (
-      request: FastifyRequest<{
-        Params: { id: string };
-        Body: UpdateMcpServerRequest;
-      }>,
-      reply: FastifyReply,
-    ) => {
-      const { id } = request.params;
-      const patch = request.body;
-
-      const existing = configService.getMcpServer(id);
-      if (!existing) {
-        return reply.status(404).send({
-          error: 'NOT_FOUND',
-          message: `MCP server "${id}" not found in config`,
-        });
-      }
-
-      // Build updated config (merge patch into existing)
-      const updated: McpServerConfig = {
-        ...existing,
-        ...(patch.name !== undefined ? { name: patch.name } : {}),
-        ...(patch.transport !== undefined
-          ? { transport: patch.transport }
-          : {}),
-        ...(patch.command !== undefined ? { command: patch.command } : {}),
-        ...(patch.args !== undefined ? { args: patch.args } : {}),
-        ...(patch.env !== undefined ? { env: patch.env } : {}),
-        ...(patch.url !== undefined ? { url: patch.url } : {}),
-        ...(patch.headers !== undefined ? { headers: patch.headers } : {}),
-      };
-
-      // Persist to config
-      const fullConfig = configService.getConfig();
-      const newServers = (fullConfig.mcpServers ?? []).map((s) =>
-        s.id === id ? updated : s,
-      );
-      await configService.save({ ...fullConfig, mcpServers: newServers });
-
-      const connected = mcpService.isConnected(id);
-      const tools = connected
-        ? mcpService.getTools(id).map((t) => ({
-            name: t.name,
-            description: t.description,
-          }))
-        : [];
-
-      return {
-        server: {
-          id: updated.id,
-          name: updated.name,
-          transport: updated.transport,
-          command: updated.command,
-          args: updated.args,
-          env: updated.env,
-          url: updated.url,
-          headers: updated.headers,
-          connected,
-          toolCount: tools.length,
-          tools,
-        },
-      };
-    },
-  );
-
-  /**
-   * DELETE /mcp/servers/:id
-   *
-   * Remove an MCP server config and disconnect if connected.
-   */
-  fastify.delete(
-    '/mcp/servers/:id',
-    async (
-      request: FastifyRequest<{ Params: { id: string } }>,
-      reply: FastifyReply,
-    ) => {
-      const { id } = request.params;
-
-      const existing = configService.getMcpServer(id);
-      if (!existing) {
-        return reply.status(404).send({
-          error: 'NOT_FOUND',
-          message: `MCP server "${id}" not found in config`,
-        });
-      }
-
-      // Disconnect if connected (ignore errors)
-      if (mcpService.isConnected(id)) {
+        // Attempt connection (non-fatal if it fails)
+        let connected = false;
         try {
-          await mcpService.disconnect(id);
+          await mcpService.connect(config as McpServerConfig);
+          connected = true;
         } catch (error) {
           fastify.log.warn(
             {
-              serverId: id,
+              serverId: config.id,
               err: error instanceof Error ? error.message : String(error),
             },
-            'Error disconnecting MCP server during delete',
+            'MCP server saved but initial connection failed',
           );
         }
-      }
 
-      // Remove from config
-      const fullConfig = configService.getConfig();
-      const newServers = (fullConfig.mcpServers ?? []).filter(
-        (s) => s.id !== id,
-      );
-      await configService.save({ ...fullConfig, mcpServers: newServers });
+        const tools = connected
+          ? mcpService.getTools(config.id).map((t) => ({
+              name: t.name,
+              description: t.description,
+            }))
+          : [];
 
-      return reply.status(204).send();
-    },
-  );
-
-  /**
-   * POST /mcp/servers/:id/connect
-   *
-   * Manually connect to an MCP server (starts from saved config).
-   */
-  fastify.post(
-    '/mcp/servers/:id/connect',
-    async (
-      request: FastifyRequest<{ Params: { id: string } }>,
-      reply: FastifyReply,
-    ) => {
-      const { id } = request.params;
-
-      const serverConfig = configService.getMcpServer(id);
-      if (!serverConfig) {
-        return reply.status(404).send({
-          error: 'NOT_FOUND',
-          message: `MCP server "${id}" not found in config`,
+        return reply.status(201).send({
+          server: {
+            id: config.id,
+            name: config.name,
+            transport: config.transport,
+            command: config.command,
+            args: config.args,
+            env: config.env,
+            url: config.url,
+            headers: config.headers,
+            connected,
+            toolCount: tools.length,
+            tools,
+          },
         });
-      }
+      },
+    );
 
-      if (mcpService.isConnected(id)) {
-        return { serverId: id, connected: true };
-      }
-
-      try {
-        await mcpService.connect(serverConfig);
-        return { serverId: id, connected: true };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unknown error';
-        return reply.status(500).send({
-          error: 'CONNECTION_FAILED',
-          message: `Failed to connect to MCP server "${id}": ${message}`,
-        });
-      }
-    },
-  );
-
-  /**
-   * POST /mcp/servers/:id/disconnect
-   *
-   * Manually disconnect from an MCP server.
-   */
-  fastify.post(
-    '/mcp/servers/:id/disconnect',
-    async (
-      request: FastifyRequest<{ Params: { id: string } }>,
-      reply: FastifyReply,
-    ) => {
-      const { id } = request.params;
-
-      try {
-        await mcpService.disconnect(id);
-        return { serverId: id, disconnected: true };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unknown error';
-        return reply.status(500).send({
-          error: 'INTERNAL_ERROR',
-          message: `Failed to disconnect MCP server "${id}": ${message}`,
-        });
-      }
-    },
-  );
-
-  /**
-   * POST /mcp/call
-   *
-   * Execute an MCP tool call (legacy — prefer /mcp/servers/:id/call)
-   */
-  fastify.post<{
-    Body: {
-      serverId: string;
-      tool: string;
-      arguments?: Record<string, unknown>;
-    };
-  }>(
-    '/mcp/call',
-    {
-      schema: {
-        body: {
-          type: 'object',
-          required: ['serverId', 'tool'],
-          properties: {
-            serverId: { type: 'string', minLength: 1 },
-            tool: { type: 'string', minLength: 1 },
-            arguments: { type: 'object', default: {} },
+    /**
+     * PATCH /mcp/servers/:id
+     *
+     * Update an existing MCP server config.
+     * If the server is connected, changes take effect on next restart.
+     */
+    authRequired.patch<{
+      Params: { id: string };
+      Body: UpdateMcpServerRequest;
+    }>(
+      '/mcp/servers/:id',
+      {
+        schema: {
+          params: {
+            type: 'object',
+            required: ['id'],
+            properties: { id: { type: 'string', minLength: 1 } },
+          },
+          body: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              transport: { type: 'string', enum: ['stdio', 'http'] },
+              command: { type: 'string' },
+              args: { type: 'array', items: { type: 'string' } },
+              env: { type: 'object', additionalProperties: { type: 'string' } },
+              url: { type: 'string' },
+              headers: {
+                type: 'object',
+                additionalProperties: { type: 'string' },
+              },
+            },
           },
         },
       },
-    },
-    async (
-      request: FastifyRequest<{
-        Body: {
-          serverId: string;
-          tool: string;
-          arguments?: Record<string, unknown>;
+      async (
+        request: FastifyRequest<{
+          Params: { id: string };
+          Body: UpdateMcpServerRequest;
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params;
+        const patch = request.body;
+
+        const existing = configService.getMcpServer(id);
+        if (!existing) {
+          return reply.status(404).send({
+            error: 'NOT_FOUND',
+            message: `MCP server "${id}" not found in config`,
+          });
+        }
+
+        // Build updated config (merge patch into existing)
+        const updated: McpServerConfig = {
+          ...existing,
+          ...(patch.name !== undefined ? { name: patch.name } : {}),
+          ...(patch.transport !== undefined
+            ? { transport: patch.transport }
+            : {}),
+          ...(patch.command !== undefined ? { command: patch.command } : {}),
+          ...(patch.args !== undefined ? { args: patch.args } : {}),
+          ...(patch.env !== undefined ? { env: patch.env } : {}),
+          ...(patch.url !== undefined ? { url: patch.url } : {}),
+          ...(patch.headers !== undefined ? { headers: patch.headers } : {}),
         };
-      }>,
-      reply: FastifyReply,
-    ) => {
-      const { serverId, tool, arguments: args } = request.body;
-      const toolArgs = args ?? {};
 
-      if (!mcpService.isConnected(serverId)) {
-        return reply.status(404).send({
-          error: 'NOT_FOUND',
-          message: `MCP server ${serverId} not connected`,
-        });
-      }
+        // Persist to config
+        const fullConfig = configService.getConfig();
+        const newServers = (fullConfig.mcpServers ?? []).map((s) =>
+          s.id === id ? updated : s,
+        );
+        await configService.save({ ...fullConfig, mcpServers: newServers });
 
-      try {
-        const result = await mcpService.callTool(serverId, tool, toolArgs);
-        return { result };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unknown error';
-        return reply.status(500).send({
-          error: 'INTERNAL_ERROR',
-          message: `Failed to call MCP tool: ${message}`,
-        });
-      }
-    },
-  );
+        const connected = mcpService.isConnected(id);
+        const tools = connected
+          ? mcpService.getTools(id).map((t) => ({
+              name: t.name,
+              description: t.description,
+            }))
+          : [];
+
+        return {
+          server: {
+            id: updated.id,
+            name: updated.name,
+            transport: updated.transport,
+            command: updated.command,
+            args: updated.args,
+            env: updated.env,
+            url: updated.url,
+            headers: updated.headers,
+            connected,
+            toolCount: tools.length,
+            tools,
+          },
+        };
+      },
+    );
+
+    /**
+     * DELETE /mcp/servers/:id
+     *
+     * Remove an MCP server config and disconnect if connected.
+     */
+    authRequired.delete(
+      '/mcp/servers/:id',
+      async (
+        request: FastifyRequest<{ Params: { id: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params;
+
+        const existing = configService.getMcpServer(id);
+        if (!existing) {
+          return reply.status(404).send({
+            error: 'NOT_FOUND',
+            message: `MCP server "${id}" not found in config`,
+          });
+        }
+
+        // Disconnect if connected (ignore errors)
+        if (mcpService.isConnected(id)) {
+          try {
+            await mcpService.disconnect(id);
+          } catch (error) {
+            fastify.log.warn(
+              {
+                serverId: id,
+                err: error instanceof Error ? error.message : String(error),
+              },
+              'Error disconnecting MCP server during delete',
+            );
+          }
+        }
+
+        // Remove from config
+        const fullConfig = configService.getConfig();
+        const newServers = (fullConfig.mcpServers ?? []).filter(
+          (s) => s.id !== id,
+        );
+        await configService.save({ ...fullConfig, mcpServers: newServers });
+
+        return reply.status(204).send();
+      },
+    );
+
+    /**
+     * POST /mcp/servers/:id/connect
+     *
+     * Manually connect to an MCP server (starts from saved config).
+     */
+    authRequired.post(
+      '/mcp/servers/:id/connect',
+      async (
+        request: FastifyRequest<{ Params: { id: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params;
+
+        const serverConfig = configService.getMcpServer(id);
+        if (!serverConfig) {
+          return reply.status(404).send({
+            error: 'NOT_FOUND',
+            message: `MCP server "${id}" not found in config`,
+          });
+        }
+
+        if (mcpService.isConnected(id)) {
+          return { serverId: id, connected: true };
+        }
+
+        try {
+          await mcpService.connect(serverConfig);
+          return { serverId: id, connected: true };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          return reply.status(500).send({
+            error: 'CONNECTION_FAILED',
+            message: `Failed to connect to MCP server "${id}": ${message}`,
+          });
+        }
+      },
+    );
+
+    /**
+     * POST /mcp/servers/:id/disconnect
+     *
+     * Manually disconnect from an MCP server.
+     */
+    authRequired.post(
+      '/mcp/servers/:id/disconnect',
+      async (
+        request: FastifyRequest<{ Params: { id: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params;
+
+        const serverConfig = configService.getMcpServer(id);
+        if (!serverConfig) {
+          return reply.status(404).send({
+            error: 'NOT_FOUND',
+            message: `MCP server "${id}" not found in config`,
+          });
+        }
+
+        try {
+          await mcpService.disconnect(id);
+          return { serverId: id, disconnected: true };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          return reply.status(500).send({
+            error: 'INTERNAL_ERROR',
+            message: `Failed to disconnect MCP server "${id}": ${message}`,
+          });
+        }
+      },
+    );
+
+    /**
+     * POST /mcp/call
+     *
+     * Execute an MCP tool call (legacy — prefer /mcp/servers/:id/call)
+     */
+    authRequired.post<{
+      Body: {
+        serverId: string;
+        tool: string;
+        arguments?: Record<string, unknown>;
+      };
+    }>(
+      '/mcp/call',
+      {
+        schema: {
+          body: {
+            type: 'object',
+            required: ['serverId', 'tool'],
+            properties: {
+              serverId: { type: 'string', minLength: 1 },
+              tool: { type: 'string', minLength: 1 },
+              arguments: { type: 'object', default: {} },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Body: {
+            serverId: string;
+            tool: string;
+            arguments?: Record<string, unknown>;
+          };
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const { serverId, tool, arguments: args } = request.body;
+        const toolArgs = args ?? {};
+
+        if (!mcpService.isConnected(serverId)) {
+          return reply.status(404).send({
+            error: 'NOT_FOUND',
+            message: `MCP server ${serverId} not connected`,
+          });
+        }
+
+        try {
+          const result = await mcpService.callTool(serverId, tool, toolArgs);
+          return { result };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          return reply.status(500).send({
+            error: 'INTERNAL_ERROR',
+            message: `Failed to call MCP tool: ${message}`,
+          });
+        }
+      },
+    );
+  }); // end authRequired plugin
 }
 
 /**

--- a/apps/web/src/components/pages/McpsPage.tsx
+++ b/apps/web/src/components/pages/McpsPage.tsx
@@ -1,13 +1,389 @@
 import { Layout } from './Layout';
-import { For, Show, createSignal, onMount } from 'solid-js';
-import { listMcpServers } from '../../lib/api';
-import type { McpServer } from '@openaidy/config';
+import { For, Show, createSignal, onMount, createMemo } from 'solid-js';
+import {
+  listMcpServers,
+  createMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
+  connectMcpServer,
+  disconnectMcpServer,
+  type McpServerRecord,
+} from '../../lib/api';
+import type {
+  CreateMcpServerRequest,
+  UpdateMcpServerRequest,
+} from '../../lib/api';
+
+function StatusBadge(props: { connected: boolean }) {
+  return (
+    <span
+      class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+        props.connected
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+          : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+      }`}
+    >
+      {props.connected ? 'Connected' : 'Disconnected'}
+    </span>
+  );
+}
+
+function ServerFormModal(props: {
+  mode: 'create' | 'edit';
+  server?: McpServerRecord;
+  onSave: (
+    data: CreateMcpServerRequest | UpdateMcpServerRequest,
+  ) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [transport, setTransport] = createSignal<'stdio' | 'http'>(
+    props.server?.transport ?? 'stdio',
+  );
+  const [formData, setFormData] = createSignal({
+    id: props.server?.id ?? '',
+    name: props.server?.name ?? '',
+    command: props.server?.command ?? '',
+    args: props.server?.args?.join(' ') ?? '',
+    url: props.server?.url ?? '',
+    env: props.server?.env
+      ? Object.entries(props.server.env)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('\n')
+      : '',
+  });
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const isEdit = () => props.mode === 'edit';
+  const isStdio = () => transport() === 'stdio';
+
+  const buildRequest = (): CreateMcpServerRequest | UpdateMcpServerRequest => {
+    const base = {
+      name: formData().name || undefined,
+      transport: transport(),
+    };
+
+    if (isStdio()) {
+      return {
+        ...base,
+        command: formData().command || undefined,
+        args: formData().args ? formData().args.trim().split(/\s+/) : undefined,
+        env: formData().env
+          ? Object.fromEntries(
+              formData()
+                .env.split('\n')
+                .filter((l) => l.includes('='))
+                .map((l) => {
+                  const idx = l.indexOf('=');
+                  return [l.slice(0, idx), l.slice(idx + 1)];
+                }),
+            )
+          : undefined,
+      };
+    } else {
+      return {
+        ...base,
+        url: formData().url || undefined,
+      };
+    }
+  };
+
+  const handleSave = async () => {
+    if (!isEdit() && !formData().id.trim()) {
+      setError('Server ID is required');
+      return;
+    }
+    if (isStdio() && !formData().command.trim()) {
+      setError('Command is required for stdio transport');
+      return;
+    }
+    if (!isStdio() && !formData().url.trim()) {
+      setError('URL is required for HTTP transport');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await props.onSave(buildRequest());
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save server');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div class="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {isEdit() ? 'Edit MCP Server' : 'Add MCP Server'}
+          </h2>
+          <button
+            onClick={props.onClose}
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div class="p-4 space-y-4">
+          <Show when={error()}>
+            <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+              {error()}
+            </div>
+          </Show>
+
+          {/* Transport selector */}
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Transport
+            </label>
+            <div class="flex gap-3">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="transport"
+                  value="stdio"
+                  checked={transport() === 'stdio'}
+                  onChange={() => setTransport('stdio')}
+                  class="accent-primary"
+                />
+                <span class="text-sm text-gray-800 dark:text-gray-200">
+                  stdio (local process)
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="transport"
+                  value="http"
+                  checked={transport() === 'http'}
+                  onChange={() => setTransport('http')}
+                  class="accent-primary"
+                />
+                <span class="text-sm text-gray-800 dark:text-gray-200">
+                  HTTP (remote server)
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* ID field — only on create */}
+          <Show when={!isEdit()}>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Server ID <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData().id}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, id: e.currentTarget.value }))
+                }
+                placeholder="e.g. filesystem-server"
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                Unique identifier. Must match the server's internal name.
+              </p>
+            </div>
+          </Show>
+
+          {/* Name field */}
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Display Name
+            </label>
+            <input
+              type="text"
+              value={formData().name}
+              onInput={(e) =>
+                setFormData((p) => ({ ...p, name: e.currentTarget.value }))
+              }
+              placeholder="e.g. Filesystem Tools"
+              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+
+          {/* stdio fields */}
+          <Show when={isStdio()}>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Command <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData().command}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, command: e.currentTarget.value }))
+                }
+                placeholder="e.g. npx"
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Arguments
+              </label>
+              <input
+                type="text"
+                value={formData().args}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, args: e.currentTarget.value }))
+                }
+                placeholder="e.g. @modelcontextprotocol/server-filesystem /path"
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                Space-separated arguments
+              </p>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Environment Variables
+              </label>
+              <textarea
+                value={formData().env}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, env: e.currentTarget.value }))
+                }
+                placeholder="KEY=value&#10;SECRET=mysecret"
+                rows={3}
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                One KEY=value per line. Use $&#123;VAR_NAME&#125; for env var
+                placeholders.
+              </p>
+            </div>
+          </Show>
+
+          {/* HTTP fields */}
+          <Show when={!isStdio()}>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                URL <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="url"
+                value={formData().url}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, url: e.currentTarget.value }))
+                }
+                placeholder="https://my-mcp-server.com/mcp"
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </Show>
+        </div>
+
+        <div class="flex items-center justify-end gap-3 p-4 border-t dark:border-gray-700">
+          <button
+            onClick={props.onClose}
+            class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving()}
+            class="px-4 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving() ? 'Saving…' : isEdit() ? 'Save Changes' : 'Add Server'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmDeleteModal(props: {
+  server: McpServerRecord;
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+}) {
+  const [deleting, setDeleting] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await props.onConfirm();
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete server');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-md mx-4">
+        <div class="p-4 border-b dark:border-gray-700">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Delete MCP Server
+          </h2>
+        </div>
+        <div class="p-4">
+          <Show when={error()}>
+            <div class="mb-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+              {error()}
+            </div>
+          </Show>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Remove{' '}
+            <strong class="text-gray-900 dark:text-gray-100">
+              {props.server.name ?? props.server.id}
+            </strong>{' '}
+            from the config? This will disconnect the server and remove it from
+            all agents.
+          </p>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-4 border-t dark:border-gray-700">
+          <button
+            onClick={props.onClose}
+            class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleDelete()}
+            disabled={deleting()}
+            class="px-4 py-2 text-sm text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {deleting() ? 'Deleting…' : 'Delete Server'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function McpsPage() {
-  const [servers, setServers] = createSignal<McpServer[]>([]);
+  const [servers, setServers] = createSignal<McpServerRecord[]>([]);
   const [isLoading, setIsLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
-  const [selectedServer, setSelectedServer] = createSignal<string | null>(null);
+  const [selectedId, setSelectedId] = createSignal<string | null>(null);
+  const [actionId, setActionId] = createSignal<string | null>(null);
+  const [actionError, setActionError] = createSignal<string | null>(null);
+  const [showForm, setShowForm] = createSignal<{
+    mode: 'create' | 'edit';
+    server?: McpServerRecord;
+  } | null>(null);
+  const [showDelete, setShowDelete] = createSignal<McpServerRecord | null>(
+    null,
+  );
+
+  const selected = createMemo(() =>
+    servers().find((s) => s.id === selectedId()),
+  );
 
   const loadServers = async () => {
     setIsLoading(true);
@@ -15,8 +391,8 @@ export function McpsPage() {
     try {
       const data = await listMcpServers();
       setServers(data.servers);
-      if (data.servers.length > 0 && !selectedServer()) {
-        setSelectedServer(data.servers[0]?.id ?? null);
+      if (data.servers.length > 0 && !selectedId()) {
+        setSelectedId(data.servers[0]?.id ?? null);
       }
     } catch (err) {
       setError(
@@ -31,69 +407,156 @@ export function McpsPage() {
     void loadServers();
   });
 
-  const selectedServerData = () =>
-    servers().find((s) => s.id === selectedServer());
+  const handleConnect = async (server: McpServerRecord) => {
+    setActionId(server.id);
+    setActionError(null);
+    try {
+      const result = await connectMcpServer(server.id);
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === server.id ? { ...s, connected: result.connected } : s,
+        ),
+      );
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to connect server',
+      );
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleDisconnect = async (server: McpServerRecord) => {
+    setActionId(server.id);
+    setActionError(null);
+    try {
+      const result = await disconnectMcpServer(server.id);
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === server.id ? { ...s, connected: !result.disconnected } : s,
+        ),
+      );
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to disconnect server',
+      );
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleSave = async (
+    data: CreateMcpServerRequest | UpdateMcpServerRequest,
+  ) => {
+    if (showForm()?.mode === 'edit' && showForm()?.server) {
+      const result = await updateMcpServer(
+        showForm()!.server!.id,
+        data as UpdateMcpServerRequest,
+      );
+      setServers((prev) =>
+        prev.map((s) => (s.id === showForm()!.server!.id ? result.server : s)),
+      );
+    } else {
+      const result = await createMcpServer(data as CreateMcpServerRequest);
+      setServers((prev) => [...prev, result.server]);
+      setSelectedId(result.server.id);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!showDelete()) return;
+    await deleteMcpServer(showDelete()!.id);
+    setServers((prev) => prev.filter((s) => s.id !== showDelete()!.id));
+    if (selectedId() === showDelete()?.id) {
+      setSelectedId(servers()[0]?.id ?? null);
+    }
+  };
 
   const connectedCount = () => servers().filter((s) => s.connected).length;
   const totalTools = () =>
     servers()
       .filter((s) => s.connected)
-      .reduce((sum, s) => sum + s.tools.length, 0);
+      .reduce((sum, s) => sum + s.toolCount, 0);
 
   return (
     <Layout
       title="MCP Servers"
-      description="Model Context Protocol connections"
+      description="Manage Model Context Protocol server connections"
+      actions={
+        <button
+          onClick={() => setShowForm({ mode: 'create' })}
+          class="flex items-center gap-2 px-3 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          + Add Server
+        </button>
+      }
     >
-      {/* Loading State */}
+      {/* Action-level error banner */}
+      <Show when={actionError()}>
+        <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center justify-between gap-3">
+          <span class="text-sm text-red-700 dark:text-red-400">
+            {actionError()}
+          </span>
+          <button
+            onClick={() => setActionError(null)}
+            class="text-red-500 hover:text-red-700 text-xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+      </Show>
+
+      {/* Loading */}
       <Show when={isLoading()}>
         <div class="flex items-center justify-center h-64">
           <div class="text-center">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-            <p class="text-text-tertiary">Loading MCP servers...</p>
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+            <p class="text-text-tertiary">Loading MCP servers…</p>
           </div>
         </div>
       </Show>
 
-      {/* Error State */}
+      {/* Load error */}
       <Show when={!isLoading() && error()}>
-        <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
-          <p class="text-red-700 dark:text-red-400">{error()}</p>
+        <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-center justify-between gap-3">
+          <span class="text-sm text-red-700 dark:text-red-400">{error()}</span>
           <button
             onClick={() => void loadServers()}
-            class="mt-2 text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
+            class="text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
           >
             Try again
           </button>
         </div>
       </Show>
 
-      {/* Empty State */}
+      {/* Empty state */}
       <Show when={!isLoading() && !error() && servers().length === 0}>
-        <div class="flex items-center justify-center h-64">
-          <div class="text-center">
-            <div class="text-4xl mb-4">🔌</div>
-            <p class="text-text-secondary mb-2">No MCP servers configured</p>
-            <p class="text-sm text-text-tertiary">
-              Add MCP servers to your{' '}
-              <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">
-                config/openaidy.json
-              </code>{' '}
-              to get started
-            </p>
-          </div>
+        <div class="flex flex-col items-center justify-center h-64 text-center">
+          <div class="text-4xl mb-4">🔌</div>
+          <p class="text-text-secondary font-medium mb-1">
+            No MCP servers configured
+          </p>
+          <p class="text-sm text-text-tertiary mb-4">
+            Add servers to enable tools from external services
+          </p>
+          <button
+            onClick={() => setShowForm({ mode: 'create' })}
+            class="px-4 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            Add your first server
+          </button>
         </div>
       </Show>
 
-      {/* Main Content */}
-      <Show when={!isLoading() && !error() && servers().length > 0}>
-        {/* Stats Bar */}
+      {/* Server list + detail */}
+      <Show when={!isLoading() && servers().length > 0}>
+        {/* Stats bar */}
         <div class="grid grid-cols-3 gap-4 mb-6">
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
             <div class="text-2xl font-bold text-primary">
               {servers().length}
             </div>
-            <div class="text-sm text-text-secondary">Configured Servers</div>
+            <div class="text-sm text-text-secondary">Configured</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
             <div class="text-2xl font-bold text-green-600 dark:text-green-400">
@@ -110,15 +573,14 @@ export function McpsPage() {
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Server List */}
-          <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
+          {/* Server list */}
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden flex flex-col">
             <div class="p-4 border-b dark:border-gray-700 flex items-center justify-between">
-              <h2 class="text-lg font-semibold">Servers</h2>
+              <h2 class="text-base font-semibold">Servers</h2>
               <button
                 onClick={() => void loadServers()}
-                disabled={isLoading()}
-                class="text-sm text-primary hover:text-primary/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
-                title="Refresh server list"
+                class="text-sm text-primary hover:text-primary/80 flex items-center gap-1"
+                title="Refresh"
               >
                 <svg
                   class={`w-4 h-4 ${isLoading() ? 'animate-spin' : ''}`}
@@ -133,38 +595,31 @@ export function McpsPage() {
                     d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
                   />
                 </svg>
-                Refresh
               </button>
             </div>
-            <div class="divide-y dark:divide-gray-700">
+
+            <div class="flex-1 overflow-y-auto divide-y dark:divide-gray-700">
               <For each={servers()}>
                 {(server) => (
                   <button
                     class={`w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ${
-                      selectedServer() === server.id
+                      selectedId() === server.id
                         ? 'bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary'
-                        : ''
+                        : 'border-l-4 border-transparent'
                     }`}
-                    onClick={() => setSelectedServer(server.id)}
+                    onClick={() => setSelectedId(server.id)}
                   >
                     <div class="flex items-center justify-between mb-1">
-                      <span class="font-medium">
+                      <span class="font-medium text-sm text-gray-900 dark:text-gray-100">
                         {server.name ?? server.id}
                       </span>
-                      <span
-                        class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                          server.connected
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-400'
-                        }`}
-                      >
-                        {server.connected ? 'Connected' : 'Disconnected'}
-                      </span>
+                      <StatusBadge connected={server.connected} />
                     </div>
-                    <div class="text-sm text-text-tertiary">
+                    <div class="text-xs text-text-tertiary">
+                      {server.transport} ·{' '}
                       {server.connected
-                        ? `${server.tools.length} tools available`
-                        : 'Not connected'}
+                        ? `${server.toolCount} tool${server.toolCount !== 1 ? 's' : ''}`
+                        : 'disconnected'}
                     </div>
                   </button>
                 )}
@@ -172,81 +627,225 @@ export function McpsPage() {
             </div>
           </div>
 
-          {/* Tool Details */}
-          <div class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-lg shadow">
-            <div class="p-4 border-b dark:border-gray-700">
-              <h2 class="text-lg font-semibold">
-                Tools
-                <Show when={selectedServerData()}>
-                  <span class="font-normal text-text-tertiary ml-2">
-                    from{' '}
-                    {selectedServerData()?.name ?? selectedServerData()?.id}
-                  </span>
+          {/* Detail panel */}
+          <div class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden flex flex-col">
+            <Show when={!selected()}>
+              <div class="flex-1 flex items-center justify-center">
+                <p class="text-text-tertiary">
+                  Select a server to view details
+                </p>
+              </div>
+            </Show>
+
+            <Show when={selected()}>
+              {/* Detail header */}
+              <div class="p-4 border-b dark:border-gray-700 flex items-start justify-between gap-3">
+                <div>
+                  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    {selected()!.name ?? selected()!.id}
+                  </h3>
+                  <div class="mt-1 flex items-center gap-2 flex-wrap">
+                    <code class="text-xs px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-gray-600 dark:text-gray-300">
+                      {selected()!.id}
+                    </code>
+                    <span class="text-xs px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded">
+                      {selected()!.transport}
+                    </span>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2 flex-shrink-0">
+                  <Show when={!selected()!.connected}>
+                    <button
+                      onClick={() => void handleConnect(selected()!)}
+                      disabled={actionId() === selected()!.id}
+                      class="flex items-center gap-1.5 px-3 py-1.5 text-xs text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800 rounded-lg hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-50 transition-colors"
+                    >
+                      <svg
+                        class="w-3.5 h-3.5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                      Connect
+                    </button>
+                  </Show>
+                  <Show when={selected()!.connected}>
+                    <button
+                      onClick={() => void handleDisconnect(selected()!)}
+                      disabled={actionId() === selected()!.id}
+                      class="flex items-center gap-1.5 px-3 py-1.5 text-xs text-yellow-700 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-800 rounded-lg hover:bg-yellow-50 dark:hover:bg-yellow-900/20 disabled:opacity-50 transition-colors"
+                    >
+                      <svg
+                        class="w-3.5 h-3.5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M18.364 18.364A5 5 0 005.636 5.636m12.728 12.728A5 5 0 015.636 5.636m12.728 12.728L5.636 5.636"
+                        />
+                      </svg>
+                      Disconnect
+                    </button>
+                  </Show>
+
+                  <button
+                    onClick={() =>
+                      setShowForm({ mode: 'edit', server: selected()! })
+                    }
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                  >
+                    <svg
+                      class="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                      />
+                    </svg>
+                    Edit
+                  </button>
+
+                  <button
+                    onClick={() => setShowDelete(selected()!)}
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 transition-colors"
+                  >
+                    <svg
+                      class="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
+                    </svg>
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              {/* Config details */}
+              <div class="flex-1 overflow-y-auto p-4 space-y-3 text-sm">
+                <Show when={selected()!.transport === 'stdio'}>
+                  <div>
+                    <span class="text-xs text-text-tertiary">Command</span>
+                    <p class="font-mono text-gray-900 dark:text-gray-100">
+                      {selected()!.command ?? '—'}
+                    </p>
+                  </div>
                 </Show>
-              </h2>
-            </div>
+                <Show when={selected()!.transport === 'http'}>
+                  <div>
+                    <span class="text-xs text-text-tertiary">URL</span>
+                    <p class="font-mono text-gray-900 dark:text-gray-100">
+                      {selected()!.url ?? '—'}
+                    </p>
+                  </div>
+                </Show>
 
-            <Show when={!selectedServerData()?.connected}>
-              <div class="p-8 text-center">
-                <div class="text-3xl mb-3">⚠️</div>
-                <p class="text-text-secondary">Server not connected</p>
-                <p class="text-sm text-text-tertiary mt-1">
-                  Check server logs for connection errors
-                </p>
-              </div>
-            </Show>
+                <Show when={selected()!.args && selected()!.args!.length > 0}>
+                  <div>
+                    <span class="text-xs text-text-tertiary">Arguments</span>
+                    <p class="font-mono text-gray-900 dark:text-gray-100">
+                      {selected()!.args!.join(' ')}
+                    </p>
+                  </div>
+                </Show>
 
-            <Show
-              when={
-                selectedServerData()?.connected &&
-                selectedServerData()?.tools.length === 0
-              }
-            >
-              <div class="p-8 text-center">
-                <div class="text-3xl mb-3">📭</div>
-                <p class="text-text-secondary">No tools available</p>
-                <p class="text-sm text-text-tertiary mt-1">
-                  This server may not expose any tools
-                </p>
-              </div>
-            </Show>
-
-            <Show
-              when={
-                selectedServerData()?.connected &&
-                selectedServerData()!.tools.length > 0
-              }
-            >
-              <div class="divide-y dark:divide-gray-700 max-h-96 overflow-y-auto">
-                <For each={selectedServerData()?.tools}>
-                  {(tool) => (
-                    <div class="p-4">
-                      <div class="font-mono text-sm text-primary mb-1">
-                        {tool.name}
-                      </div>
-                      <Show when={tool.description}>
-                        <p class="text-sm text-text-secondary">
-                          {tool.description}
-                        </p>
-                      </Show>
-                      <Show when={!tool.description}>
-                        <p class="text-sm text-text-tertiary italic">
-                          No description available
-                        </p>
-                      </Show>
+                <Show
+                  when={
+                    selected()!.env && Object.keys(selected()!.env!).length > 0
+                  }
+                >
+                  <div>
+                    <span class="text-xs text-text-tertiary">
+                      Environment Variables
+                    </span>
+                    <div class="mt-1 space-y-0.5">
+                      <For each={Object.entries(selected()!.env!)}>
+                        {([key, val]) => (
+                          <p class="font-mono text-xs text-gray-700 dark:text-gray-300">
+                            {key}=<span class="text-text-tertiary">{val}</span>
+                          </p>
+                        )}
+                      </For>
                     </div>
-                  )}
-                </For>
-              </div>
-            </Show>
+                  </div>
+                </Show>
 
-            <Show when={!selectedServer()}>
-              <div class="p-8 text-center">
-                <p class="text-text-tertiary">Select a server to see tools</p>
+                {/* Tools */}
+                <div>
+                  <span class="text-xs text-text-tertiary">
+                    Tools ({selected()!.toolCount})
+                  </span>
+                  <Show when={selected()!.tools.length === 0}>
+                    <p class="mt-1 text-text-tertiary italic text-xs">
+                      {selected()!.connected
+                        ? 'No tools exposed by this server'
+                        : 'Connect to see available tools'}
+                    </p>
+                  </Show>
+                  <Show when={selected()!.tools.length > 0}>
+                    <div class="mt-2 space-y-2">
+                      <For each={selected()!.tools}>
+                        {(tool) => (
+                          <div class="p-2 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                            <div class="font-mono text-xs text-primary">
+                              {tool.name}
+                            </div>
+                            <Show when={tool.description}>
+                              <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                                {tool.description}
+                              </p>
+                            </Show>
+                          </div>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+                </div>
               </div>
             </Show>
           </div>
         </div>
+      </Show>
+
+      {/* Modals */}
+      <Show when={showForm()}>
+        <ServerFormModal
+          mode={showForm()!.mode}
+          server={showForm()!.server}
+          onSave={handleSave}
+          onClose={() => setShowForm(null)}
+        />
+      </Show>
+
+      <Show when={showDelete()}>
+        <ConfirmDeleteModal
+          server={showDelete()!}
+          onConfirm={handleDelete}
+          onClose={() => setShowDelete(null)}
+        />
       </Show>
     </Layout>
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -813,15 +813,124 @@ export async function clearLogs(): Promise<{
   return response.json();
 }
 
-import type { McpServer } from '@openaidy/config';
+import type {
+  McpServerRecord,
+  McpToolWithSchema,
+  CreateMcpServerRequest,
+  UpdateMcpServerRequest,
+} from '@openaidy/shared-types';
+export type {
+  McpServerRecord,
+  McpToolWithSchema,
+  CreateMcpServerRequest,
+  UpdateMcpServerRequest,
+};
 
 /**
- * List all configured MCP servers and their status
+ * List all configured MCP servers and their live runtime status.
+ * Returns both persisted config fields and current connection state.
  */
-export async function listMcpServers(): Promise<{ servers: McpServer[] }> {
+export async function listMcpServers(): Promise<{
+  servers: McpServerRecord[];
+}> {
   const response = await apiFetch(`${API_BASE}/mcp/servers`);
   if (!response.ok) {
     throw new Error(`Failed to list MCP servers: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Create a new MCP server config and connect to it.
+ */
+export async function createMcpServer(
+  config: CreateMcpServerRequest,
+): Promise<{ server: McpServerRecord }> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ config }),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Update an existing MCP server config (requires restart to take effect).
+ */
+export async function updateMcpServer(
+  id: string,
+  patch: UpdateMcpServerRequest,
+): Promise<{ server: McpServerRecord }> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Delete an MCP server config and disconnect it if connected.
+ */
+export async function deleteMcpServer(id: string): Promise<void> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers/${id}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok && response.status !== 204) {
+    const body = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+}
+
+/**
+ * Manually connect to an MCP server.
+ */
+export async function connectMcpServer(
+  id: string,
+): Promise<{ serverId: string; connected: boolean }> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers/${id}/connect`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Manually disconnect from an MCP server.
+ */
+export async function disconnectMcpServer(
+  id: string,
+): Promise<{ serverId: string; disconnected: boolean }> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers/${id}/disconnect`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Get the full tool schema for an MCP server (useful for tooling UIs).
+ */
+export async function getMcpServerTools(
+  id: string,
+): Promise<{ tools: McpToolWithSchema[] }> {
+  const response = await apiFetch(`${API_BASE}/mcp/servers/${id}/tools`);
+  if (!response.ok) {
+    throw new Error(`Failed to get MCP server tools: ${response.statusText}`);
   }
   return response.json();
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -6,3 +6,4 @@ export * from './websocket.js';
 export * from './logs.js';
 export * from './api.js';
 export * from './addon.js';
+export * from './mcp.js';

--- a/packages/shared-types/src/mcp.ts
+++ b/packages/shared-types/src/mcp.ts
@@ -14,13 +14,13 @@ export type McpServerTransport = 'stdio' | 'http';
  */
 export type McpServerTransportConfig = {
   id: string;
-  name?: string;
+  name?: string | undefined;
   transport: McpServerTransport;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
+  command?: string | undefined;
+  args?: string[] | undefined;
+  env?: Record<string, string> | undefined;
+  url?: string | undefined;
+  headers?: Record<string, string> | undefined;
 };
 
 /**
@@ -28,23 +28,14 @@ export type McpServerTransportConfig = {
  */
 export type McpToolSummary = {
   name: string;
-  description?: string;
+  description?: string | undefined;
 };
 
 /**
  * Full MCP server record combining persisted config + live runtime status.
  * Returned by GET /mcp/servers
  */
-export type McpServerRecord = {
-  /** Persisted config */
-  id: string;
-  name?: string;
-  transport: McpServerTransport;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
+export type McpServerRecord = McpServerTransportConfig & {
   /** Live runtime state */
   connected: boolean;
   toolCount: number;
@@ -54,35 +45,21 @@ export type McpServerRecord = {
 /**
  * Request body for creating a new MCP server config
  */
-export type CreateMcpServerRequest = {
-  id: string;
-  name?: string;
-  transport: McpServerTransport;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
-};
+export type CreateMcpServerRequest = McpServerTransportConfig;
 
 /**
  * Request body for updating an existing MCP server config
  */
-export type UpdateMcpServerRequest = {
-  name?: string;
-  transport?: McpServerTransport;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
-};
+export type UpdateMcpServerRequest = Omit<
+  Partial<McpServerTransportConfig>,
+  'id'
+>;
 
 /**
  * MCP tool with its input schema exposed (for UI exploration)
  */
 export type McpToolWithSchema = {
   name: string;
-  description?: string;
+  description?: string | undefined;
   inputSchema: Record<string, unknown>;
 };

--- a/packages/shared-types/src/mcp.ts
+++ b/packages/shared-types/src/mcp.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP Server shared types
+ *
+ * These types are shared between the server and the frontend.
+ */
+
+/**
+ * MCP server transport type
+ */
+export type McpServerTransport = 'stdio' | 'http';
+
+/**
+ * MCP server transport config fields (shared shape for both transports)
+ */
+export type McpServerTransportConfig = {
+  id: string;
+  name?: string;
+  transport: McpServerTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+/**
+ * Runtime status of a single MCP tool
+ */
+export type McpToolSummary = {
+  name: string;
+  description?: string;
+};
+
+/**
+ * Full MCP server record combining persisted config + live runtime status.
+ * Returned by GET /mcp/servers
+ */
+export type McpServerRecord = {
+  /** Persisted config */
+  id: string;
+  name?: string;
+  transport: McpServerTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  /** Live runtime state */
+  connected: boolean;
+  toolCount: number;
+  tools: McpToolSummary[];
+};
+
+/**
+ * Request body for creating a new MCP server config
+ */
+export type CreateMcpServerRequest = {
+  id: string;
+  name?: string;
+  transport: McpServerTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+/**
+ * Request body for updating an existing MCP server config
+ */
+export type UpdateMcpServerRequest = {
+  name?: string;
+  transport?: McpServerTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+/**
+ * MCP tool with its input schema exposed (for UI exploration)
+ */
+export type McpToolWithSchema = {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+};

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -91,6 +91,7 @@ export const WS_CAPABILITIES = {
 
   // Agent capabilities
   AGENTS_LIST: 'agents.list',
+  AGENTS_READ: 'agents.read',
   AGENTS_INVOKE: 'agents.invoke',
 
   // Provider capabilities


### PR DESCRIPTION
## Summary

Adds complete MCP server management UI — both the REST API backend and the web frontend.

### Backend REST API

| Method | Path | Description |
|---|---|---|
| GET | `/mcp/servers` | List all configured servers with live runtime status |
| GET | `/mcp/servers/:id` | Single server detail |
| GET | `/mcp/servers/:id/tools` | Full tool schemas from a connected server |
| POST | `/mcp/servers` | Create new server config + auto-connect |
| PATCH | `/mcp/servers/:id` | Update server config |
| DELETE | `/mcp/servers/:id` | Remove config + disconnect |
| POST | `/mcp/servers/:id/connect` | Manual connect |
| POST | `/mcp/servers/:id/disconnect` | Manual disconnect |

### Frontend

- **McpsPage** with server list sidebar, detail panel, stats bar
- **ServerFormModal** — Add/Edit with stdio + HTTP transport fields
- **ConfirmDeleteModal** — Delete with confirmation
- Connect/disconnect actions, refresh, edit, delete buttons
- Live status badges, tool count, config display

### Shared types

New `packages/shared-types/src/mcp.ts` exports:
- `McpServerRecord`, `McpToolSummary`, `McpToolWithSchema`
- `CreateMcpServerRequest`, `UpdateMcpServerRequest`

- `McpServerTransport`

### Also includes

Pre-existing bugfix: `AGENTS_READ` capability was missing from `WS_CAPABILITIES` in `shared-types/src/websocket.ts`, blocking SDK and server builds.

---

**Stacked on:** PRs #276 (skills backend) + #277 (security hardening)