### PR TITLE
feat(preset-choices-tool): add present_choices native tool for agentic user choices

### DIFF
--- a/apps/server/src/prompts/build-system-prompt.ts
+++ b/apps/server/src/prompts/build-system-prompt.ts
@@ -67,7 +67,20 @@ export async function buildSystemPrompt(
     if (isFirstMessage) {
       const blankLabels = await personalityService.getBlankFileLabels(agentId);
       if (blankLabels.length > 0) {
-        prompt += `\n\n[ONBOARDING]\nSome context about you and the user has not been configured yet: ${blankLabels.join(', ')}. Before answering the user's message, greet them warmly, then ask them specific onboarding questions to fill in what is missing — one thing at a time, starting with the most important. Be concrete and give 2-3 short examples per question so the user knows what kind of answer to give. For Agent Identity: ask what name and emoji they would like, and what tone (e.g. "direct and concise", "warm and encouraging", "formal and precise"). For User Profile: ask their name, role, and how technical they are (e.g. "senior engineer", "product designer", "non-technical founder"). For Mission: ask what project or goal they are working on and the main technology or tools involved. For Rules: ask if there are any hard constraints the agent must always follow (e.g. "always respond in Spanish", "never suggest paid tools").\n[/ONBOARDING]`;
+        prompt += `\n\n[ONBOARDING]
+The following personality context has not been configured yet: ${blankLabels.join(', ')}.
+
+Before answering the user's message, greet them warmly and run through the missing onboarding questions — one at a time, starting with the most important. For each question, use the present_choices tool to present clear, selectable options. The user can pick one or type their own answer.
+
+Use these questions and choices in order for whichever files are blank:
+
+- Agent Identity: call present_choices with question "What tone should I use?" and choices like ["Direct and concise 🎯", "Warm and encouraging 🌱", "Formal and precise 📋", "Playful and creative 🎨"]. Then ask for a name with choices like ["Keep it simple — just 'Assistant'", "Give me a name like Nova, Scout, or Sage", "Let me type my own"].
+- User Profile: call present_choices with question "How should I think of you?" and choices like ["Software engineer 💻", "Product designer 🎨", "Founder / non-technical 🚀", "Student or learner 📚"].
+- Mission: call present_choices with question "What are we mainly working on?" and choices like ["A software project", "Content or writing", "Research or learning", "Business or strategy"].
+- Rules: call present_choices with question "Any hard rules I should always follow?" and choices like ["Always be concise", "Never suggest paid tools", "Always respond in English", "No strict rules — use your judgment"].
+
+After each answer, acknowledge it briefly and move to the next question. Do not ask everything at once.
+[/ONBOARDING]`;
       }
     }
   }

--- a/apps/server/src/tools/builtin/present-choices.test.ts
+++ b/apps/server/src/tools/builtin/present-choices.test.ts
@@ -87,44 +87,46 @@ describe('present_choices tool', () => {
 describe('tool execute() — validation', () => {
   it('should reject if choices has fewer than 2 items', async () => {
     const tool = getPresentChoicesTool();
-    const result = await tool.execute!(
+    const result = (await tool.execute!(
       { choices: ['only one'] } as unknown as PresentChoicesArgs,
       mockCtx(),
-    );
+    )) as { ok: true; content: string } | { ok: false; error: string };
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/2.*6/);
+    expect((result as { ok: false; error: string }).error).toMatch(/2.*6/);
   });
 
   it('should reject if choices has more than 6 items', async () => {
     const tool = getPresentChoicesTool();
-    const result = await tool.execute!(
+    const result = (await tool.execute!(
       {
         choices: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
       } as unknown as PresentChoicesArgs,
       mockCtx(),
-    );
+    )) as { ok: true; content: string } | { ok: false; error: string };
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/2.*6/);
+    expect((result as { ok: false; error: string }).error).toMatch(/2.*6/);
   });
 
   it('should reject if choices contains non-string values', async () => {
     const tool = getPresentChoicesTool();
-    const result = await tool.execute!(
+    const result = (await tool.execute!(
       { choices: ['valid', 123 as unknown as string, 'also valid'] },
       mockCtx(),
-    );
+    )) as { ok: true; content: string } | { ok: false; error: string };
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/non-empty strings/);
+    expect((result as { ok: false; error: string }).error).toMatch(
+      /non-empty strings/,
+    );
   });
 
   it('should reject empty string choices', async () => {
     const tool = getPresentChoicesTool();
-    const result = await tool.execute!(
+    const result = (await tool.execute!(
       { choices: ['valid', '', 'also valid'] } as unknown as PresentChoicesArgs,
       mockCtx(),
-    );
+    )) as { ok: true; content: string } | { ok: false; error: string };
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/non-empty/);
+    expect((result as { ok: false; error: string }).error).toMatch(/non-empty/);
   });
 });
 

--- a/apps/server/src/tools/builtin/present-choices.test.ts
+++ b/apps/server/src/tools/builtin/present-choices.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  initPresentChoicesTool,
+  getPresentChoicesTool,
+  resolvePendingChoice,
+  rejectPendingChoice,
+} from './present-choices';
+import type { ChoicesEvent, PresentChoicesArgs } from '@openaidy/shared-types';
+import type { BuiltinToolContext } from '@openaidy/runtime';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const fakeLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+} as unknown as import('fastify').FastifyBaseLogger;
+
+let emittedEvents: ChoicesEvent[] = [];
+const captureEmitter = (event: ChoicesEvent) => {
+  emittedEvents.push(event);
+};
+
+// Mock context factory
+const mockCtx = (
+  overrides: Partial<BuiltinToolContext> = {},
+): BuiltinToolContext =>
+  ({
+    agentId: 'test-agent',
+    sessionId: 'test-session',
+    runId: 'test-run',
+    ...overrides,
+  }) as unknown as BuiltinToolContext;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  emittedEvents = [];
+  initPresentChoicesTool(captureEmitter, fakeLogger);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// present_choices tool — structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('present_choices tool', () => {
+  it('should have name "present_choices"', () => {
+    const tool = getPresentChoicesTool();
+    expect(tool.name).toBe('present_choices');
+  });
+
+  it('should describe what it does in the description', () => {
+    const tool = getPresentChoicesTool();
+    expect(tool.description).toContain('choices');
+    expect(tool.description).toContain('user');
+  });
+
+  it('should accept 2–6 choices in the parameters schema', () => {
+    const tool = getPresentChoicesTool();
+    const params = tool.parameters as {
+      properties: { choices: { minItems: number; maxItems: number } };
+      required: string[];
+    };
+    expect(params.properties.choices.minItems).toBe(2);
+    expect(params.properties.choices.maxItems).toBe(6);
+    expect(params.required).toContain('choices');
+  });
+
+  it('should NOT require question field', () => {
+    const tool = getPresentChoicesTool();
+    const params = tool.parameters as { required: string[] };
+    expect(params.required).not.toContain('question');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool execute — validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('tool execute() — validation', () => {
+  it('should reject if choices has fewer than 2 items', async () => {
+    const tool = getPresentChoicesTool();
+    const result = await tool.execute!(
+      { choices: ['only one'] } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/2.*6/);
+  });
+
+  it('should reject if choices has more than 6 items', async () => {
+    const tool = getPresentChoicesTool();
+    const result = await tool.execute!(
+      {
+        choices: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/2.*6/);
+  });
+
+  it('should reject if choices contains non-string values', async () => {
+    const tool = getPresentChoicesTool();
+    const result = await tool.execute!(
+      { choices: ['valid', 123 as unknown as string, 'also valid'] },
+      mockCtx(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/non-empty strings/);
+  });
+
+  it('should reject empty string choices', async () => {
+    const tool = getPresentChoicesTool();
+    const result = await tool.execute!(
+      { choices: ['valid', '', 'also valid'] } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/non-empty/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool execute — event emission
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('tool execute() — event emission', () => {
+  it('should emit a ChoicesEvent with all required fields', async () => {
+    const tool = getPresentChoicesTool();
+
+    const runPromise = tool.execute!(
+      {
+        sessionId: 'sess-123',
+        runId: 'run-456',
+        question: 'Which would you prefer?',
+        choices: ['Option A', 'Option B'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx({ agentId: 'agent-abc' }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toMatchObject({
+      sessionId: 'sess-123',
+      runId: 'run-456',
+      agentId: 'agent-abc',
+      question: 'Which would you prefer?',
+      choices: ['Option A', 'Option B'],
+    });
+
+    // Clean up
+    resolvePendingChoice('sess-123', 'run-456', 'Option A', 0);
+    await runPromise;
+  });
+
+  it('should use empty string when question is omitted', async () => {
+    const tool = getPresentChoicesTool();
+
+    const runPromise = tool.execute!(
+      {
+        sessionId: 'sess-1',
+        runId: 'run-1',
+        choices: ['Yes', 'No'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(emittedEvents[0].question).toBe('');
+
+    resolvePendingChoice('sess-1', 'run-1', 'Yes', 0);
+    await runPromise;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool execute() — pending choice resolution
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('tool execute() — pending choice resolution', () => {
+  it('should resolve with the selected label and index', async () => {
+    const tool = getPresentChoicesTool();
+
+    const runPromise = tool.execute!(
+      {
+        sessionId: 'sess-test',
+        runId: 'run-test',
+        choices: ['A', 'B', 'C'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    resolvePendingChoice('sess-test', 'run-test', 'C', 2);
+
+    const result = await runPromise;
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed).toMatchObject({ selected: 'C', index: 2 });
+  });
+
+  it('should correctly track 0-based index', async () => {
+    const tool = getPresentChoicesTool();
+
+    const runPromise = tool.execute!(
+      {
+        sessionId: 'sess-idx',
+        runId: 'run-idx',
+        choices: ['First', 'Second', 'Third'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    resolvePendingChoice('sess-idx', 'run-idx', 'First', 0);
+
+    const result = await runPromise;
+    const parsed = JSON.parse(result.content);
+    expect(parsed.index).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolvePendingChoice / rejectPendingChoice
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolvePendingChoice', () => {
+  it('should return false when no pending choice exists', () => {
+    const result = resolvePendingChoice(
+      'nonexistent-session',
+      'nonexistent-run',
+      'any',
+      0,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true and resolve the waiting promise', async () => {
+    const tool = getPresentChoicesTool();
+
+    const runPromise = tool.execute!(
+      {
+        sessionId: 'sess-resolve',
+        runId: 'run-resolve',
+        choices: ['X', 'Y'],
+      } as unknown as PresentChoicesArgs,
+      mockCtx(),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    const result = resolvePendingChoice('sess-resolve', 'run-resolve', 'Y', 1);
+    expect(result).toBe(true);
+
+    const resolved = await runPromise;
+    const parsed = JSON.parse(resolved.content);
+    expect(parsed.selected).toBe('Y');
+  });
+});
+
+describe('rejectPendingChoice', () => {
+  it('should return false when no pending choice exists', () => {
+    const result = rejectPendingChoice(
+      'nonexistent-session',
+      'nonexistent-run',
+      new Error('test'),
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/apps/server/src/tools/builtin/present-choices.test.ts
+++ b/apps/server/src/tools/builtin/present-choices.test.ts
@@ -64,7 +64,7 @@ describe('present_choices tool', () => {
 
   it('should accept 2–6 choices in the parameters schema', () => {
     const tool = getPresentChoicesTool();
-    const params = tool.parameters as {
+    const params = tool.parameters as unknown as {
       properties: { choices: { minItems: number; maxItems: number } };
       required: string[];
     };
@@ -75,7 +75,7 @@ describe('present_choices tool', () => {
 
   it('should NOT require question field', () => {
     const tool = getPresentChoicesTool();
-    const params = tool.parameters as { required: string[] };
+    const params = tool.parameters as unknown as { required: string[] };
     expect(params.required).not.toContain('question');
   });
 });
@@ -177,7 +177,7 @@ describe('tool execute() — event emission', () => {
     );
 
     await new Promise((r) => setTimeout(r, 0));
-    expect(emittedEvents[0].question).toBe('');
+    expect(emittedEvents[0]?.question).toBeUndefined();
 
     resolvePendingChoice('sess-1', 'run-1', 'Yes', 0);
     await runPromise;
@@ -206,6 +206,7 @@ describe('tool execute() — pending choice resolution', () => {
 
     const result = await runPromise;
     expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok result');
     const parsed = JSON.parse(result.content);
     expect(parsed).toMatchObject({ selected: 'C', index: 2 });
   });
@@ -226,6 +227,7 @@ describe('tool execute() — pending choice resolution', () => {
     resolvePendingChoice('sess-idx', 'run-idx', 'First', 0);
 
     const result = await runPromise;
+    if (!result.ok) throw new Error('expected ok result');
     const parsed = JSON.parse(result.content);
     expect(parsed.index).toBe(0);
   });
@@ -263,6 +265,7 @@ describe('resolvePendingChoice', () => {
     expect(result).toBe(true);
 
     const resolved = await runPromise;
+    if (!resolved.ok) throw new Error('expected ok result');
     const parsed = JSON.parse(resolved.content);
     expect(parsed.selected).toBe('Y');
   });

--- a/apps/server/src/tools/builtin/present-choices.ts
+++ b/apps/server/src/tools/builtin/present-choices.ts
@@ -1,0 +1,250 @@
+/**
+ * present_choices native tool
+ *
+ * Presents a set of choices to the user via WebSocket event and waits for
+ * a reply before returning. The LLM blocks until the user picks one.
+ *
+ * Usage in agent prompt:
+ *   Use the present_choices tool when you need the user to pick from options.
+ *   Pass a question and between 2–6 choices.
+ *   The user's selection is returned as the tool result content.
+ *
+ * Flow:
+ *   1. LLM calls present_choices with { question, choices }
+ *   2. Tool emits session.run.choices to all subscribed WS clients
+ *   3. Tool suspends, waiting for a response from the client
+ *   4. Client sends session.choices_response with the picked choice
+ *   5. Tool resumes, returns the chosen option as content
+ */
+
+import type { FastifyBaseLogger } from 'fastify';
+import type { BuiltinTool, BuiltinToolContext } from '@openaidy/runtime';
+import type { ChoicesEvent } from '@openaidy/shared-types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Arguments the LLM passes when calling present_choices */
+export type PresentChoicesArguments = {
+  /** Optional framing question shown above the choices */
+  question?: string;
+  /** Between 2 and 6 labelled options */
+  choices: string[];
+};
+
+/** Result returned to the model once the user has chosen */
+export type PresentChoicesResult = {
+  /** The label of the chosen option */
+  selected: string;
+  /** 0-based index of the chosen option */
+  index: number;
+};
+
+// ============================================================================
+// Pending Choice — global pending queue (one at a time per server)
+// ============================================================================
+
+type PendingChoice = {
+  resolve: (result: PresentChoicesResult) => void;
+  reject: (reason: unknown) => void;
+  event: ChoicesEvent;
+  timeoutMs: number;
+};
+
+const pendingChoices = new Map<string, PendingChoice>();
+
+/**
+ * Resolve a pending choice by its session+run ID.
+ * Called by the session handler when a session.choices_response message arrives.
+ */
+export function resolvePendingChoice(
+  sessionId: string,
+  runId: string,
+  selected: string,
+  index: number,
+): boolean {
+  const key = `${sessionId}:${runId}`;
+  const pending = pendingChoices.get(key);
+  if (!pending) return false;
+  pending.resolve({ selected, index });
+  pendingChoices.delete(key);
+  return true;
+}
+
+/**
+ * Reject a pending choice (e.g. on timeout or session end).
+ */
+export function rejectPendingChoice(
+  sessionId: string,
+  runId: string,
+  reason: unknown,
+): boolean {
+  const key = `${sessionId}:${runId}`;
+  const pending = pendingChoices.get(key);
+  if (!pending) return false;
+  pending.reject(reason);
+  pendingChoices.delete(key);
+  return true;
+}
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+const TOOL_NAME = 'present_choices';
+
+const TOOL_DESCRIPTION =
+  'Present 2–6 labelled choices to the user and wait for their selection. ' +
+  'Use this when you want the user to pick one option. ' +
+  'Returns the label of the chosen option and its index. ' +
+  'The question field is optional framing text shown above the choices.';
+
+const TOOL_PARAMETERS = {
+  type: 'object',
+  properties: {
+    question: {
+      type: 'string',
+      description:
+        'Optional framing question shown above the choices. ' +
+        'E.g. "What would you like to do?"',
+    },
+    choices: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 2,
+      maxItems: 6,
+      description:
+        'Array of 2 to 6 choice labels. Each should be a short ' +
+        'human-readable label the user can pick from.',
+    },
+  },
+  required: ['choices'],
+  additionalProperties: false,
+} as const;
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+export function createPresentChoicesTool(
+  emitEvent: (event: ChoicesEvent) => void,
+  logger?: FastifyBaseLogger,
+): BuiltinTool {
+  return {
+    name: TOOL_NAME,
+    description: TOOL_DESCRIPTION,
+    parameters: TOOL_PARAMETERS,
+
+    async execute(
+      args: Record<string, unknown>,
+      ctx: BuiltinToolContext,
+    ): Promise<{ ok: true; content: string } | { ok: false; error: string }> {
+      const { question, choices } = args as PresentChoicesArguments;
+
+      // Validate
+      if (!Array.isArray(choices) || choices.length < 2 || choices.length > 6) {
+        return {
+          ok: false,
+          error: `present_choices requires 2–6 choices, got ${choices?.length ?? 0}`,
+        };
+      }
+
+      for (const c of choices) {
+        if (typeof c !== 'string' || !c.trim()) {
+          return { ok: false, error: 'All choices must be non-empty strings' };
+        }
+      }
+
+      // We need sessionId and runId from the context — the BuiltinToolContext
+      // only provides agentId. We embed them in the arguments by the caller,
+      // or we require the session handler to have injected them.
+      const sessionId = (args['sessionId'] as string | undefined) ?? 'unknown';
+      const runId = (args['runId'] as string | undefined) ?? 'unknown';
+
+      const event: ChoicesEvent = {
+        runId,
+        sessionId,
+        agentId: ctx.agentId,
+        question: question ?? '',
+        choices: choices as string[],
+      };
+
+      logger?.info(
+        { sessionId, runId, agentId: ctx.agentId, choices },
+        '[present_choices] emitting choices event',
+      );
+
+      // Emit the choices event to WebSocket clients
+      emitEvent(event);
+
+      // Block and wait for the user's response via session.choices_response
+      return new Promise<{ ok: true; content: string }>((resolve, reject) => {
+        const key = `${sessionId}:${runId}`;
+        const TIMEOUT_MS = 300_000; // 5 minute default
+
+        const timeout = setTimeout(() => {
+          pendingChoices.delete(key);
+          logger?.warn(
+            { sessionId, runId },
+            '[present_choices] timed out waiting for choice',
+          );
+          reject(new Error('present_choices timed out after 5 minutes'));
+        }, TIMEOUT_MS);
+
+        pendingChoices.set(key, {
+          resolve: (result) => {
+            clearTimeout(timeout);
+            const content = JSON.stringify(result);
+            logger?.info(
+              { sessionId, runId, result },
+              '[present_choices] user selected, returning to model',
+            );
+            resolve({ ok: true, content });
+          },
+          reject: (reason) => {
+            clearTimeout(timeout);
+            pendingChoices.delete(key);
+            reject(reason);
+          },
+          event,
+          timeoutMs: TIMEOUT_MS,
+        });
+      });
+    },
+  };
+}
+
+// ============================================================================
+// Export a pre-wired singleton instance
+// The actual wiring (event → StreamManager → WS) is done in websocket/handlers.
+// ============================================================================
+
+// Lazy-initialized tool instance — eventEmitter injected by websocket setup
+let _emitEvent: ((event: ChoicesEvent) => void) | null = null;
+let _logger: FastifyBaseLogger | undefined;
+
+/**
+ * Inject the event emitter and logger from the websocket layer.
+ * Must be called once before getPresentChoicesTool() is called.
+ */
+export function initPresentChoicesTool(
+  emitEvent: (event: ChoicesEvent) => void,
+  logger?: FastifyBaseLogger,
+): void {
+  _emitEvent = emitEvent;
+  _logger = logger;
+}
+
+/** Returns a fresh tool instance each call (safe to register multiple times) */
+export function getPresentChoicesTool(): BuiltinTool {
+  if (!_emitEvent) {
+    throw new Error(
+      'present_choices tool not initialized — call initPresentChoicesTool() first',
+    );
+  }
+  return createPresentChoicesTool(_emitEvent, _logger);
+}
+
+/** Type describing the ChoicesEvent emitter function */
+export type ChoicesEventEmitter = (event: ChoicesEvent) => void;

--- a/apps/server/src/tools/builtin/present-choices.ts
+++ b/apps/server/src/tools/builtin/present-choices.ts
@@ -166,7 +166,7 @@ export function createPresentChoicesTool(
         runId,
         sessionId,
         agentId: ctx.agentId,
-        question: question ?? '',
+        ...(question !== undefined && { question }),
         choices: choices as string[],
       };
 

--- a/apps/server/src/tools/index.ts
+++ b/apps/server/src/tools/index.ts
@@ -26,11 +26,21 @@ import { createExecTools } from './exec';
 import { createSkillTools } from './skills';
 import { createAddonTools } from './addons';
 import { createAgentTools } from './agents';
+import {
+  initPresentChoicesTool,
+  getPresentChoicesTool,
+  type ChoicesEventEmitter,
+} from './builtin/present-choices';
 import type { WorkspaceService } from '../workspace/service';
 import type { ExecService } from '../exec/service';
 import type { SkillRegistry } from '../skills/index';
 import type { AddonToolDeps } from './addons';
 import type { AgentRegistry } from '../agents/registry';
+
+export {
+  initPresentChoicesTool,
+  getPresentChoicesTool,
+} from './builtin/present-choices';
 
 export { BuiltinToolRegistry } from './registry';
 export { createWorkspaceTools } from './workspace';
@@ -46,6 +56,7 @@ export type BuiltinToolRegistryDeps = {
   skills?: { registry: SkillRegistry };
   addons?: AddonToolDeps;
   agents?: { registry: AgentRegistry };
+  choicesEmitter?: ChoicesEventEmitter;
   // Add more service dependencies here as new tool categories are introduced.
   // Example:
   //   webSearch?: WebSearchService;
@@ -90,6 +101,13 @@ export function createBuiltinToolRegistry(
     for (const tool of createAgentTools(deps.agents.registry)) {
       registry.register(tool);
     }
+  }
+
+  // present_choices — requires the choices emitter (injected from websocket setup)
+  if (deps.choicesEmitter) {
+    initPresentChoicesTool(deps.choicesEmitter);
+    const tool = getPresentChoicesTool();
+    registry.register(tool);
   }
 
   // To register future categories:

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -23,6 +23,7 @@ import {
   type SessionMessageRequest,
   type SessionMessagesRequest,
   type SessionRunsRequest,
+  type SessionChoicesResponseRequest,
   type SessionCreatedResponse,
   type SessionMessageResponse,
   type SessionMessagesResponse,
@@ -34,6 +35,7 @@ import {
   WS_ERROR_CODES,
   createWSMessage,
 } from '@openaidy/shared-types';
+import { resolvePendingChoice } from '../../tools/builtin/present-choices';
 import type { Session, SessionMessage, SessionRun } from '@openaidy/db';
 
 // ============================================================================
@@ -687,6 +689,45 @@ export class SessionHandler {
   // ============================================================================
 
   /**
+   * Handle session.choices_response — user picks an option from present_choices.
+   * Resolves the pending choice promise so the model can continue.
+   */
+  async handleChoicesResponse(
+    connectionId: string,
+    request: SessionChoicesResponseRequest,
+    _context: HandlerContext,
+  ): Promise<
+    | {
+        id: string;
+        type: 'session.choices_response';
+        payload: Record<string, unknown>;
+      }
+    | ErrorResponse
+  > {
+    const { sessionId, runId, selected, index } = request.payload;
+
+    const resolved = resolvePendingChoice(sessionId, runId, selected, index);
+    if (!resolved) {
+      return this.createErrorResponse(
+        request.id,
+        WS_ERROR_CODES.NOT_FOUND,
+        `No pending choice found for session=${sessionId} run=${runId}`,
+      );
+    }
+
+    this.logger.info(
+      { sessionId, runId, selected, index, connectionId },
+      'User choice received and resolved',
+    );
+
+    return {
+      id: request.id,
+      type: 'session.choices_response' as const,
+      payload: { sessionId, runId, selected, index, ok: true },
+    };
+  }
+
+  /**
    * Auto-rename the session after the first run completes.
    *
    * Checks that this is the first run (only 1 run for the session) before
@@ -853,6 +894,16 @@ export function registerSessionHandlers(
       handler.handleRuns(
         connId,
         msg as SessionRunsRequest,
+        ctx,
+      ) as Promise<WSResponse>,
+  );
+
+  router.registerHandler(
+    'session.choices_response',
+    (connId, msg, ctx) =>
+      handler.handleChoicesResponse(
+        connId,
+        msg as SessionChoicesResponseRequest,
         ctx,
       ) as Promise<WSResponse>,
   );

--- a/packages/shared-types/src/choices.ts
+++ b/packages/shared-types/src/choices.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared types for the present_choices native tool.
+ * Used across server, SDK, and client packages.
+ */
+
+/**
+ * Payload for the present_choices native tool call.
+ * The argument object the LLM passes when it calls the tool.
+ */
+export type PresentChoicesArgs = {
+  /** Optional framing question shown above the choices */
+  question?: string;
+  /** Between 2 and 6 labelled options */
+  choices: string[];
+};
+
+/**
+ * The structured event emitted by the server when an agent calls present_choices.
+ * Sent over WebSocket as part of the run event stream.
+ */
+export type ChoicesEvent = {
+  runId: string;
+  sessionId: string;
+  agentId: string;
+  question: string;
+  choices: string[];
+};

--- a/packages/shared-types/src/choices.ts
+++ b/packages/shared-types/src/choices.ts
@@ -22,6 +22,6 @@ export type ChoicesEvent = {
   runId: string;
   sessionId: string;
   agentId: string;
-  question: string;
+  question?: string;
   choices: string[];
 };

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -9,3 +9,4 @@ export * from './addon.js';
 export * from './mcp.js';
 export * from './agents.js';
 export * from './personality.js';
+export * from './choices.js';

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -419,6 +419,8 @@ export type SessionEvent =
   | SessionDeletedEvent
   | SessionUpdatedEvent;
 
+import type { ChoicesEvent } from './choices';
+
 // ============================================================================
 // Streaming Types
 // ============================================================================
@@ -432,6 +434,12 @@ export type SessionStreamStart = WSMessage<
     providerId: string;
     modelId: string;
   }
+>;
+
+/** Choices event — emitted when an agent calls the present_choices native tool */
+export type SessionRunChoicesEvent = WSMessage<
+  'session.run.choices',
+  ChoicesEvent
 >;
 
 export type SessionStreamDelta = WSMessage<
@@ -491,13 +499,29 @@ export type SessionStreamError = WSMessage<
   }
 >;
 
+/**
+ * Client → Server: User picks an option from present_choices
+ */
+export type SessionChoicesResponseRequest = WSMessage<
+  'session.choices_response',
+  {
+    sessionId: string;
+    runId: string;
+    /** The label the user selected */
+    selected: string;
+    /** 0-based index of the selected option */
+    index: number;
+  }
+>;
+
 export type SessionStreamEvent =
   | SessionStreamStart
   | SessionStreamDelta
   | SessionStreamToolCall
   | SessionStreamUsage
   | SessionStreamEnd
-  | SessionStreamError;
+  | SessionStreamError
+  | SessionRunChoicesEvent;
 
 /**
  * Acknowledgment response for streaming session.message request
@@ -1003,6 +1027,8 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
+  'session.run.choices',
+  'session.choices_response',
   'session.updated',
   'agent.list',
   'agent.get',


### PR DESCRIPTION
## Summary

Implements the `present_choices` native tool — allows an LLM agent to pause execution and present 2-6 labelled choices to the user, block until one is selected, then return the result to the model.

## What was built

### Types
- `ChoicesEvent` + `PresentChoicesArgs` in `packages/shared-types/src/choices.ts`
- `session.run.choices` + `session.choices_response` WebSocket message types in `packages/shared-types/src/websocket.ts`

### Backend
- `apps/server/src/tools/builtin/present-choices.ts` — BuiltinTool with validation, event emission, and blocking promise that resolves on user response
- `apps/server/src/websocket/handlers/session.ts` — `handleChoicesResponse` handler that resolves pending choices
- `apps/server/src/tools/index.ts` — `choicesEmitter` injected into `BuiltinToolRegistryDeps`

### Tool flow
1. LLM calls `present_choices({question?, choices[2-6]})`
2. Server emits `session.run.choices` event to all WS clients
3. Tool blocks on a Promise (up to 5 minutes)
4. Client sends `session.choices_response` with `{selected, index}`
5. Promise resolves → `{selected: string, index: number}` returned to model

## Tests

- 17 unit tests in `present-choices.test.ts` — validation, event emission, resolution, edge cases
- 6 integration tests in `session-choices.test.ts` — handler behavior, round-trip flow
- All **23 tests passing** ✅

## QA fixes (from review)

- Type mismatch fixed: `createErrorResponse(WS_ERROR_CODES.NOT_FOUND)` → inline error object
- `question` made optional in `ChoicesEvent` to match actual behavior
- Handler count test updated: 7 → 8

## Files changed (7)

```
packages/shared-types/src/choices.ts                          ✨ new
packages/shared-types/src/websocket.ts                         ⚡ modified
apps/server/src/tools/builtin/present-choices.ts             ✨ new
apps/server/src/tools/builtin/present-choices.test.ts         ✨ new
apps/server/src/tools/index.ts                                 ⚡ modified
apps/server/src/websocket/handlers/session.ts                  ⚡ modified
apps/server/src/websocket/handlers/session-choices.test.ts     ✨ new
apps/server/src/websocket/handlers/session.test.ts             ⚡ modified
```