### PR TITLE
feat: add DeleteAgentModal and scope-based auth per agent route (fixes #304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,6 @@ See the [`docs/`](./docs/) directory for detailed documentation:
 ## License
 
 MIT
+
+---
+*Test PR from Jetson Agent (bot account)*

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -22,219 +22,268 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
 ) => {
   const { agentRegistry, personalityService, authMiddleware } = options;
 
-  app.addHook(
-    'preHandler',
-    requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
-  );
-
   /**
    * GET /agents
    * List all enabled agents (summaries)
    */
-  app.get('/agents', async () => {
-    const agents = agentRegistry.listAgents();
-    return { items: agents };
-  });
+  app.get(
+    '/agents',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
+    },
+    async () => {
+      const agents = agentRegistry.listAgents();
+      return { items: agents };
+    },
+  );
 
   /**
    * GET /agents/:agentId
    * Get a specific agent by ID
    */
-  app.get('/agents/:agentId', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const agent = agentRegistry.getAgent(agentId);
+  app.get(
+    '/agents/:agentId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const agent = agentRegistry.getAgent(agentId);
 
-    if (!agent) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      if (!agent) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
 
-    return agent;
-  });
+      return agent;
+    },
+  );
 
   /**
    * POST /agents
    * Create a new agent.
    * Body: Agent object (id, name, enabled, systemPrompt, model required)
    */
-  app.post('/agents', async (request, reply) => {
-    const body = request.body as Record<string, unknown>;
+  app.post(
+    '/agents',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const body = request.body as Record<string, unknown>;
 
-    try {
-      const agent = agentRegistry.createAgent(body as CreateAgentInput);
-      // Scaffold personality files for the new agent (fire and forget — non-fatal)
-      personalityService.scaffold(agent.id).catch(() => {});
-      reply.code(201);
-      return agent;
-    } catch (err) {
-      reply.code(400);
-      return {
-        error: err instanceof Error ? err.message : 'Failed to create agent',
-      };
-    }
-  });
+      try {
+        const agent = agentRegistry.createAgent(body as CreateAgentInput);
+        // Scaffold personality files for the new agent (fire and forget — non-fatal)
+        personalityService.scaffold(agent.id).catch(() => {});
+        reply.code(201);
+        return agent;
+      } catch (err) {
+        reply.code(400);
+        return {
+          error: err instanceof Error ? err.message : 'Failed to create agent',
+        };
+      }
+    },
+  );
 
   /**
    * DELETE /agents/:agentId
    * Delete an agent by ID. Also removes the agent's workspace directory.
    */
-  app.delete('/agents/:agentId', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const deleted = agentRegistry.deleteAgent(agentId);
-    if (!deleted) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    personalityService?.deleteWorkspace(agentId).catch(() => {});
-    return { deleted };
-  });
+  app.delete(
+    '/agents/:agentId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.delete' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const deleted = agentRegistry.deleteAgent(agentId);
+      if (!deleted) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      personalityService?.deleteWorkspace(agentId).catch(() => {});
+      return { deleted };
+    },
+  );
 
   /**
    * GET /agents/:agentId/personality
    * List all personality file metadata for an agent.
    */
-  app.get('/agents/:agentId/personality', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    return { files: PERSONALITY_FILES };
-  });
+  app.get(
+    '/agents/:agentId/personality',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      return { files: PERSONALITY_FILES };
+    },
+  );
 
   /**
    * GET /agents/:agentId/personality/:fileId
    * Read a specific personality file (AGENT, USER, MISSION, RULES).
    */
-  app.get('/agents/:agentId/personality/:fileId', async (request, reply) => {
-    const { agentId, fileId } = request.params as {
-      agentId: string;
-      fileId: string;
-    };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
-    if (!valid) {
-      reply.code(400);
-      return { error: `Unknown personality file: ${fileId}` };
-    }
-    const file = await personalityService.readFile(
-      agentId,
-      fileId as PersonalityFileId,
-    );
-    return file;
-  });
+  app.get(
+    '/agents/:agentId/personality/:fileId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId, fileId } = request.params as {
+        agentId: string;
+        fileId: string;
+      };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
+      if (!valid) {
+        reply.code(400);
+        return { error: `Unknown personality file: ${fileId}` };
+      }
+      const file = await personalityService.readFile(
+        agentId,
+        fileId as PersonalityFileId,
+      );
+      return file;
+    },
+  );
 
   /**
    * PUT /agents/:agentId/personality/:fileId
    * Write (create or overwrite) a personality file.
    * Body: { content: string }
    */
-  app.put('/agents/:agentId/personality/:fileId', async (request, reply) => {
-    const { agentId, fileId } = request.params as {
-      agentId: string;
-      fileId: string;
-    };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
-    if (!valid) {
-      reply.code(400);
-      return { error: `Unknown personality file: ${fileId}` };
-    }
-    const body = request.body as { content?: unknown };
-    if (typeof body?.content !== 'string') {
-      reply.code(400);
-      return { error: 'Invalid request: content must be a string' };
-    }
-    await personalityService.writeFile(
-      agentId,
-      fileId as PersonalityFileId,
-      body.content,
-    );
-    return { ok: true };
-  });
+  app.put(
+    '/agents/:agentId/personality/:fileId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId, fileId } = request.params as {
+        agentId: string;
+        fileId: string;
+      };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
+      if (!valid) {
+        reply.code(400);
+        return { error: `Unknown personality file: ${fileId}` };
+      }
+      const body = request.body as { content?: unknown };
+      if (typeof body?.content !== 'string') {
+        reply.code(400);
+        return { error: 'Invalid request: content must be a string' };
+      }
+      await personalityService.writeFile(
+        agentId,
+        fileId as PersonalityFileId,
+        body.content,
+      );
+      return { ok: true };
+    },
+  );
 
   /**
    * PATCH /agents/:agentId/tools
    * Update the builtin tools list for an agent.
    * Body: { tools: string[] }
    */
-  app.patch('/agents/:agentId/tools', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const body = request.body as { tools?: unknown };
+  app.patch(
+    '/agents/:agentId/tools',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const body = request.body as { tools?: unknown };
 
-    if (
-      !Array.isArray(body?.tools) ||
-      body.tools.some((t) => typeof t !== 'string')
-    ) {
-      reply.code(400);
-      return { error: 'Invalid request: tools must be an array of strings' };
-    }
+      if (
+        !Array.isArray(body?.tools) ||
+        body.tools.some((t) => typeof t !== 'string')
+      ) {
+        reply.code(400);
+        return { error: 'Invalid request: tools must be an array of strings' };
+      }
 
-    const result = agentRegistry.updateAgentTools(
-      agentId,
-      body.tools as string[],
-    );
-    if (!result) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      const result = agentRegistry.updateAgentTools(
+        agentId,
+        body.tools as string[],
+      );
+      if (!result) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
 
-    return result;
-  });
+      return result;
+    },
+  );
 
   /**
    * PATCH /agents/:agentId/mcp-servers
    * Update the MCP server references for an agent.
    * Body: { mcpServers: Array<{ id: string; tools?: string[] }> }
    */
-  app.patch('/agents/:agentId/mcp-servers', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const body = request.body as { mcpServers?: unknown };
+  app.patch(
+    '/agents/:agentId/mcp-servers',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const body = request.body as { mcpServers?: unknown };
 
-    if (!Array.isArray(body?.mcpServers)) {
-      reply.code(400);
-      return {
-        error: 'Invalid request: mcpServers must be an array',
-      };
-    }
-
-    const isValidRef = (ref: unknown): ref is McpServerRef => {
-      if (!ref || typeof ref !== 'object') return false;
-      const r = ref as Record<string, unknown>;
-      if (typeof r['id'] !== 'string' || r['id'].length === 0) return false;
-      if (r['tools'] !== undefined) {
-        if (
-          !Array.isArray(r['tools']) ||
-          r['tools'].some((t) => typeof t !== 'string')
-        )
-          return false;
+      if (!Array.isArray(body?.mcpServers)) {
+        reply.code(400);
+        return {
+          error: 'Invalid request: mcpServers must be an array',
+        };
       }
-      return true;
-    };
 
-    if (!body.mcpServers.every(isValidRef)) {
-      reply.code(400);
-      return {
-        error:
-          'Invalid request: each mcpServer must have a string id and an optional tools string array',
+      const isValidRef = (ref: unknown): ref is McpServerRef => {
+        if (!ref || typeof ref !== 'object') return false;
+        const r = ref as Record<string, unknown>;
+        if (typeof r['id'] !== 'string' || r['id'].length === 0) return false;
+        if (r['tools'] !== undefined) {
+          if (
+            !Array.isArray(r['tools']) ||
+            r['tools'].some((t) => typeof t !== 'string')
+          )
+            return false;
+        }
+        return true;
       };
-    }
 
-    const result = agentRegistry.updateAgentMcpServers(
-      agentId,
-      body.mcpServers as McpServerRef[],
-    );
-    if (!result) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      if (!body.mcpServers.every(isValidRef)) {
+        reply.code(400);
+        return {
+          error:
+            'Invalid request: each mcpServer must have a string id and an optional tools string array',
+        };
+      }
 
-    return result;
-  });
+      const result = agentRegistry.updateAgentMcpServers(
+        agentId,
+        body.mcpServers as McpServerRef[],
+      );
+      if (!result) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+
+      return result;
+    },
+  );
 };

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -35,7 +35,6 @@ import {
   getConfig,
   getPersonalityFile,
   updatePersonalityFile,
-  deleteAgent,
   type Agent,
   type BuiltinToolInfo,
   type SkillInfo,
@@ -47,6 +46,7 @@ import {
   type PersonalityFile,
 } from '../../lib/api';
 import { CreateAgentModal } from './CreateAgentModal';
+import { DeleteAgentModal } from './DeleteAgentModal';
 import {
   FileExplorer,
   WorkspaceEditor,
@@ -85,7 +85,7 @@ export function AgentsPage(props: AgentsPageProps) {
   const [mcpUpdating, setMcpUpdating] = createSignal<Set<string>>(new Set());
   const [providers, setProviders] = createSignal<ProviderConfig[]>([]);
   const [showCreateModal, setShowCreateModal] = createSignal(false);
-  const [isDeleting, setIsDeleting] = createSignal(false);
+  const [showDeleteModal, setShowDeleteModal] = createSignal(false);
 
   const selectedAgent = () => agents().find((a) => a.id === selectedAgentId());
 
@@ -331,26 +331,17 @@ export function AgentsPage(props: AgentsPageProps) {
     }
   };
 
-  const handleDeleteAgent = async () => {
-    const agent = selectedAgent();
-    if (!agent) return;
-    const confirmed = window.confirm(
-      `Delete agent "${agent.name}"?\n\nThis will permanently remove the agent and its entire workspace directory. This cannot be undone.`,
-    );
-    if (!confirmed) return;
-    setIsDeleting(true);
-    try {
-      await deleteAgent(agent.id);
-      const remaining = agents().filter((a) => a.id !== agent.id);
-      setAgents(remaining);
-      setSelectedAgentId(remaining.length > 0 ? remaining[0].id : null);
-      setSelectedWorkspaceFile(null);
-      setHasUnsavedWorkspaceChanges(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete agent');
-    } finally {
-      setIsDeleting(false);
-    }
+  const handleDeleteAgent = () => {
+    if (!selectedAgent()) return;
+    setShowDeleteModal(true);
+  };
+
+  const handleDeleteAgentConfirm = async (agentId: string) => {
+    const remaining = agents().filter((a) => a.id !== agentId);
+    setAgents(remaining);
+    setSelectedAgentId(remaining.length > 0 ? remaining[0].id : null);
+    setSelectedWorkspaceFile(null);
+    setHasUnsavedWorkspaceChanges(false);
   };
 
   createEffect(() => {
@@ -588,12 +579,11 @@ export function AgentsPage(props: AgentsPageProps) {
                     {/* Delete Agent button */}
                     <button
                       onClick={handleDeleteAgent}
-                      disabled={isDeleting()}
-                      class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                       title="Delete agent"
                     >
                       <Trash2 class="w-4 h-4" />
-                      {isDeleting() ? 'Deleting…' : 'Delete'}
+                      Delete
                     </button>
 
                     {/* Status Badge */}
@@ -1274,6 +1264,14 @@ export function AgentsPage(props: AgentsPageProps) {
         onClose={() => setShowCreateModal(false)}
         onCreated={handleAgentCreated}
       />
+      <Show when={selectedAgent()}>
+        <DeleteAgentModal
+          agent={selectedAgent()!}
+          isOpen={showDeleteModal()}
+          onClose={() => setShowDeleteModal(false)}
+          onDeleted={handleDeleteAgentConfirm}
+        />
+      </Show>
     </Layout>
   );
 }

--- a/apps/web/src/components/pages/DeleteAgentModal.tsx
+++ b/apps/web/src/components/pages/DeleteAgentModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * DeleteAgentModal
+ *
+ *Confirmation dialog for deleting an agent. Uses the shared Modal component
+ *and renders a clear destructive-action prompt with the agent name.
+ */
+
+import { Show, createSignal } from 'solid-js';
+import { AlertTriangle } from 'lucide-solid';
+import { Modal } from '../ui/Modal';
+import { deleteAgent } from '../../lib/api';
+import type { Agent } from '../../lib/api';
+
+type Props = {
+  agent: Agent;
+  isOpen: boolean;
+  onClose: () => void;
+  onDeleted: (agentId: string) => void;
+};
+
+export function DeleteAgentModal(props: Props) {
+  const [isDeleting, setIsDeleting] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const handleConfirm = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteAgent(props.agent.id);
+      props.onDeleted(props.agent.id);
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete agent');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (isDeleting()) return;
+    setError(null);
+    props.onClose();
+  };
+
+  return (
+    <Modal isOpen={props.isOpen} onClose={handleClose} title="" size="sm">
+      <div class="flex flex-col items-center text-center">
+        {/* Icon + Title */}
+        <div class="mt-2 mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle class="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+
+        <h2 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+          Delete agent?
+        </h2>
+
+        <p class="mb-1 text-sm text-gray-600 dark:text-gray-400">
+          You are about to permanently delete
+        </p>
+        <p class="mb-3 text-base font-medium text-gray-900 dark:text-white">
+          &ldquo;{props.agent.name}&rdquo;
+        </p>
+        <p class="mb-6 text-sm text-gray-500 dark:text-gray-400">
+          This will remove the agent and its entire workspace directory. This
+          action cannot be undone.
+        </p>
+
+        {/* Error banner */}
+        <Show when={error()}>
+          <div class="mb-4 w-full rounded-lg bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+            {error()}
+          </div>
+        </Show>
+
+        {/* Actions */}
+        <div class="flex w-full gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isDeleting()}
+            class="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 dark:border-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isDeleting()}
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+          >
+            <Show
+              when={isDeleting()}
+              fallback={
+                <>
+                  <svg
+                    class="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  Delete Agent
+                </>
+              }
+            >
+              <svg
+                class="h-4 w-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8v8H4z"
+                />
+              </svg>
+              Deleting…
+            </Show>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

Issue #304: Allow users to delete agents from the UI

Two problems were fixed:

1. **Auth scope bug**: The DELETE endpoint had a global preHandler requiring  scope instead of . Tokens with  but not  were rejected before reaching the delete handler.

2. **Native confirm() replacement**: The delete button used  which is a bare browser dialog. A proper  component now handles the confirmation with a polished UI, error handling, and loading state.

## Changes

### Backend — 
Per-route scope options replace the global hook:

| Route | Scope |
|-------|-------|
|  |  |
|  + personality routes |  |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |

### Frontend —  (new)
- Confirmation dialog with agent name, destructive-action icon, and warning text
- Calls  API, handles errors inline
- Loading state with spinner on the confirm button
- Follows existing modal pattern from 

### Frontend — 
- Imports and renders  instead of using 
-  opens the modal;  cleans up UI state after success
-  import removed (moved to modal)