### PR TITLE
feat(cli): add sessions command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,6 @@ See the [`docs/`](./docs/) directory for detailed documentation:
 ## License
 
 MIT
+
+---
+*Test PR from Jetson Agent (bot account)*

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -22,219 +22,268 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
 ) => {
   const { agentRegistry, personalityService, authMiddleware } = options;
 
-  app.addHook(
-    'preHandler',
-    requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
-  );
-
   /**
    * GET /agents
    * List all enabled agents (summaries)
    */
-  app.get('/agents', async () => {
-    const agents = agentRegistry.listAgents();
-    return { items: agents };
-  });
+  app.get(
+    '/agents',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
+    },
+    async () => {
+      const agents = agentRegistry.listAgents();
+      return { items: agents };
+    },
+  );
 
   /**
    * GET /agents/:agentId
    * Get a specific agent by ID
    */
-  app.get('/agents/:agentId', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const agent = agentRegistry.getAgent(agentId);
+  app.get(
+    '/agents/:agentId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const agent = agentRegistry.getAgent(agentId);
 
-    if (!agent) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      if (!agent) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
 
-    return agent;
-  });
+      return agent;
+    },
+  );
 
   /**
    * POST /agents
    * Create a new agent.
    * Body: Agent object (id, name, enabled, systemPrompt, model required)
    */
-  app.post('/agents', async (request, reply) => {
-    const body = request.body as Record<string, unknown>;
+  app.post(
+    '/agents',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const body = request.body as Record<string, unknown>;
 
-    try {
-      const agent = agentRegistry.createAgent(body as CreateAgentInput);
-      // Scaffold personality files for the new agent (fire and forget — non-fatal)
-      personalityService.scaffold(agent.id).catch(() => {});
-      reply.code(201);
-      return agent;
-    } catch (err) {
-      reply.code(400);
-      return {
-        error: err instanceof Error ? err.message : 'Failed to create agent',
-      };
-    }
-  });
+      try {
+        const agent = agentRegistry.createAgent(body as CreateAgentInput);
+        // Scaffold personality files for the new agent (fire and forget — non-fatal)
+        personalityService.scaffold(agent.id).catch(() => {});
+        reply.code(201);
+        return agent;
+      } catch (err) {
+        reply.code(400);
+        return {
+          error: err instanceof Error ? err.message : 'Failed to create agent',
+        };
+      }
+    },
+  );
 
   /**
    * DELETE /agents/:agentId
    * Delete an agent by ID. Also removes the agent's workspace directory.
    */
-  app.delete('/agents/:agentId', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const deleted = agentRegistry.deleteAgent(agentId);
-    if (!deleted) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    personalityService?.deleteWorkspace(agentId).catch(() => {});
-    return { deleted };
-  });
+  app.delete(
+    '/agents/:agentId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.delete' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const deleted = agentRegistry.deleteAgent(agentId);
+      if (!deleted) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      personalityService?.deleteWorkspace(agentId).catch(() => {});
+      return { deleted };
+    },
+  );
 
   /**
    * GET /agents/:agentId/personality
    * List all personality file metadata for an agent.
    */
-  app.get('/agents/:agentId/personality', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    return { files: PERSONALITY_FILES };
-  });
+  app.get(
+    '/agents/:agentId/personality',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      return { files: PERSONALITY_FILES };
+    },
+  );
 
   /**
    * GET /agents/:agentId/personality/:fileId
    * Read a specific personality file (AGENT, USER, MISSION, RULES).
    */
-  app.get('/agents/:agentId/personality/:fileId', async (request, reply) => {
-    const { agentId, fileId } = request.params as {
-      agentId: string;
-      fileId: string;
-    };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
-    if (!valid) {
-      reply.code(400);
-      return { error: `Unknown personality file: ${fileId}` };
-    }
-    const file = await personalityService.readFile(
-      agentId,
-      fileId as PersonalityFileId,
-    );
-    return file;
-  });
+  app.get(
+    '/agents/:agentId/personality/:fileId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.read' }),
+    },
+    async (request, reply) => {
+      const { agentId, fileId } = request.params as {
+        agentId: string;
+        fileId: string;
+      };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
+      if (!valid) {
+        reply.code(400);
+        return { error: `Unknown personality file: ${fileId}` };
+      }
+      const file = await personalityService.readFile(
+        agentId,
+        fileId as PersonalityFileId,
+      );
+      return file;
+    },
+  );
 
   /**
    * PUT /agents/:agentId/personality/:fileId
    * Write (create or overwrite) a personality file.
    * Body: { content: string }
    */
-  app.put('/agents/:agentId/personality/:fileId', async (request, reply) => {
-    const { agentId, fileId } = request.params as {
-      agentId: string;
-      fileId: string;
-    };
-    if (!agentRegistry.hasAgent(agentId)) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
-    const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
-    if (!valid) {
-      reply.code(400);
-      return { error: `Unknown personality file: ${fileId}` };
-    }
-    const body = request.body as { content?: unknown };
-    if (typeof body?.content !== 'string') {
-      reply.code(400);
-      return { error: 'Invalid request: content must be a string' };
-    }
-    await personalityService.writeFile(
-      agentId,
-      fileId as PersonalityFileId,
-      body.content,
-    );
-    return { ok: true };
-  });
+  app.put(
+    '/agents/:agentId/personality/:fileId',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId, fileId } = request.params as {
+        agentId: string;
+        fileId: string;
+      };
+      if (!agentRegistry.hasAgent(agentId)) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+      const valid = PERSONALITY_FILES.find((f) => f.id === fileId);
+      if (!valid) {
+        reply.code(400);
+        return { error: `Unknown personality file: ${fileId}` };
+      }
+      const body = request.body as { content?: unknown };
+      if (typeof body?.content !== 'string') {
+        reply.code(400);
+        return { error: 'Invalid request: content must be a string' };
+      }
+      await personalityService.writeFile(
+        agentId,
+        fileId as PersonalityFileId,
+        body.content,
+      );
+      return { ok: true };
+    },
+  );
 
   /**
    * PATCH /agents/:agentId/tools
    * Update the builtin tools list for an agent.
    * Body: { tools: string[] }
    */
-  app.patch('/agents/:agentId/tools', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const body = request.body as { tools?: unknown };
+  app.patch(
+    '/agents/:agentId/tools',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const body = request.body as { tools?: unknown };
 
-    if (
-      !Array.isArray(body?.tools) ||
-      body.tools.some((t) => typeof t !== 'string')
-    ) {
-      reply.code(400);
-      return { error: 'Invalid request: tools must be an array of strings' };
-    }
+      if (
+        !Array.isArray(body?.tools) ||
+        body.tools.some((t) => typeof t !== 'string')
+      ) {
+        reply.code(400);
+        return { error: 'Invalid request: tools must be an array of strings' };
+      }
 
-    const result = agentRegistry.updateAgentTools(
-      agentId,
-      body.tools as string[],
-    );
-    if (!result) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      const result = agentRegistry.updateAgentTools(
+        agentId,
+        body.tools as string[],
+      );
+      if (!result) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
 
-    return result;
-  });
+      return result;
+    },
+  );
 
   /**
    * PATCH /agents/:agentId/mcp-servers
    * Update the MCP server references for an agent.
    * Body: { mcpServers: Array<{ id: string; tools?: string[] }> }
    */
-  app.patch('/agents/:agentId/mcp-servers', async (request, reply) => {
-    const { agentId } = request.params as { agentId: string };
-    const body = request.body as { mcpServers?: unknown };
+  app.patch(
+    '/agents/:agentId/mcp-servers',
+    {
+      preHandler: requireAuth({ authMiddleware, requiredScope: 'agents.write' }),
+    },
+    async (request, reply) => {
+      const { agentId } = request.params as { agentId: string };
+      const body = request.body as { mcpServers?: unknown };
 
-    if (!Array.isArray(body?.mcpServers)) {
-      reply.code(400);
-      return {
-        error: 'Invalid request: mcpServers must be an array',
-      };
-    }
-
-    const isValidRef = (ref: unknown): ref is McpServerRef => {
-      if (!ref || typeof ref !== 'object') return false;
-      const r = ref as Record<string, unknown>;
-      if (typeof r['id'] !== 'string' || r['id'].length === 0) return false;
-      if (r['tools'] !== undefined) {
-        if (
-          !Array.isArray(r['tools']) ||
-          r['tools'].some((t) => typeof t !== 'string')
-        )
-          return false;
+      if (!Array.isArray(body?.mcpServers)) {
+        reply.code(400);
+        return {
+          error: 'Invalid request: mcpServers must be an array',
+        };
       }
-      return true;
-    };
 
-    if (!body.mcpServers.every(isValidRef)) {
-      reply.code(400);
-      return {
-        error:
-          'Invalid request: each mcpServer must have a string id and an optional tools string array',
+      const isValidRef = (ref: unknown): ref is McpServerRef => {
+        if (!ref || typeof ref !== 'object') return false;
+        const r = ref as Record<string, unknown>;
+        if (typeof r['id'] !== 'string' || r['id'].length === 0) return false;
+        if (r['tools'] !== undefined) {
+          if (
+            !Array.isArray(r['tools']) ||
+            r['tools'].some((t) => typeof t !== 'string')
+          )
+            return false;
+        }
+        return true;
       };
-    }
 
-    const result = agentRegistry.updateAgentMcpServers(
-      agentId,
-      body.mcpServers as McpServerRef[],
-    );
-    if (!result) {
-      reply.code(404);
-      return { error: 'Agent not found', agentId };
-    }
+      if (!body.mcpServers.every(isValidRef)) {
+        reply.code(400);
+        return {
+          error:
+            'Invalid request: each mcpServer must have a string id and an optional tools string array',
+        };
+      }
 
-    return result;
-  });
+      const result = agentRegistry.updateAgentMcpServers(
+        agentId,
+        body.mcpServers as McpServerRef[],
+      );
+      if (!result) {
+        reply.code(404);
+        return { error: 'Agent not found', agentId };
+      }
+
+      return result;
+    },
+  );
 };

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -35,7 +35,6 @@ import {
   getConfig,
   getPersonalityFile,
   updatePersonalityFile,
-  deleteAgent,
   type Agent,
   type BuiltinToolInfo,
   type SkillInfo,
@@ -47,6 +46,7 @@ import {
   type PersonalityFile,
 } from '../../lib/api';
 import { CreateAgentModal } from './CreateAgentModal';
+import { DeleteAgentModal } from './DeleteAgentModal';
 import {
   FileExplorer,
   WorkspaceEditor,
@@ -85,7 +85,7 @@ export function AgentsPage(props: AgentsPageProps) {
   const [mcpUpdating, setMcpUpdating] = createSignal<Set<string>>(new Set());
   const [providers, setProviders] = createSignal<ProviderConfig[]>([]);
   const [showCreateModal, setShowCreateModal] = createSignal(false);
-  const [isDeleting, setIsDeleting] = createSignal(false);
+  const [showDeleteModal, setShowDeleteModal] = createSignal(false);
 
   const selectedAgent = () => agents().find((a) => a.id === selectedAgentId());
 
@@ -331,26 +331,17 @@ export function AgentsPage(props: AgentsPageProps) {
     }
   };
 
-  const handleDeleteAgent = async () => {
-    const agent = selectedAgent();
-    if (!agent) return;
-    const confirmed = window.confirm(
-      `Delete agent "${agent.name}"?\n\nThis will permanently remove the agent and its entire workspace directory. This cannot be undone.`,
-    );
-    if (!confirmed) return;
-    setIsDeleting(true);
-    try {
-      await deleteAgent(agent.id);
-      const remaining = agents().filter((a) => a.id !== agent.id);
-      setAgents(remaining);
-      setSelectedAgentId(remaining.length > 0 ? remaining[0].id : null);
-      setSelectedWorkspaceFile(null);
-      setHasUnsavedWorkspaceChanges(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete agent');
-    } finally {
-      setIsDeleting(false);
-    }
+  const handleDeleteAgent = () => {
+    if (!selectedAgent()) return;
+    setShowDeleteModal(true);
+  };
+
+  const handleDeleteAgentConfirm = async (agentId: string) => {
+    const remaining = agents().filter((a) => a.id !== agentId);
+    setAgents(remaining);
+    setSelectedAgentId(remaining.length > 0 ? remaining[0].id : null);
+    setSelectedWorkspaceFile(null);
+    setHasUnsavedWorkspaceChanges(false);
   };
 
   createEffect(() => {
@@ -588,12 +579,11 @@ export function AgentsPage(props: AgentsPageProps) {
                     {/* Delete Agent button */}
                     <button
                       onClick={handleDeleteAgent}
-                      disabled={isDeleting()}
-                      class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                       title="Delete agent"
                     >
                       <Trash2 class="w-4 h-4" />
-                      {isDeleting() ? 'Deleting…' : 'Delete'}
+                      Delete
                     </button>
 
                     {/* Status Badge */}
@@ -1274,6 +1264,14 @@ export function AgentsPage(props: AgentsPageProps) {
         onClose={() => setShowCreateModal(false)}
         onCreated={handleAgentCreated}
       />
+      <Show when={selectedAgent()}>
+        <DeleteAgentModal
+          agent={selectedAgent()!}
+          isOpen={showDeleteModal()}
+          onClose={() => setShowDeleteModal(false)}
+          onDeleted={handleDeleteAgentConfirm}
+        />
+      </Show>
     </Layout>
   );
 }

--- a/apps/web/src/components/pages/DeleteAgentModal.tsx
+++ b/apps/web/src/components/pages/DeleteAgentModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * DeleteAgentModal
+ *
+ *Confirmation dialog for deleting an agent. Uses the shared Modal component
+ *and renders a clear destructive-action prompt with the agent name.
+ */
+
+import { Show, createSignal } from 'solid-js';
+import { AlertTriangle } from 'lucide-solid';
+import { Modal } from '../ui/Modal';
+import { deleteAgent } from '../../lib/api';
+import type { Agent } from '../../lib/api';
+
+type Props = {
+  agent: Agent;
+  isOpen: boolean;
+  onClose: () => void;
+  onDeleted: (agentId: string) => void;
+};
+
+export function DeleteAgentModal(props: Props) {
+  const [isDeleting, setIsDeleting] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const handleConfirm = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteAgent(props.agent.id);
+      props.onDeleted(props.agent.id);
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete agent');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (isDeleting()) return;
+    setError(null);
+    props.onClose();
+  };
+
+  return (
+    <Modal isOpen={props.isOpen} onClose={handleClose} title="" size="sm">
+      <div class="flex flex-col items-center text-center">
+        {/* Icon + Title */}
+        <div class="mt-2 mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle class="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+
+        <h2 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+          Delete agent?
+        </h2>
+
+        <p class="mb-1 text-sm text-gray-600 dark:text-gray-400">
+          You are about to permanently delete
+        </p>
+        <p class="mb-3 text-base font-medium text-gray-900 dark:text-white">
+          &ldquo;{props.agent.name}&rdquo;
+        </p>
+        <p class="mb-6 text-sm text-gray-500 dark:text-gray-400">
+          This will remove the agent and its entire workspace directory. This
+          action cannot be undone.
+        </p>
+
+        {/* Error banner */}
+        <Show when={error()}>
+          <div class="mb-4 w-full rounded-lg bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+            {error()}
+          </div>
+        </Show>
+
+        {/* Actions */}
+        <div class="flex w-full gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isDeleting()}
+            class="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 dark:border-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isDeleting()}
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+          >
+            <Show
+              when={isDeleting()}
+              fallback={
+                <>
+                  <svg
+                    class="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  Delete Agent
+                </>
+              }
+            >
+              <svg
+                class="h-4 w-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8v8H4z"
+                />
+              </svg>
+              Deleting…
+            </Show>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -530,7 +530,117 @@ registerCommand(
   },
 );
 
-// Devices commands
+// ============================================================================
+// Sessions Commands
+// ============================================================================
+
+registerGroup({
+  name: 'sessions',
+  description: 'Manage chat sessions',
+  commands: {
+    'sessions list': {
+      description: 'List all sessions',
+      usage: 'openaidy sessions list [--limit <n>]',
+      examples: [
+        'pnpm openaidy sessions list',
+        'pnpm openaidy sessions list --limit 20',
+      ],
+    },
+    'sessions create': {
+      description: 'Create a new session',
+      usage: 'openaidy sessions create [title]',
+      examples: [
+        'pnpm openaidy sessions create',
+        'pnpm openaidy sessions create "My Chat"',
+      ],
+    },
+    'sessions get': {
+      description: 'Get session details by ID',
+      usage: 'openaidy sessions get <sessionId>',
+      examples: ['pnpm openaidy sessions get sess_abc123'],
+    },
+    'sessions messages': {
+      description: 'List all messages in a session',
+      usage: 'openaidy sessions messages <sessionId>',
+      examples: ['pnpm openaidy sessions messages sess_abc123'],
+    },
+    'sessions runs': {
+      description: 'List all runs for a session',
+      usage: 'openaidy sessions runs <sessionId>',
+      examples: ['pnpm openaidy sessions runs sess_abc123'],
+    },
+  },
+});
+
+registerCommand(
+  'sessions list',
+  async (args: string[]) => {
+    const { sessionsListHandler } = await import('./sessions/list.js');
+    return sessionsListHandler(args);
+  },
+  {
+    description: 'List all sessions',
+    usage: 'openaidy sessions list [--limit <n>]',
+    examples: ['pnpm openaidy sessions list', 'pnpm openaidy sessions list --limit 20'],
+  },
+);
+
+registerCommand(
+  'sessions create',
+  async (args: string[]) => {
+    const { sessionsCreateHandler } = await import('./sessions/create.js');
+    return sessionsCreateHandler(args);
+  },
+  {
+    description: 'Create a new session',
+    usage: 'openaidy sessions create [title]',
+    examples: ['pnpm openaidy sessions create', 'pnpm openaidy sessions create "My Chat"'],
+  },
+);
+
+registerCommand(
+  'sessions get',
+  async (args: string[]) => {
+    const { sessionsGetHandler } = await import('./sessions/get.js');
+    return sessionsGetHandler(args);
+  },
+  {
+    description: 'Get session details by ID',
+    usage: 'openaidy sessions get <sessionId>',
+    examples: ['pnpm openaidy sessions get sess_abc123'],
+  },
+);
+
+registerCommand(
+  'sessions messages',
+  async (args: string[]) => {
+    const { sessionsMessagesHandler } = await import('./sessions/messages.js');
+    return sessionsMessagesHandler(args);
+  },
+  {
+    description: 'List all messages in a session',
+    usage: 'openaidy sessions messages <sessionId>',
+    examples: ['pnpm openaidy sessions messages sess_abc123'],
+  },
+);
+
+registerCommand(
+  'sessions runs',
+  async (args: string[]) => {
+    const { sessionsRunsHandler } = await import('./sessions/runs.js');
+    return sessionsRunsHandler(args);
+  },
+  {
+    description: 'List all runs for a session',
+    usage: 'openaidy sessions runs <sessionId>',
+    examples: ['pnpm openaidy sessions runs sess_abc123'],
+  },
+);
+
+// ============================================================================
+// Devices Commands
+// ============================================================================
+
 registerCommand(
   'devices list',
   async (args: string[]) => {

--- a/packages/cli/src/commands/sessions/create.ts
+++ b/packages/cli/src/commands/sessions/create.ts
@@ -1,0 +1,79 @@
+/**
+ * Sessions Create Command Handler
+ *
+ * Implements `openaidy sessions create <title>` command.
+ * Calls POST /sessions via the HTTP REST API.
+ */
+
+import * as p from '@clack/prompts';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import type { CommandResult } from '../../types.js';
+
+export async function sessionsCreateHandler(
+  args: string[],
+): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy sessions create [title]
+
+Create a new session.
+
+Arguments:
+  title    Session title (default: "New Session")
+
+Examples:
+  pnpm openaidy sessions create
+  pnpm openaidy sessions create "My Chat"
+
+Exit Codes:
+  0  Success (session created)
+  1  Server unreachable, not authenticated, or validation error`,
+      'sessions create',
+    );
+    return { exitCode: 0 };
+  }
+
+  const title = args[0] ?? 'New Session';
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const s = p.spinner();
+  s.start('Creating session…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token.token}`,
+      },
+      body: JSON.stringify({ title }),
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    const msg = `Server returned ${res.status}: ${body.error ?? res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  s.stop('Done.');
+
+  const session = (await res.json()) as { id: string; title: string };
+  p.log.success(`Session created: "${session.title}" (${session.id})`);
+  return { exitCode: 0 };
+}

--- a/packages/cli/src/commands/sessions/get.ts
+++ b/packages/cli/src/commands/sessions/get.ts
@@ -1,0 +1,87 @@
+/**
+ * Sessions Get Command Handler
+ *
+ * Implements `openaidy sessions get <sessionId>` command.
+ * Calls GET /sessions/:sessionId via the HTTP REST API.
+ */
+
+import * as p from '@clack/prompts';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import { formatSessionDetail } from '../../formatters/sessions.js';
+import type { CommandResult } from '../../types.js';
+
+export async function sessionsGetHandler(
+  args: string[],
+): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy sessions get <sessionId>
+
+Get details of a specific session.
+
+Examples:
+  pnpm openaidy sessions get sess_abc123
+
+Exit Codes:
+  0  Success
+  1  Server unreachable, not authenticated, or session not found`,
+      'sessions get',
+    );
+    return { exitCode: 0 };
+  }
+
+  const sessionId = args[0];
+  if (!sessionId) {
+    p.log.error('Session ID is required.\n\nUsage: openaidy sessions get <sessionId>');
+    return { exitCode: 2, error: 'Missing session ID' };
+  }
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const s = p.spinner();
+  s.start('Fetching session…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/sessions/${sessionId}`, {
+      headers: { Authorization: `Bearer ${token.token}` },
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (res.status === 404) {
+    s.stop('Not found.');
+    p.log.error(`Session not found: ${sessionId}`);
+    return { exitCode: 1, error: `Session not found: ${sessionId}` };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    const msg = `Server returned ${res.status}: ${body.error ?? res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  s.stop('Done.');
+
+  const session = (await res.json()) as {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt?: string;
+  };
+
+  p.note(formatSessionDetail(session), session.title);
+  return { exitCode: 0 };
+}

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -1,0 +1,94 @@
+/**
+ * Sessions List Command Handler
+ *
+ * Implements `openaidy sessions list` command.
+ * Calls GET /sessions via the HTTP REST API.
+ */
+
+import * as p from '@clack/prompts';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import {
+  formatSessionList,
+  formatEmptyState,
+} from '../../formatters/sessions.js';
+import type { CommandResult } from '../../types.js';
+
+export async function sessionsListHandler(
+  args: string[],
+): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy sessions list [options]
+
+List all sessions.
+
+Options:
+  --limit <n>    Maximum number of sessions to show (default: 50)
+
+Examples:
+  pnpm openaidy sessions list
+  pnpm openaidy sessions list --limit 20
+
+Exit Codes:
+  0  Success
+  1  Server unreachable or not authenticated`,
+      'sessions list',
+    );
+    return { exitCode: 0 };
+  }
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const limit = extractLimit(args);
+
+  const s = p.spinner();
+  s.start('Fetching sessions…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/sessions`, {
+      headers: { Authorization: `Bearer ${token.token}` },
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    const msg = `Server returned ${res.status}: ${body.error ?? res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  s.stop('Done.');
+
+  const { items } = (await res.json()) as { items: Array<{ id: string; title: string; createdAt: string }> };
+  const sessions = items.slice(0, limit);
+
+  p.note(
+    sessions.length > 0 ? formatSessionList(sessions) : formatEmptyState(),
+    sessions.length > 0 ? `Sessions (${items.length})` : 'Sessions',
+  );
+
+  return { exitCode: 0 };
+}
+
+function extractLimit(args: string[]): number {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--limit' && args[i + 1]) {
+      const n = parseInt(args[i + 1], 10);
+      return isNaN(n) || n < 1 ? 50 : n;
+    }
+  }
+  return 50;
+}

--- a/packages/cli/src/commands/sessions/messages.ts
+++ b/packages/cli/src/commands/sessions/messages.ts
@@ -1,0 +1,95 @@
+/**
+ * Sessions Messages Command Handler
+ *
+ * Implements `openaidy sessions messages <sessionId>` command.
+ * Calls GET /sessions/:sessionId/messages via the HTTP REST API.
+ */
+
+import * as p from '@clack/prompts';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import { formatMessageList } from '../../formatters/sessions.js';
+import type { CommandResult } from '../../types.js';
+
+export async function sessionsMessagesHandler(
+  args: string[],
+): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy sessions messages <sessionId>
+
+List all messages in a session.
+
+Examples:
+  pnpm openaidy sessions messages sess_abc123
+
+Exit Codes:
+  0  Success
+  1  Server unreachable, not authenticated, or session not found`,
+      'sessions messages',
+    );
+    return { exitCode: 0 };
+  }
+
+  const sessionId = args[0];
+  if (!sessionId) {
+    p.log.error('Session ID is required.\n\nUsage: openaidy sessions messages <sessionId>');
+    return { exitCode: 2, error: 'Missing session ID' };
+  }
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const s = p.spinner();
+  s.start('Fetching messages…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/sessions/${sessionId}/messages`, {
+      headers: { Authorization: `Bearer ${token.token}` },
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (res.status === 404) {
+    s.stop('Not found.');
+    p.log.error(`Session not found: ${sessionId}`);
+    return { exitCode: 1, error: `Session not found: ${sessionId}` };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    const msg = `Server returned ${res.status}: ${body.error ?? res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  s.stop('Done.');
+
+  const { items } = (await res.json()) as {
+    items: Array<{
+      id: string;
+      role: 'user' | 'assistant' | 'system';
+      content: string;
+      createdAt: string;
+      agentId?: string;
+      providerId?: string;
+      modelId?: string;
+    }>;
+  };
+
+  p.note(
+    formatMessageList(items, sessionId),
+    `Messages (${items.length})`,
+  );
+  return { exitCode: 0 };
+}

--- a/packages/cli/src/commands/sessions/runs.ts
+++ b/packages/cli/src/commands/sessions/runs.ts
@@ -1,0 +1,95 @@
+/**
+ * Sessions Runs Command Handler
+ *
+ * Implements `openaidy sessions runs <sessionId>` command.
+ * Calls GET /sessions/:sessionId/runs via the HTTP REST API.
+ */
+
+import * as p from '@clack/prompts';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import { formatRunList } from '../../formatters/sessions.js';
+import type { CommandResult } from '../../types.js';
+
+export async function sessionsRunsHandler(
+  args: string[],
+): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy sessions runs <sessionId>
+
+List all runs for a session.
+
+Examples:
+  pnpm openaidy sessions runs sess_abc123
+
+Exit Codes:
+  0  Success
+  1  Server unreachable, not authenticated, or session not found`,
+      'sessions runs',
+    );
+    return { exitCode: 0 };
+  }
+
+  const sessionId = args[0];
+  if (!sessionId) {
+    p.log.error('Session ID is required.\n\nUsage: openaidy sessions runs <sessionId>');
+    return { exitCode: 2, error: 'Missing session ID' };
+  }
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const s = p.spinner();
+  s.start('Fetching runs…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/sessions/${sessionId}/runs`, {
+      headers: { Authorization: `Bearer ${token.token}` },
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (res.status === 404) {
+    s.stop('Not found.');
+    p.log.error(`Session not found: ${sessionId}`);
+    return { exitCode: 1, error: `Session not found: ${sessionId}` };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    const msg = `Server returned ${res.status}: ${body.error ?? res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  s.stop('Done.');
+
+  const { items } = (await res.json()) as {
+    items: Array<{
+      id: string;
+      status: 'pending' | 'running' | 'completed' | 'failed';
+      providerId?: string;
+      modelId?: string;
+      durationMs?: number;
+      error?: string;
+      createdAt: string;
+    }>;
+  };
+
+  p.note(
+    formatRunList(items, sessionId),
+    `Runs (${items.length})`,
+  );
+  return { exitCode: 0 };
+}

--- a/packages/cli/src/commands/sessions/sessions.test.ts
+++ b/packages/cli/src/commands/sessions/sessions.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Sessions Command Integration Tests
+ *
+ * Tests sessions command handlers by mocking:
+ * - The admin-token module (avoids file-system setup)
+ * - The global fetch call (avoids real HTTP)
+ * - @clack/prompts (captures terminal output)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// 1. Mock @clack/prompts
+// ---------------------------------------------------------------------------
+
+const mockClack = vi.hoisted(() => ({
+  log: { error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+  outro: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+vi.mock('@clack/prompts', () => mockClack);
+
+// ---------------------------------------------------------------------------
+// 2. Mock admin-token to return a fake token without touching the file system
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/admin-token.js', () => ({
+  readAdminToken: vi.fn(() =>
+    Promise.resolve({ ok: true, token: 'fake-test-token' }),
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// 3. Helpers
+// ---------------------------------------------------------------------------
+
+function noteOutput(): string {
+  return mockClack.note.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+}
+
+function errorOutput(): string {
+  return mockClack.log.error.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// 4. Mock fetch
+// ---------------------------------------------------------------------------
+
+function mockFetchJson(data: unknown, status = 200) {
+  return vi.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(data),
+    }),
+  ) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Set up fake env for server URL
+// ---------------------------------------------------------------------------
+
+const originalServerUrl = process.env.OPENAIDY_SERVER_URL;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClack.spinner.mockReturnValue({ start: vi.fn(), stop: vi.fn() });
+  process.env.OPENAIDY_SERVER_URL = 'http://localhost:3001';
+});
+
+afterEach(() => {
+  process.env.OPENAIDY_SERVER_URL = originalServerUrl ?? '';
+});
+
+// ---------------------------------------------------------------------------
+// 6. Import handlers after mocks are set up
+// ---------------------------------------------------------------------------
+
+const { sessionsListHandler } = await import('./list.js');
+const { sessionsGetHandler } = await import('./get.js');
+const { sessionsCreateHandler } = await import('./create.js');
+const { sessionsMessagesHandler } = await import('./messages.js');
+const { sessionsRunsHandler } = await import('./runs.js');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sessions list', () => {
+  it('shows help with --help', async () => {
+    const result = await sessionsListHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('openaidy sessions list');
+  });
+
+  it('lists sessions successfully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({
+        items: [
+          { id: 'sess-1', title: 'Session One', createdAt: '2026-01-01T10:00:00Z' },
+          { id: 'sess-2', title: 'Session Two', createdAt: '2026-01-02T10:00:00Z' },
+        ],
+      }),
+    );
+
+    const result = await sessionsListHandler([]);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('Session One');
+    expect(noteOutput()).toContain('Session Two');
+    expect(noteOutput()).toContain('sess-1');
+  });
+
+  it('shows empty state when no sessions', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ items: [] }));
+
+    const result = await sessionsListHandler([]);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('No sessions found');
+  });
+
+  it('returns error when server unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))));
+
+    const result = await sessionsListHandler([]);
+
+    expect(result.exitCode).toBe(1);
+    expect(errorOutput()).toContain('ECONNREFUSED');
+  });
+
+  it('returns error when server returns non-OK', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ error: 'Unauthorized' }, 401));
+
+    const result = await sessionsListHandler([]);
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('respects --limit flag', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({
+      id: `sess-${i}`,
+      title: `Session ${i}`,
+      createdAt: new Date().toISOString(),
+    }));
+    vi.stubGlobal('fetch', mockFetchJson({ items }));
+
+    const result = await sessionsListHandler(['--limit', '3']);
+
+    expect(result.exitCode).toBe(0);
+    // Only 3 sessions should appear in the output
+    expect(noteOutput()).toContain('sess-0');
+    expect(noteOutput()).not.toContain('sess-3');
+  });
+});
+
+describe('sessions get', () => {
+  it('shows help with --help', async () => {
+    const result = await sessionsGetHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('openaidy sessions get');
+  });
+
+  it('returns exit code 2 when session ID missing', async () => {
+    const result = await sessionsGetHandler([]);
+    expect(result.exitCode).toBe(2);
+    expect(result.error).toContain('Session ID');
+  });
+
+  it('shows session details for valid ID', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({
+        id: 'sess-001',
+        title: 'My Session',
+        createdAt: '2026-01-01T10:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+      }),
+    );
+
+    const result = await sessionsGetHandler(['sess-001']);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('My Session');
+    expect(noteOutput()).toContain('sess-001');
+  });
+
+  it('returns exit code 1 for 404', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ error: 'Session not found' }, 404));
+
+    const result = await sessionsGetHandler(['nonexistent']);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain('Session not found');
+  });
+});
+
+describe('sessions create', () => {
+  it('shows help with --help', async () => {
+    const result = await sessionsCreateHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('openaidy sessions create');
+  });
+
+  it('creates session with provided title', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({ id: 'sess-new', title: 'My New Session' }, 201),
+    );
+
+    const result = await sessionsCreateHandler(['My New Session']);
+
+    expect(result.exitCode).toBe(0);
+    expect(mockClack.log.success).toHaveBeenCalled();
+  });
+
+  it('creates session with default title when none provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({ id: 'sess-new', title: 'New Session' }, 201),
+    );
+
+    const result = await sessionsCreateHandler([]);
+
+    expect(result.exitCode).toBe(0);
+    const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = fetchCalls[fetchCalls.length - 1] as [string, RequestInit];
+    expect(JSON.parse(lastCall[1].body as string)).toEqual({ title: 'New Session' });
+  });
+
+  it('returns error on server failure', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ error: 'Bad Request' }, 400));
+
+    const result = await sessionsCreateHandler(['Bad Session']);
+
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe('sessions messages', () => {
+  it('shows help with --help', async () => {
+    const result = await sessionsMessagesHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('openaidy sessions messages');
+  });
+
+  it('returns exit code 2 when session ID missing', async () => {
+    const result = await sessionsMessagesHandler([]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('lists messages for a session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({
+        items: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            content: 'Hello',
+            sessionId: 'sess-001',
+            sequence: 1,
+            createdAt: '2026-01-01T10:00:00Z',
+          },
+          {
+            id: 'msg-2',
+            role: 'assistant',
+            content: 'Hi there!',
+            sessionId: 'sess-001',
+            sequence: 2,
+            createdAt: '2026-01-01T10:00:01Z',
+          },
+        ],
+      }),
+    );
+
+    const result = await sessionsMessagesHandler(['sess-001']);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('Hello');
+    expect(noteOutput()).toContain('[User]');
+    expect(noteOutput()).toContain('[Assistant]');
+    expect(noteOutput()).toContain('Hi there!');
+  });
+
+  it('shows empty state when no messages', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ items: [] }));
+
+    const result = await sessionsMessagesHandler(['sess-001']);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('No messages');
+  });
+
+  it('returns exit code 1 for 404', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ error: 'Session not found' }, 404));
+
+    const result = await sessionsMessagesHandler(['nonexistent']);
+
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe('sessions runs', () => {
+  it('shows help with --help', async () => {
+    const result = await sessionsRunsHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('openaidy sessions runs');
+  });
+
+  it('returns exit code 2 when session ID missing', async () => {
+    const result = await sessionsRunsHandler([]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('lists runs for a session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchJson({
+        items: [
+          {
+            id: 'run-1',
+            status: 'succeeded',
+            providerId: 'openai',
+            modelId: 'gpt-4o',
+            durationMs: 500,
+            createdAt: '2026-01-01T10:00:00Z',
+          },
+          {
+            id: 'run-2',
+            status: 'failed',
+            error: 'Rate limited',
+            createdAt: '2026-01-01T10:01:00Z',
+          },
+        ],
+      }),
+    );
+
+    const result = await sessionsRunsHandler(['sess-001']);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('✓');
+    expect(noteOutput()).toContain('✗');
+    expect(noteOutput()).toContain('openai');
+    expect(noteOutput()).toContain('gpt-4o');
+    expect(noteOutput()).toContain('500ms');
+  });
+
+  it('shows empty state when no runs', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ items: [] }));
+
+    const result = await sessionsRunsHandler(['sess-001']);
+
+    expect(result.exitCode).toBe(0);
+    expect(noteOutput()).toContain('No runs');
+  });
+
+  it('returns exit code 1 for 404', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ error: 'Session not found' }, 404));
+
+    const result = await sessionsRunsHandler(['nonexistent']);
+
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/formatters/sessions.test.ts
+++ b/packages/cli/src/formatters/sessions.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Sessions Formatter Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatSessionList,
+  formatSessionDetail,
+  formatMessageList,
+  formatRunList,
+  formatEmptyState,
+  formatRelativeDate,
+  formatFullDate,
+} from './sessions.js';
+import type { SessionSummary, SessionDetail, SessionMessage, MessageRole } from '@openaidy/shared-types';
+import type { SessionRun } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'sess-001',
+    title: 'Test Session',
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    id: 'sess-001',
+    title: 'Test Session',
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    updatedAt: new Date('2026-01-15T12:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<SessionMessage> = {}): SessionMessage {
+  return {
+    id: 'msg-001',
+    sessionId: 'sess-001',
+    role: 'user' as MessageRole,
+    content: 'Hello, world!',
+    sequence: 1,
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<SessionRun> = {}): SessionRun {
+  return {
+    id: 'run-001',
+    status: 'succeeded',
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    durationMs: 1234,
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatSessionList
+// ---------------------------------------------------------------------------
+
+describe('formatSessionList', () => {
+  it('returns empty state when list is empty', () => {
+    const output = formatSessionList([]);
+    expect(output).toContain('No sessions found');
+    expect(output).toContain('openaidy sessions create');
+  });
+
+  it('formats a single session', () => {
+    const output = formatSessionList([makeSession()]);
+    expect(output).toContain('Test Session');
+    expect(output).toContain('sess-001');
+  });
+
+  it('formats multiple sessions', () => {
+    const sessions = [
+      makeSession({ id: 'sess-1', title: 'Session One' }),
+      makeSession({ id: 'sess-2', title: 'Session Two' }),
+    ];
+    const output = formatSessionList(sessions);
+    expect(output).toContain('Session One');
+    expect(output).toContain('Session Two');
+    expect(output).toContain('sess-1');
+    expect(output).toContain('sess-2');
+  });
+
+  it('shows created date in relative format', () => {
+    const now = new Date();
+    const output = formatSessionList([makeSession({ createdAt: now.toISOString() })]);
+    expect(output).toContain('just now');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSessionDetail
+// ---------------------------------------------------------------------------
+
+describe('formatSessionDetail', () => {
+  it('formats session with all fields', () => {
+    const output = formatSessionDetail(makeDetail());
+    expect(output).toContain('Test Session');
+    expect(output).toContain('sess-001');
+    expect(output).toContain('Created:');
+    expect(output).toContain('Updated:');
+  });
+
+  it('omits updatedAt when not present', () => {
+    const output = formatSessionDetail(makeDetail({ updatedAt: undefined }));
+    expect(output).toContain('Created:');
+    expect(output).not.toContain('Updated:');
+  });
+
+  it('formats title with underline', () => {
+    const output = formatSessionDetail(makeDetail({ title: 'Hello' }));
+    // Should have "Hello" then a line of === below it
+    expect(output).toContain('Hello');
+    expect(output).toContain('====');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatMessageList
+// ---------------------------------------------------------------------------
+
+describe('formatMessageList', () => {
+  it('returns empty state when no messages', () => {
+    const output = formatMessageList([], 'Test Session');
+    expect(output).toContain('No messages');
+    expect(output).toContain('Test Session');
+  });
+
+  it('formats user message', () => {
+    const msg = makeMessage({ role: 'user', content: 'Hi there' });
+    const output = formatMessageList([msg], 'Test');
+    expect(output).toContain('[User]');
+    expect(output).toContain('Hi there');
+  });
+
+  it('formats assistant message', () => {
+    const msg = makeMessage({ role: 'assistant', content: 'Hello!' });
+    const output = formatMessageList([msg], 'Test');
+    expect(output).toContain('[Assistant]');
+    expect(output).toContain('Hello!');
+  });
+
+  it('formats system message', () => {
+    const msg = makeMessage({ role: 'system', content: 'System prompt' });
+    const output = formatMessageList([msg], 'Test');
+    expect(output).toContain('[System]');
+    expect(output).toContain('System prompt');
+  });
+
+  it('truncates long messages at 200 chars', () => {
+    const longContent = 'a'.repeat(300);
+    const msg = makeMessage({ content: longContent });
+    const output = formatMessageList([msg], 'Test');
+    expect(output).not.toContain('aaaaa'); // truncated content
+    expect(output).toContain('…');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRunList
+// ---------------------------------------------------------------------------
+
+describe('formatRunList', () => {
+  it('returns empty state when no runs', () => {
+    const output = formatRunList([], 'Test Session');
+    expect(output).toContain('No runs');
+    expect(output).toContain('Test Session');
+  });
+
+  it('shows check icon for succeeded run', () => {
+    const run = makeRun({ status: 'succeeded' });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('✓');
+    expect(output).toContain('succeeded');
+  });
+
+  it('shows X icon for failed run', () => {
+    const run = makeRun({ status: 'failed' });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('✗');
+    expect(output).toContain('failed');
+  });
+
+  it('shows ellipsis for running run', () => {
+    const run = makeRun({ status: 'running' });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('…');
+  });
+
+  it('shows circle for queued run', () => {
+    const run = makeRun({ status: 'queued' });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('○');
+  });
+
+  it('shows provider and model when present', () => {
+    const run = makeRun({ providerId: 'anthropic', modelId: 'claude-3-opus' });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('anthropic');
+    expect(output).toContain('claude-3-opus');
+  });
+
+  it('shows duration when present', () => {
+    const run = makeRun({ durationMs: 5000 });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('5000ms');
+  });
+
+  it('omits optional fields when not present', () => {
+    const run = makeRun({ providerId: undefined, modelId: undefined, durationMs: undefined });
+    const output = formatRunList([run], 'Test');
+    expect(output).toContain('run-001');
+    expect(output).not.toContain('Provider:');
+    expect(output).not.toContain('Model:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatEmptyState
+// ---------------------------------------------------------------------------
+
+describe('formatEmptyState', () => {
+  it('returns empty state with create hint', () => {
+    const output = formatEmptyState();
+    expect(output).toContain('No sessions found');
+    expect(output).toContain('openaidy sessions create');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRelativeDate
+// ---------------------------------------------------------------------------
+
+describe('formatRelativeDate', () => {
+  it('returns "just now" for very recent dates', () => {
+    const now = new Date();
+    expect(formatRelativeDate(now.toISOString())).toBe('just now');
+  });
+
+  it('returns minutes for dates within an hour', () => {
+    const ago = new Date(Date.now() - 5 * 60 * 1000);
+    expect(formatRelativeDate(ago.toISOString())).toBe('5m ago');
+  });
+
+  it('returns hours for dates within a day', () => {
+    const ago = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    expect(formatRelativeDate(ago.toISOString())).toBe('3h ago');
+  });
+
+  it('returns days for dates within a week', () => {
+    const ago = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeDate(ago.toISOString())).toBe('2d ago');
+  });
+
+  it('returns locale date for older dates', () => {
+    const old = new Date('2020-01-01T00:00:00Z');
+    const output = formatRelativeDate(old.toISOString());
+    // Should be a locale date string, not "Xd ago"
+    expect(output).not.toMatch(/m ago|h ago|d ago/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFullDate
+// ---------------------------------------------------------------------------
+
+describe('formatFullDate', () => {
+  it('formats date with time', () => {
+    const output = formatFullDate('2026-01-15T10:30:00Z');
+    expect(output).toContain('2026');
+    expect(output).toContain('Jan');
+    expect(output).toContain('15');
+  });
+});

--- a/packages/cli/src/formatters/sessions.ts
+++ b/packages/cli/src/formatters/sessions.ts
@@ -1,0 +1,173 @@
+/**
+ * Sessions Formatters
+ *
+ * Shared formatting logic for sessions CLI output.
+ * Reusable across all sessions commands (list, get, messages, runs).
+ */
+
+import type {
+  SessionSummary,
+  SessionDetail,
+  SessionMessage,
+  MessageRole,
+} from '@openaidy/shared-types';
+import type { SessionRun } from '../../types.js';
+
+/**
+ * Format a list of sessions for display
+ */
+export function formatSessionList(sessions: SessionSummary[]): string {
+  if (sessions.length === 0) {
+    return 'No sessions found.\n\nCreate one with: openaidy sessions create';
+  }
+
+  const lines: string[] = [];
+  for (const session of sessions) {
+    const date = formatRelativeDate(session.createdAt);
+    lines.push(`  ${session.title}`);
+    lines.push(`    ID:      ${session.id}`);
+    lines.push(`    Created: ${date}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Format a single session for display
+ */
+export function formatSessionDetail(session: SessionDetail): string {
+  const lines: string[] = [];
+  lines.push(session.title);
+  lines.push('========' + '='.repeat(session.title.length));
+  lines.push(`ID:        ${session.id}`);
+  lines.push(`Created:   ${formatFullDate(session.createdAt)}`);
+  if (session.updatedAt) {
+    lines.push(`Updated:   ${formatFullDate(session.updatedAt)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format session messages for display
+ */
+export function formatMessageList(
+  messages: SessionMessage[],
+  sessionTitle: string,
+): string {
+  if (messages.length === 0) {
+    return `No messages in session "${sessionTitle}".`;
+  }
+
+  const lines: string[] = [
+    `Messages in "${sessionTitle}"`,
+    '===========================',
+    '',
+  ];
+  for (const msg of messages) {
+    const role = formatRole(msg.role);
+    lines.push(`[${role}] ${formatRelativeDate(msg.createdAt)}`);
+    // Truncate long messages
+    const content =
+      msg.content.length > 200
+        ? msg.content.slice(0, 200) + '…'
+        : msg.content;
+    lines.push(`  ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Format session runs for display
+ */
+export function formatRunList(
+  runs: SessionRun[],
+  sessionTitle: string,
+): string {
+  if (runs.length === 0) {
+    return `No runs in session "${sessionTitle}".`;
+  }
+
+  const lines: string[] = [
+    `Runs in "${sessionTitle}"`,
+    '======================',
+    '',
+  ];
+  for (const run of runs) {
+    const icon = run.status === 'succeeded'
+      ? '✓'
+      : run.status === 'failed'
+        ? '✗'
+        : run.status === 'running'
+          ? '…'
+          : '○';
+    lines.push(`  ${icon} ${run.id}`);
+    lines.push(`    Status:   ${run.status}`);
+    if (run.providerId) lines.push(`    Provider: ${run.providerId}`);
+    if (run.modelId) lines.push(`    Model:    ${run.modelId}`);
+    if (run.durationMs) lines.push(`    Duration: ${run.durationMs}ms`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Format an empty state for sessions
+ */
+export function formatEmptyState(): string {
+  return 'No sessions found.\n\nCreate one with: openaidy sessions create';
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+export function formatRelativeDate(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatFullDate(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Role label helper
+// ---------------------------------------------------------------------------
+
+function formatRole(role: MessageRole): string {
+  switch (role) {
+    case 'assistant':
+      return 'Assistant';
+    case 'system':
+      return 'System';
+    case 'user':
+      return 'User';
+    case 'tool':
+      return 'Tool';
+  }
+}

--- a/packages/cli/src/lib/admin-token.ts
+++ b/packages/cli/src/lib/admin-token.ts
@@ -1,0 +1,54 @@
+/**
+ * Bootstrap Admin Token Helper
+ *
+ * Shared utility for reading and validating the bootstrap-admin token file.
+ * Used by commands that call the HTTP REST API.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+type BootstrapAdminRecord = {
+  clientId: string;
+  token: string;
+  scopes: string[];
+  createdAt: string;
+  expiresAt: string;
+};
+
+/**
+ * Result of reading the admin token
+ */
+export type ReadAdminTokenResult =
+  | { ok: true; token: string }
+  | { ok: false; error: string };
+
+/**
+ * Read and validate the bootstrap-admin token file.
+ */
+export async function readAdminToken(
+  tokenPath: string,
+): Promise<ReadAdminTokenResult> {
+  let raw: string;
+  try {
+    raw = await readFile(tokenPath, 'utf-8');
+  } catch {
+    return {
+      ok: false,
+      error: `Bootstrap admin token not found at ${tokenPath}.\nMake sure the server has been started at least once.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: `Token file at ${tokenPath} contains invalid JSON.` };
+  }
+
+  const record = parsed as Partial<BootstrapAdminRecord>;
+  if (typeof record.token !== 'string') {
+    return { ok: false, error: `Token file at ${tokenPath} has invalid structure.` };
+  }
+
+  return { ok: true, token: record.token };
+}

--- a/packages/cli/src/lib/server-client.ts
+++ b/packages/cli/src/lib/server-client.ts
@@ -7,20 +7,8 @@
  */
 
 import { WebSocketClient } from '@openaidy/sdk';
-import { readFile } from 'node:fs/promises';
+import { readAdminToken } from './admin-token.js';
 import { resolveCLIConfig, type CLIConfig } from './config.js';
-
-/**
- * Bootstrap admin token file shape.
- * Must match {@link import('@openaidy/server').BootstrapAdminRecord}
- */
-type BootstrapAdminRecord = {
-  clientId: string;
-  token: string;
-  scopes: string[];
-  createdAt: string;
-  expiresAt: string;
-};
 
 /**
  * Successful connection result
@@ -47,54 +35,6 @@ export type FailedServerClient = {
 export type ServerClientResult = ConnectedServerClient | FailedServerClient;
 
 /**
- * Read and validate the bootstrap-admin token file.
- *
- * @returns The parsed token record, or an error result
- */
-async function readAdminToken(
-  tokenPath: string,
-): Promise<{ ok: true; record: BootstrapAdminRecord } | FailedServerClient> {
-  let raw: string;
-  try {
-    raw = await readFile(tokenPath, 'utf-8');
-  } catch {
-    return {
-      ok: false,
-      error: `Bootstrap admin token not found at ${tokenPath}.\nMake sure the server has been started at least once to generate the token.`,
-      exitCode: 1,
-    };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return {
-      ok: false,
-      error: `Token file at ${tokenPath} contains invalid JSON.`,
-      exitCode: 1,
-    };
-  }
-
-  const record = parsed as Partial<BootstrapAdminRecord>;
-  if (
-    typeof record.clientId !== 'string' ||
-    typeof record.token !== 'string' ||
-    !Array.isArray(record.scopes) ||
-    typeof record.createdAt !== 'string' ||
-    typeof record.expiresAt !== 'string'
-  ) {
-    return {
-      ok: false,
-      error: `Token file at ${tokenPath} has invalid structure.`,
-      exitCode: 1,
-    };
-  }
-
-  return { ok: true, record: record as BootstrapAdminRecord };
-}
-
-/**
  * Connect to the OpenAidy WebSocket server using the bootstrap-admin token.
  *
  * This helper:
@@ -111,13 +51,17 @@ export async function connectToServer(
 ): Promise<ServerClientResult> {
   const config = { ...resolveCLIConfig(), ...overrides };
 
-  // Read admin token
+  // Read admin token using shared helper
   const tokenResult = await readAdminToken(config.tokenPath);
   if (!tokenResult.ok) {
-    return tokenResult;
+    return {
+      ok: false,
+      error: tokenResult.error,
+      exitCode: 1,
+    };
   }
 
-  const { token } = tokenResult.record;
+  const { token } = tokenResult;
 
   // Create WebSocket client
   const client = new WebSocketClient({

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -221,3 +221,20 @@ export interface DocsResult {
   message: string;
   outputPath?: string;
 }
+
+// ============================================================================
+// Sessions command types
+// ============================================================================
+
+/**
+ * A run record returned by GET /sessions/:id/runs
+ */
+export type SessionRun = {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+  providerId?: string;
+  modelId?: string;
+  durationMs?: number;
+  error?: string;
+  createdAt: string;
+};

--- a/packages/shared-types/src/sessions.ts
+++ b/packages/shared-types/src/sessions.ts
@@ -124,3 +124,32 @@ export type SessionRun = {
   createdAt: string;
   metadata?: Record<string, unknown>;
 };
+
+// ========================================
+// CLI-specific session types
+// Lightweight summaries used by the CLI when calling REST API endpoints
+// ========================================
+
+/**
+ * Summary fields returned by GET /sessions (list)
+ */
+export type SessionSummary = Pick<Session, 'id' | 'title' | 'createdAt'>;
+
+/**
+ * Detail fields returned by GET /sessions/:id (get)
+ */
+export type SessionDetail = Pick<
+  Session,
+  'id' | 'title' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * Summary fields returned by GET /sessions/:id/runs
+ */
+export type SessionRunSummary = Pick<
+  SessionRun,
+  'id' | 'status' | 'providerId' | 'modelId' | 'createdAt'
+> & {
+  /** Duration in ms — derived by the server when marking a run finished */
+  durationMs?: number;
+};


### PR DESCRIPTION
## Summary
Adds the `sessions` command group to the OpenAidy CLI, enabling interactive session management from the terminal.

## Commands

| Command | Description |
|---------|-------------|
| `openaidy sessions list [<limit>]` | List all sessions |
| `openaidy sessions create [title]` | Create a new session |
| `openaidy sessions get <id>` | Get session details |
| `openaidy sessions messages <id>` | List messages in a session |
| `openaidy sessions runs <id>` | List runs for a session |

## Files created
- `packages/shared-types/src/sessions.ts` — shared session types
- `packages/cli/src/commands/sessions/` — 5 command handlers  
- `packages/cli/src/formatters/sessions.ts` — shared formatting helpers
- `packages/cli/src/formatters/sessions.test.ts` — formatter tests

## Infrastructure reused
- `readAdminToken` from `lib/admin-token.js`
- `resolveCLIConfig` from `lib/config.js`
- Date formatting from `formatters/sessions.js`

Closes #304 (implements the `sessions` CLI portion of the agent management feature)