### PR TITLE
feat(web): add homepage with hero banner and platform features

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,7 @@ import { PulsesPage } from './components/pages/PulsesPage';
 import { ChannelsPage } from './components/pages/ChannelsPage';
 import { WebhooksPage } from './components/pages/WebhooksPage';
 import { AgentsPage } from './components/pages/AgentsPage';
+import { HomePage } from './components/pages/HomePage';
 import { SkillsPage } from './components/pages/SkillsPage';
 import { McpsPage } from './components/pages/McpsPage';
 import { LogsPage } from './components/pages/LogsPage';
@@ -479,6 +480,13 @@ function AppContent(props: AppContentProps) {
             </button>
           </div>
         </header>
+
+        <Show when={view() === 'home'}>
+          <HomePage
+            onNavigate={navigate}
+            onCreateSession={handleCreateSession}
+          />
+        </Show>
 
         <Show when={view() === 'settings'}>
           <SettingsView />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -17,11 +17,13 @@ import {
   Puzzle,
   Layers,
   KeyRound,
+  Home,
 } from 'lucide-solid';
 import { ThemeToggle } from './ThemeToggle';
 import type { Session, AddonRecord } from '../lib/api';
 
 export type ViewType =
+  | 'home'
   | 'chat'
   | 'sessions'
   | 'tasks'
@@ -169,17 +171,44 @@ export function Sidebar(props: SidebarProps) {
 
         {/* Navigation Sections */}
         <div class="flex-1 overflow-y-auto flex flex-col">
-          {/* Chat Item with Plus */}
+          {/* General — Home + Chat */}
+          <div class="mb-2">
+            <Show when={!props.isCollapsed}>
+              <h3 class="px-4 py-1 text-xs font-semibold text-text-muted uppercase tracking-wider">
+                General
+              </h3>
+            </Show>
+            <div class="flex items-center gap-1 px-2">
+              {/* Home */}
+              <button
+                type="button"
+                onClick={() => {
+                  props.onNavigate('home');
+                  if (isMobileViewport()) {
+                    props.onCollapse();
+                  }
+                }}
+                class={`flex items-center justify-center p-2 rounded-lg transition-colors ${
+                  props.currentView === 'home'
+                    ? 'bg-blue-50 dark:bg-blue-900/20 text-text-primary'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-text-secondary'
+                } ${props.isCollapsed ? 'flex-1' : ''}`}
+                title="Home"
+              >
+                <Home class="w-5 h-5 flex-shrink-0" />
+                <Show when={!props.isCollapsed}>
+                  <span class="text-sm ml-2">Home</span>
+                </Show>
+              </button>
+            </div>
+          </div>
+
+          {/* Chat Section */}
           <div class="mb-2">
             <Show when={!props.isCollapsed}>
               <h3 class="px-4 py-1 text-xs font-semibold text-text-muted uppercase tracking-wider">
                 Chat
               </h3>
-            </Show>
-            <Show when={props.isCollapsed}>
-              <div class="px-2 py-1">
-                <div class="h-px bg-gray-200 dark:bg-gray-700" />
-              </div>
             </Show>
             <div class="flex items-center gap-1 px-2">
               <button
@@ -195,11 +224,7 @@ export function Sidebar(props: SidebarProps) {
                   props.currentView === 'chat'
                     ? 'bg-blue-50 dark:bg-blue-900/20 text-text-primary'
                     : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-text-secondary'
-                } ${
-                  props.isCollapsed
-                    ? 'justify-center px-0'
-                    : 'px-2 justify-start'
-                }`}
+                } ${props.isCollapsed ? 'justify-center px-0' : 'px-2 justify-start'}`}
                 title="Chat"
               >
                 <MessageSquare class="w-5 h-5 flex-shrink-0" />

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -482,89 +482,128 @@ export function AgentsPage(props: AgentsPageProps) {
       <Show when={!isLoading() && agents().length === 0}>
         <div class="w-full max-w-5xl mx-auto">
           {/* Banner Image */}
-          <div class="rounded-2xl overflow-hidden shadow-lg mb-8 border border-gray-200 dark:border-gray-700">
+          <div class="relative rounded-2xl overflow-hidden shadow-lg mb-10 border border-gray-200 dark:border-gray-700 group">
             <img
               src="../../../docs/assets/banner.png"
-              alt="OpenAidy"
-              class="w-full object-cover"
-              style="max-height: 280px;"
+              alt="OpenAidy platform"
+              class="w-full object-cover transition-transform duration-700 group-hover:scale-105"
+              style="max-height: 300px;"
             />
+            <div class="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent pointer-events-none" />
           </div>
 
           {/* Headline + CTA */}
           <div class="text-center mb-10">
-            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-medium mb-4">
+            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-medium mb-5">
               <Bot class="w-3.5 h-3.5" />
               AI Agents
             </div>
-            <h2 class="text-3xl font-bold text-text-primary mb-3">
+
+            <h2 class="text-3xl sm:text-4xl font-bold text-text-primary mb-4 tracking-tight">
               Create your first agent
             </h2>
-            <p class="text-text-secondary text-base max-w-lg mx-auto mb-6">
-              Agents are AI-powered assistants with custom personalities, tools,
-              skills, and MCP integrations — tailored to your workflow.
+            <p class="text-text-secondary text-base sm:text-lg max-w-xl mx-auto mb-8 leading-relaxed">
+              Powerful AI assistants with custom personalities, built-in tools,
+              skills, and MCP integrations — all tailored to your workflow.
             </p>
-            <button
-              onClick={() => setShowCreateModal(true)}
-              class="inline-flex items-center gap-2 px-6 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-primary-hover shadow-sm transition-colors"
-            >
-              <Plus class="w-4 h-4" />
-              Create Agent
-            </button>
+
+            <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <button
+                onClick={() => setShowCreateModal(true)}
+                class="inline-flex items-center gap-2.5 px-7 py-3.5 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-primary-hover shadow-md hover:shadow-lg hover:shadow-blue-500/20 transition-all duration-200 active:scale-95"
+              >
+                <Plus class="w-4 h-4" />
+                Create Agent
+                <kbd class="hidden sm:inline-flex items-center gap-1 ml-1 px-1.5 py-0.5 text-xs font-normal bg-white/20 rounded">
+                  N
+                </kbd>
+              </button>
+              <span class="text-xs text-text-muted">
+                or press{' '}
+                <kbd class="font-mono text-[10px] px-1 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded">
+                  N
+                </kbd>{' '}
+                anywhere
+              </span>
+            </div>
           </div>
 
           {/* Feature Grid */}
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
-              <div class="w-9 h-9 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center mb-3">
-                <Lightbulb class="w-4 h-4 text-blue-600 dark:text-blue-400" />
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-5 mb-10">
+            {/* Custom Personality */}
+            <div class="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-600 hover:shadow-lg hover:shadow-blue-500/10 transition-all duration-200 cursor-default">
+              <div class="absolute top-5 right-5 w-8 h-8 rounded-xl bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center group-hover:bg-blue-100 dark:group-hover:bg-blue-900/50 group-hover:shadow-lg group-hover:shadow-blue-400/30 transition-all duration-300">
+                <Lightbulb class="w-4 h-4 text-blue-500 dark:text-blue-400" />
               </div>
-              <h3 class="text-sm font-semibold text-text-primary mb-1">
+              <h3 class="text-base font-semibold text-text-primary mb-2 pr-8">
                 Custom Personality
               </h3>
-              <p class="text-xs text-text-secondary leading-relaxed">
+              <p class="text-sm text-text-secondary leading-relaxed">
                 Define identity, tone, and behavior through personality files —
                 AGENT, USER, MISSION, and RULES.
               </p>
+              <div class="absolute bottom-0 left-6 right-6 h-0.5 bg-gradient-to-r from-blue-500/0 via-blue-500/60 to-blue-500/0 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </div>
-            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
-              <div class="w-9 h-9 rounded-lg bg-green-50 dark:bg-green-900/30 flex items-center justify-center mb-3">
+
+            {/* Built-in Tools */}
+            <div class="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-200 dark:border-gray-700 hover:border-green-300 dark:hover:border-green-600 hover:shadow-lg hover:shadow-green-500/10 transition-all duration-200 cursor-default">
+              <div class="absolute top-5 right-5 w-8 h-8 rounded-xl bg-green-50 dark:bg-green-900/30 flex items-center justify-center group-hover:bg-green-100 dark:group-hover:bg-green-900/50 group-hover:shadow-lg group-hover:shadow-green-400/30 transition-all duration-300">
                 <Wrench class="w-4 h-4 text-green-600 dark:text-green-400" />
               </div>
-              <h3 class="text-sm font-semibold text-text-primary mb-1">
+              <h3 class="text-base font-semibold text-text-primary mb-2 pr-8">
                 Built-in Tools
               </h3>
-              <p class="text-xs text-text-secondary leading-relaxed">
+              <p class="text-sm text-text-secondary leading-relaxed">
                 Equip agents with tools for web search, code execution, file
                 operations, and more.
               </p>
+              <div class="absolute bottom-0 left-6 right-6 h-0.5 bg-gradient-to-r from-green-500/0 via-green-500/60 to-green-500/0 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </div>
-            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
-              <div class="w-9 h-9 rounded-lg bg-purple-50 dark:bg-purple-900/30 flex items-center justify-center mb-3">
+
+            {/* MCP Integration */}
+            <div class="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-200 dark:border-gray-700 hover:border-purple-300 dark:hover:border-purple-600 hover:shadow-lg hover:shadow-purple-500/10 transition-all duration-200 cursor-default">
+              <div class="absolute top-5 right-5 w-8 h-8 rounded-xl bg-purple-50 dark:bg-purple-900/30 flex items-center justify-center group-hover:bg-purple-100 dark:group-hover:bg-purple-900/50 group-hover:shadow-lg group-hover:shadow-purple-400/30 transition-all duration-300">
                 <Server class="w-4 h-4 text-purple-600 dark:text-purple-400" />
               </div>
-              <h3 class="text-sm font-semibold text-text-primary mb-1">
+              <h3 class="text-base font-semibold text-text-primary mb-2 pr-8">
                 MCP Integration
               </h3>
-              <p class="text-xs text-text-secondary leading-relaxed">
+              <p class="text-sm text-text-secondary leading-relaxed">
                 Connect to any MCP server to extend agent capabilities with
                 external APIs and services.
               </p>
+              <div class="absolute bottom-0 left-6 right-6 h-0.5 bg-gradient-to-r from-purple-500/0 via-purple-500/60 to-purple-500/0 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </div>
           </div>
 
-          {/* Secondary hint */}
-          <div class="text-center">
-            <p class="text-xs text-text-muted">
-              Agents run in persistent sessions with real-time streaming — head
-              to <span class="font-medium text-text-tertiary">Sessions</span> to
-              chat once created.
+          {/* Divider + secondary hint */}
+          <div class="flex items-center justify-center gap-4 mb-6">
+            <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+            <p class="text-xs text-text-muted px-4 text-center">
+              Agents run in persistent sessions with real-time streaming — go to{' '}
+              <span class="font-medium text-text-secondary">Sessions</span> to
+              start chatting once created.
             </p>
+            <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+          </div>
+
+          {/* Quick stats strip */}
+          <div class="flex items-center justify-center gap-6 text-xs text-text-muted">
+            <div class="flex items-center gap-1.5">
+              <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+              <span>Persistent sessions</span>
+            </div>
+            <div class="flex items-center gap-1.5">
+              <div class="w-1.5 h-1.5 rounded-full bg-blue-400" />
+              <span>Real-time streaming</span>
+            </div>
+            <div class="flex items-center gap-1.5">
+              <div class="w-1.5 h-1.5 rounded-full bg-purple-400" />
+              <span>Plugin extensible</span>
+            </div>
           </div>
         </div>
       </Show>
-
-      {/* Main Content - Split View */}
       <Show when={!isLoading() && agents().length > 0}>
         <div class="flex h-[calc(100vh-200px)] gap-4">
           {/* Agent List - Left Panel */}

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -478,19 +478,88 @@ export function AgentsPage(props: AgentsPageProps) {
         </div>
       </Show>
 
-      {/* Empty State */}
+      {/* Empty State — Hero Landing */}
       <Show when={!isLoading() && agents().length === 0}>
-        <div class="flex items-center justify-center h-64">
-          <div class="text-center">
-            <Bot class="w-12 h-12 mx-auto mb-4 text-text-tertiary" />
-            <p class="text-text-tertiary mb-2">No agents configured</p>
+        <div class="w-full max-w-5xl mx-auto">
+          {/* Banner Image */}
+          <div class="rounded-2xl overflow-hidden shadow-lg mb-8 border border-gray-200 dark:border-gray-700">
+            <img
+              src="../../../docs/assets/banner.png"
+              alt="OpenAidy"
+              class="w-full object-cover"
+              style="max-height: 280px;"
+            />
+          </div>
+
+          {/* Headline + CTA */}
+          <div class="text-center mb-10">
+            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-medium mb-4">
+              <Bot class="w-3.5 h-3.5" />
+              AI Agents
+            </div>
+            <h2 class="text-3xl font-bold text-text-primary mb-3">
+              Create your first agent
+            </h2>
+            <p class="text-text-secondary text-base max-w-lg mx-auto mb-6">
+              Agents are AI-powered assistants with custom personalities, tools,
+              skills, and MCP integrations — tailored to your workflow.
+            </p>
             <button
               onClick={() => setShowCreateModal(true)}
-              class="mt-3 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+              class="inline-flex items-center gap-2 px-6 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-primary-hover shadow-sm transition-colors"
             >
               <Plus class="w-4 h-4" />
-              Create your first agent
+              Create Agent
             </button>
+          </div>
+
+          {/* Feature Grid */}
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
+              <div class="w-9 h-9 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center mb-3">
+                <Lightbulb class="w-4 h-4 text-blue-600 dark:text-blue-400" />
+              </div>
+              <h3 class="text-sm font-semibold text-text-primary mb-1">
+                Custom Personality
+              </h3>
+              <p class="text-xs text-text-secondary leading-relaxed">
+                Define identity, tone, and behavior through personality files —
+                AGENT, USER, MISSION, and RULES.
+              </p>
+            </div>
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
+              <div class="w-9 h-9 rounded-lg bg-green-50 dark:bg-green-900/30 flex items-center justify-center mb-3">
+                <Wrench class="w-4 h-4 text-green-600 dark:text-green-400" />
+              </div>
+              <h3 class="text-sm font-semibold text-text-primary mb-1">
+                Built-in Tools
+              </h3>
+              <p class="text-xs text-text-secondary leading-relaxed">
+                Equip agents with tools for web search, code execution, file
+                operations, and more.
+              </p>
+            </div>
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
+              <div class="w-9 h-9 rounded-lg bg-purple-50 dark:bg-purple-900/30 flex items-center justify-center mb-3">
+                <Server class="w-4 h-4 text-purple-600 dark:text-purple-400" />
+              </div>
+              <h3 class="text-sm font-semibold text-text-primary mb-1">
+                MCP Integration
+              </h3>
+              <p class="text-xs text-text-secondary leading-relaxed">
+                Connect to any MCP server to extend agent capabilities with
+                external APIs and services.
+              </p>
+            </div>
+          </div>
+
+          {/* Secondary hint */}
+          <div class="text-center">
+            <p class="text-xs text-text-muted">
+              Agents run in persistent sessions with real-time streaming — head
+              to <span class="font-medium text-text-tertiary">Sessions</span> to
+              chat once created.
+            </p>
           </div>
         </div>
       </Show>

--- a/apps/web/src/components/pages/HomePage.tsx
+++ b/apps/web/src/components/pages/HomePage.tsx
@@ -1,0 +1,235 @@
+import { createSignal, onMount } from 'solid-js';
+import {
+  Bot,
+  Zap,
+  Link,
+  Wrench,
+  Server,
+  Layers,
+  CheckSquare,
+  Plus,
+  ArrowRight,
+} from 'lucide-solid';
+import type { ViewType } from '../Sidebar';
+
+type HomePageProps = {
+  onNavigate: (view: ViewType) => void;
+  onCreateSession: () => void;
+};
+
+const features = [
+  {
+    icon: Bot,
+    color: 'blue',
+    title: 'AI Agents',
+    description:
+      'Persistent, streaming AI assistants with custom personalities, tools, and skills.',
+    view: 'agents' as ViewType,
+  },
+  {
+    icon: Layers,
+    color: 'green',
+    title: 'Sessions',
+    description:
+      'Conversational memory across time — pick up where you left off, with full context.',
+    view: 'sessions' as ViewType,
+  },
+  {
+    icon: CheckSquare,
+    color: 'emerald',
+    title: 'Tasks & Automations',
+    description:
+      'Schedule agent work with cron jobs and one-shot triggers — runs happen while you sleep.',
+    view: 'tasks' as ViewType,
+  },
+  {
+    icon: Link,
+    color: 'cyan',
+    title: 'Channels',
+    description:
+      'Connect to WhatsApp, Telegram, Discord, and more — bring agents where your users are.',
+    view: 'channels' as ViewType,
+  },
+  {
+    icon: Wrench,
+    color: 'violet',
+    title: 'Skills',
+    description:
+      'Reusable system-prompt templates attachable to any agent — compose capability, not code.',
+    view: 'skills' as ViewType,
+  },
+  {
+    icon: Server,
+    color: 'purple',
+    title: 'MCP Servers',
+    description:
+      'Connect to any MCP server via stdio or HTTP — extend platform and agent capabilities.',
+    view: 'mcps' as ViewType,
+  },
+];
+
+const colorMap: Record<
+  string,
+  { bg: string; icon: string; border: string; shadow: string; dot: string }
+> = {
+  blue: {
+    bg: 'bg-blue-50 dark:bg-blue-900/20',
+    icon: 'text-blue-600 dark:text-blue-400',
+    border: 'hover:border-blue-300 dark:hover:border-blue-600',
+    shadow: 'hover:shadow-blue-500/10',
+    dot: 'bg-blue-400',
+  },
+  green: {
+    bg: 'bg-green-50 dark:bg-green-900/20',
+    icon: 'text-green-600 dark:text-green-400',
+    border: 'hover:border-green-300 dark:hover:border-green-600',
+    shadow: 'hover:shadow-green-500/10',
+    dot: 'bg-green-400',
+  },
+  emerald: {
+    bg: 'bg-emerald-50 dark:bg-emerald-900/20',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    border: 'hover:border-emerald-300 dark:hover:border-emerald-600',
+    shadow: 'hover:shadow-emerald-500/10',
+    dot: 'bg-emerald-400',
+  },
+  cyan: {
+    bg: 'bg-cyan-50 dark:bg-cyan-900/20',
+    icon: 'text-cyan-600 dark:text-cyan-400',
+    border: 'hover:border-cyan-300 dark:hover:border-cyan-600',
+    shadow: 'hover:shadow-cyan-500/10',
+    dot: 'bg-cyan-400',
+  },
+  violet: {
+    bg: 'bg-violet-50 dark:bg-violet-900/20',
+    icon: 'text-violet-600 dark:text-violet-400',
+    border: 'hover:border-violet-300 dark:hover:border-violet-600',
+    shadow: 'hover:shadow-violet-500/10',
+    dot: 'bg-violet-400',
+  },
+  purple: {
+    bg: 'bg-purple-50 dark:bg-purple-900/20',
+    icon: 'text-purple-600 dark:text-purple-400',
+    border: 'hover:border-purple-300 dark:hover:border-purple-600',
+    shadow: 'hover:shadow-purple-500/10',
+    dot: 'bg-purple-400',
+  },
+};
+
+export function HomePage(props: HomePageProps) {
+  const [visible, setVisible] = createSignal(false);
+
+  onMount(() => {
+    // Stagger entrance animation
+    requestAnimationFrame(() => setVisible(true));
+  });
+
+  return (
+    <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+      <div class="w-full max-w-6xl mx-auto px-4 sm:px-6 py-10">
+        {/* ── Hero ── */}
+        <div
+          class={`text-center mb-12 transition-all duration-700 ${visible() ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}
+        >
+          {/* Banner */}
+          <div class="relative rounded-2xl overflow-hidden shadow-xl mb-8 border border-gray-200 dark:border-gray-700 group">
+            <img
+              src="../../docs/assets/banner.png"
+              alt="OpenAidy"
+              class="w-full object-cover group-hover:scale-105 transition-transform duration-700"
+              style="max-height: 320px;"
+            />
+            <div class="absolute inset-0 bg-gradient-to-t from-black/25 to-transparent pointer-events-none" />
+          </div>
+
+          {/* Badge */}
+          <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-medium mb-5">
+            <Zap class="w-3.5 h-3.5" />
+            OpenAI DIY
+          </div>
+
+          <h1 class="text-4xl sm:text-5xl font-bold text-text-primary mb-4 tracking-tight">
+            Build, run, and extend
+            <br class="hidden sm:block" /> AI agents
+          </h1>
+          <p class="text-text-secondary text-lg sm:text-xl max-w-2xl mx-auto mb-8 leading-relaxed">
+            A plugin-first AI operations platform — persistent sessions,
+            real-time streaming, channels, automations, and MCP integration.
+            Open source and self-hosted.
+          </p>
+
+          {/* CTA row */}
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <button
+              onClick={props.onCreateSession}
+              class="inline-flex items-center gap-2 px-7 py-3.5 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-primary-hover shadow-md hover:shadow-lg hover:shadow-blue-500/20 transition-all duration-200 active:scale-95"
+            >
+              <Plus class="w-4 h-4" />
+              Start chatting
+              <ArrowRight class="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => props.onNavigate('agents')}
+              class="inline-flex items-center gap-2 px-6 py-3.5 text-sm font-medium text-text-secondary bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all duration-200"
+            >
+              Explore agents
+            </button>
+          </div>
+        </div>
+
+        {/* ── Feature Grid ── */}
+        <div class="mb-10">
+          <div class="flex items-center justify-center gap-4 mb-6">
+            <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+            <span class="text-xs font-medium text-text-muted uppercase tracking-widest">
+              Platform capabilities
+            </span>
+            <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {features.map((feature, i) => {
+              const c = colorMap[feature.color];
+              return (
+                <button
+                  onClick={() => props.onNavigate(feature.view)}
+                  class={`group relative text-left bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-200 dark:border-gray-700 ${c.border} ${c.shadow} hover:shadow-lg transition-all duration-200 cursor-pointer`}
+                  style={`animation-delay: ${i * 80}ms`}
+                >
+                  {/* Icon */}
+                  <div
+                    class={`w-10 h-10 rounded-xl ${c.bg} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-200`}
+                  >
+                    <feature.icon class={`w-5 h-5 ${c.icon}`} />
+                  </div>
+
+                  <h3 class="text-base font-semibold text-text-primary mb-2">
+                    {feature.title}
+                  </h3>
+                  <p class="text-sm text-text-secondary leading-relaxed">
+                    {feature.description}
+                  </p>
+
+                  {/* Arrow indicator */}
+                  <div class="absolute top-5 right-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    <ArrowRight class={`w-4 h-4 ${c.icon}`} />
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Getting started strip ── */}
+        <div class="flex items-center justify-center gap-4 mb-6">
+          <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+          <div class="flex items-center gap-3 text-xs text-text-muted">
+            <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+            <span>Ready to go — self-hosted, no cloud required</span>
+          </div>
+          <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-gray-700 to-transparent" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/router.ts
+++ b/apps/web/src/lib/router.ts
@@ -3,6 +3,7 @@ import type { ViewType } from '../components/Sidebar';
 
 // Route path constants - single source of truth
 export const RoutePaths = {
+  HOME: '/',
   SESSIONS: '/sessions',
   CHAT: '/chat',
   TASKS: '/tasks',
@@ -23,6 +24,7 @@ export type RoutePath = (typeof RoutePaths)[keyof typeof RoutePaths];
 
 // Map ViewType to RoutePaths
 export const viewToRouteMap: Record<ViewType, RoutePath> = {
+  home: RoutePaths.HOME,
   sessions: RoutePaths.SESSIONS,
   chat: RoutePaths.CHAT,
   tasks: RoutePaths.TASKS,
@@ -42,7 +44,7 @@ export const viewToRouteMap: Record<ViewType, RoutePath> = {
 
 // Map RoutePaths to ViewType
 export const routeToViewMap: Record<string, ViewType> = {
-  '/': 'chat',
+  '/': 'home',
   [RoutePaths.SESSIONS]: 'sessions',
   [RoutePaths.CHAT]: 'chat',
   [RoutePaths.TASKS]: 'tasks',
@@ -70,13 +72,7 @@ export function createRouter() {
   // Handle root path redirect on initial load
   const getInitialPath = () => {
     if (typeof window !== 'undefined') {
-      const path = window.location.pathname;
-      // Redirect root to chat
-      if (path === '/') {
-        window.history.replaceState({}, '', RoutePaths.CHAT);
-        return RoutePaths.CHAT;
-      }
-      return path;
+      return window.location.pathname || DEFAULT_ROUTE;
     }
     return DEFAULT_ROUTE;
   };


### PR DESCRIPTION
## Summary

Adds a proper homepage to the web app at the `/` route — replacing the old redirect-to-chat behavior. The homepage shows the OpenAidy banner, a hero section with dual CTAs, and a 6-card feature grid for all platform capabilities.

## What changed

### Homepage (`/`)
- **Hero section**: OpenAidy banner image with zoom-on-hover, "OpenAI DIY" badge pill, bold headline, descriptive copy, dual CTAs ("Start chatting" + "Explore agents")
- **Feature grid**: 6 clickable cards — Agents, Sessions, Tasks, Channels, Skills, MCP Servers — each with color-coded icons, hover animations, arrow indicators, and navigation on click
- **Getting started strip** with pulsing green "Ready to go" indicator

### Navigation
- **Sidebar**: new Home icon in a "General" section above Chat — clicking it navigates to `/`
- **Router**: `/` now maps to `'home'` view instead of redirecting to `/chat`

### Files
- `apps/web/src/components/pages/HomePage.tsx` — new component
- `apps/web/src/App.tsx` — import and render HomePage
- `apps/web/src/components/Sidebar.tsx` — added Home icon and nav
- `apps/web/src/lib/router.ts` — `/` → `'home'`, removed redirect

## Testing

```bash
cd apps/web && pnpm dev
```
Then open `http://localhost:5173/` to see the homepage. The sidebar Home button also works.