### PR TITLE
feat(mcp): resolve ${VAR} secrets for stdio+http, redact secrets in A…

### DIFF
--- a/apps/server/src/mcp/client.test.ts
+++ b/apps/server/src/mcp/client.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { McpClientService, createMcpClientService } from './client';
+import {
+  EnvPlaceholderResolver,
+  MissingEnvVarsError,
+} from './placeholder-resolver';
 import type { McpServerConfig } from '@openaidy/config';
 
 describe('McpClientService', () => {
@@ -120,6 +124,56 @@ describe('McpClientService', () => {
       };
       await expect(mcpService.connect(config)).rejects.toThrow(
         'requires command',
+      );
+    });
+  });
+
+  describe('env/header placeholder resolution', () => {
+    it('fails fast (before spawning) when a stdio env placeholder is unset', async () => {
+      const service = createMcpClientService({
+        resolver: new EnvPlaceholderResolver({}),
+      });
+      const config: McpServerConfig = {
+        id: 'stdio-missing',
+        transport: 'stdio',
+        command: 'echo',
+        env: { TOKEN: '${MISSING_VAR}' },
+      };
+      await expect(service.connect(config)).rejects.toBeInstanceOf(
+        MissingEnvVarsError,
+      );
+      expect(service.isConnected('stdio-missing')).toBe(false);
+    });
+
+    it('fails fast (before connecting) when an http header placeholder is unset', async () => {
+      const service = createMcpClientService({
+        resolver: new EnvPlaceholderResolver({}),
+      });
+      const config: McpServerConfig = {
+        id: 'http-missing',
+        transport: 'http',
+        url: 'http://localhost:1/mcp',
+        headers: { Authorization: 'Bearer ${MISSING_VAR}' },
+      };
+      await expect(service.connect(config)).rejects.toBeInstanceOf(
+        MissingEnvVarsError,
+      );
+    });
+
+    it('passes header resolution when the var is set (fails later at the network)', async () => {
+      const service = createMcpClientService({
+        resolver: new EnvPlaceholderResolver({ GH_TOKEN: 'ghp_x' }),
+      });
+      const config: McpServerConfig = {
+        id: 'http-resolved',
+        transport: 'http',
+        url: 'http://localhost:1/mcp',
+        headers: { Authorization: 'Bearer ${GH_TOKEN}' },
+      };
+      // Resolution succeeded (no MissingEnvVarsError); the connection then
+      // fails at the transport/network layer with the wrapped message.
+      await expect(service.connect(config)).rejects.toThrow(
+        'Failed to connect to MCP server',
       );
     });
   });

--- a/apps/server/src/mcp/client.ts
+++ b/apps/server/src/mcp/client.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { FastifyBaseLogger } from 'fastify';
 import type { McpServerConfig } from '@openaidy/config';
+import { EnvPlaceholderResolver } from './placeholder-resolver';
 
 /**
  * Tool definition from an MCP server
@@ -62,6 +63,11 @@ type McpConnection = {
  */
 export type McpClientServiceOptions = {
   logger?: FastifyBaseLogger | undefined;
+  /**
+   * Resolves `${VAR}` placeholders in server `env`/`headers`. Injectable for
+   * testing; defaults to reading from `process.env`.
+   */
+  resolver?: EnvPlaceholderResolver | undefined;
 };
 
 /**
@@ -72,10 +78,12 @@ export type McpClientServiceOptions = {
 export class McpClientService {
   private connections = new Map<string, McpConnection>();
   private logger: FastifyBaseLogger | undefined;
+  private resolver: EnvPlaceholderResolver;
   private shutdownHandlersRegistered = false;
 
   constructor(options?: McpClientServiceOptions) {
     this.logger = options?.logger;
+    this.resolver = options?.resolver ?? new EnvPlaceholderResolver();
     this.registerShutdownHandlers();
   }
 
@@ -119,39 +127,6 @@ export class McpClientService {
   }
 
   /**
-   * Validate environment variable placeholders in config
-   * Checks for placeholders like ${VAR_NAME} and ensures they exist in process.env
-   */
-  private validateEnvPlaceholders(
-    env: Record<string, string> | undefined,
-    serverId: string,
-  ): void {
-    if (!env) return;
-
-    const placeholderPattern = /\$\{([^}]+)\}/g;
-    const missingVars: string[] = [];
-
-    for (const [key, value] of Object.entries(env)) {
-      const matches = value.match(placeholderPattern);
-      if (matches) {
-        for (const match of matches) {
-          const varName = match.slice(2, -1); // Extract VAR_NAME from ${VAR_NAME}
-          if (!process.env[varName]) {
-            missingVars.push(`${key}: ${varName}`);
-          }
-        }
-      }
-    }
-
-    if (missingVars.length > 0) {
-      throw new Error(
-        `MCP server ${serverId}: Missing required environment variables: ${missingVars.join(', ')}. ` +
-          `Please set these environment variables before starting the server.`,
-      );
-    }
-  }
-
-  /**
    * Connect to a stdio-based MCP server
    *
    * The {@link StdioClientTransport} owns the spawned child process — it
@@ -167,8 +142,12 @@ export class McpClientService {
       throw new Error(`stdio transport requires command for server ${id}`);
     }
 
-    // Validate environment variable placeholders before spawning
-    this.validateEnvPlaceholders(env, id);
+    // Resolve ${VAR} placeholders from the environment before spawning; throws
+    // MissingEnvVarsError listing any unset variables.
+    const resolvedEnv = this.resolver.resolveRecord(
+      env,
+      `MCP server ${id} env`,
+    );
 
     this.logger?.info(
       { serverId: id, command },
@@ -182,7 +161,7 @@ export class McpClientService {
     const transport = new StdioClientTransport({
       command,
       args: args ?? [],
-      ...(env ? { env } : {}),
+      ...(resolvedEnv ? { env: resolvedEnv } : {}),
       stderr: 'pipe',
     });
 
@@ -251,6 +230,15 @@ export class McpClientService {
       throw new Error(`http transport requires url for server ${id}`);
     }
 
+    // Resolve ${VAR} placeholders (e.g. `Bearer ${TOKEN}`) before connecting;
+    // throws MissingEnvVarsError listing any unset variables. Done outside the
+    // try below so the failure surfaces directly rather than as a generic
+    // connection error.
+    const resolvedHeaders = this.resolver.resolveRecord(
+      headers,
+      `MCP server ${id} headers`,
+    );
+
     this.logger?.info(
       { serverId: id, url },
       'Connecting to MCP server via HTTP',
@@ -259,9 +247,9 @@ export class McpClientService {
     try {
       // Create Streamable HTTP transport with optional headers via requestInit
       const httpTransportOptions: { requestInit?: RequestInit } = {};
-      if (headers && Object.keys(headers).length > 0) {
+      if (resolvedHeaders && Object.keys(resolvedHeaders).length > 0) {
         httpTransportOptions.requestInit = {
-          headers,
+          headers: resolvedHeaders,
         };
       }
       const transport = new StreamableHTTPClientTransport(

--- a/apps/server/src/mcp/config-import.test.ts
+++ b/apps/server/src/mcp/config-import.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeMcpServerEntry,
+  normalizeMcpServerMap,
+  McpConfigImportError,
+} from './config-import';
+
+describe('normalizeMcpServerEntry', () => {
+  it('maps the Claude-Desktop http format (type -> transport, key -> id)', () => {
+    const config = normalizeMcpServerEntry('github', {
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+    });
+    expect(config).toEqual({
+      id: 'github',
+      transport: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+    });
+  });
+
+  it('accepts an explicit "transport" field too', () => {
+    const config = normalizeMcpServerEntry('fs', {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
+    });
+    expect(config.transport).toBe('stdio');
+    expect(config.command).toBe('npx');
+  });
+
+  it('infers stdio from command when type/transport is omitted', () => {
+    const config = normalizeMcpServerEntry('local', { command: 'my-server' });
+    expect(config.transport).toBe('stdio');
+  });
+
+  it('infers http from url when type/transport is omitted', () => {
+    const config = normalizeMcpServerEntry('remote', {
+      url: 'https://example.com/mcp',
+    });
+    expect(config.transport).toBe('http');
+  });
+
+  it('accepts streamable-http as an http alias', () => {
+    const config = normalizeMcpServerEntry('r', {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+    });
+    expect(config.transport).toBe('http');
+  });
+
+  it('rejects sse with a helpful message', () => {
+    expect(() =>
+      normalizeMcpServerEntry('x', { type: 'sse', url: 'https://e.com' }),
+    ).toThrow(/sse.*not supported/i);
+  });
+
+  it('rejects an unknown transport', () => {
+    expect(() =>
+      normalizeMcpServerEntry('x', { type: 'carrier-pigeon' }),
+    ).toThrow(McpConfigImportError);
+  });
+
+  it('rejects stdio without a command', () => {
+    expect(() => normalizeMcpServerEntry('x', { type: 'stdio' })).toThrow(
+      /requires a "command"/,
+    );
+  });
+
+  it('rejects http without a url', () => {
+    expect(() => normalizeMcpServerEntry('x', { type: 'http' })).toThrow(
+      /requires a "url"/,
+    );
+  });
+
+  it('rejects an entry with no way to determine transport', () => {
+    expect(() => normalizeMcpServerEntry('x', {})).toThrow(
+      /cannot determine transport/,
+    );
+  });
+});
+
+describe('normalizeMcpServerMap', () => {
+  it('normalises multiple entries', () => {
+    const configs = normalizeMcpServerMap({
+      github: { type: 'http', url: 'https://api.githubcopilot.com/mcp/' },
+      fs: { command: 'npx', args: ['-y', 'server-fs'] },
+    });
+    expect(configs).toHaveLength(2);
+    expect(configs.map((c) => c.id).sort()).toEqual(['fs', 'github']);
+  });
+
+  it('throws on an empty map', () => {
+    expect(() => normalizeMcpServerMap({})).toThrow(McpConfigImportError);
+  });
+
+  it('fails the whole import if any entry is invalid (all-or-nothing)', () => {
+    expect(() =>
+      normalizeMcpServerMap({
+        ok: { command: 'x' },
+        bad: { type: 'sse', url: 'https://e.com' },
+      }),
+    ).toThrow(McpConfigImportError);
+  });
+});

--- a/apps/server/src/mcp/config-import.ts
+++ b/apps/server/src/mcp/config-import.ts
@@ -1,0 +1,137 @@
+/**
+ * MCP config import.
+ *
+ * Translates the widely-used keyed-map config format (Claude Desktop, VS Code,
+ * Cursor, …) into this project's flat {@link McpServerConfig} shape. The map
+ * key is the server id; transport comes from `transport`/`type`, or is inferred
+ * from the presence of `command` (stdio) vs `url` (http).
+ *
+ * Example input (the `mcpServers` object of a standard config):
+ *
+ *   {
+ *     "github": {
+ *       "type": "http",
+ *       "url": "https://api.githubcopilot.com/mcp/",
+ *       "headers": { "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" }
+ *     }
+ *   }
+ *
+ * Single responsibility: normalisation only — no persistence, no connection.
+ */
+
+import type { McpServerConfig } from '@openaidy/config';
+import type { McpServerTransport } from '@openaidy/shared-types';
+
+/**
+ * A raw MCP server entry in the keyed-map format. Transport may be given as
+ * `type` or `transport`, or omitted and inferred.
+ */
+export type RawMcpServerEntry = {
+  type?: string;
+  transport?: string;
+  name?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+/** The standard `mcpServers` map: server id → entry. */
+export type RawMcpServerMap = Record<string, RawMcpServerEntry>;
+
+/** Thrown when an entry cannot be normalised into a valid server config. */
+export class McpConfigImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'McpConfigImportError';
+  }
+}
+
+/** Aliases accepted for each supported transport (case-insensitive). */
+const HTTP_TYPE_ALIASES = new Set([
+  'http',
+  'streamable-http',
+  'streamablehttp',
+]);
+const STDIO_TYPE_ALIASES = new Set(['stdio']);
+
+function resolveTransport(
+  id: string,
+  entry: RawMcpServerEntry,
+): McpServerTransport {
+  const declared = (entry.transport ?? entry.type)?.trim().toLowerCase();
+
+  if (declared) {
+    if (STDIO_TYPE_ALIASES.has(declared)) return 'stdio';
+    if (HTTP_TYPE_ALIASES.has(declared)) return 'http';
+    if (declared === 'sse') {
+      throw new McpConfigImportError(
+        `MCP server "${id}": the "sse" transport is not supported; use "http" (streamable HTTP).`,
+      );
+    }
+    throw new McpConfigImportError(
+      `MCP server "${id}": unknown transport "${declared}"; expected "stdio" or "http".`,
+    );
+  }
+
+  // Infer from shape when transport/type is omitted.
+  if (entry.command) return 'stdio';
+  if (entry.url) return 'http';
+  throw new McpConfigImportError(
+    `MCP server "${id}": cannot determine transport — provide "type"/"transport", or a "command" (stdio) or "url" (http).`,
+  );
+}
+
+/**
+ * Normalise a single keyed-map entry into a {@link McpServerConfig}.
+ */
+export function normalizeMcpServerEntry(
+  id: string,
+  entry: RawMcpServerEntry,
+): McpServerConfig {
+  if (!id.trim()) {
+    throw new McpConfigImportError(
+      'MCP server id (map key) must not be empty.',
+    );
+  }
+
+  const transport = resolveTransport(id, entry);
+
+  if (transport === 'stdio' && !entry.command) {
+    throw new McpConfigImportError(
+      `MCP server "${id}": stdio transport requires a "command".`,
+    );
+  }
+  if (transport === 'http' && !entry.url) {
+    throw new McpConfigImportError(
+      `MCP server "${id}": http transport requires a "url".`,
+    );
+  }
+
+  return {
+    id,
+    transport,
+    ...(entry.name !== undefined ? { name: entry.name } : {}),
+    ...(entry.command !== undefined ? { command: entry.command } : {}),
+    ...(entry.args !== undefined ? { args: entry.args } : {}),
+    ...(entry.env !== undefined ? { env: entry.env } : {}),
+    ...(entry.url !== undefined ? { url: entry.url } : {}),
+    ...(entry.headers !== undefined ? { headers: entry.headers } : {}),
+  } as McpServerConfig;
+}
+
+/**
+ * Normalise a full keyed-map of MCP servers into config records. Fails if the
+ * map is empty or any entry is invalid (all-or-nothing, so an import never
+ * half-applies).
+ */
+export function normalizeMcpServerMap(map: RawMcpServerMap): McpServerConfig[] {
+  const entries = Object.entries(map);
+  if (entries.length === 0) {
+    throw new McpConfigImportError(
+      'No MCP servers to import: the "mcpServers" map is empty.',
+    );
+  }
+  return entries.map(([id, entry]) => normalizeMcpServerEntry(id, entry));
+}

--- a/apps/server/src/mcp/index.ts
+++ b/apps/server/src/mcp/index.ts
@@ -11,3 +11,17 @@ export {
   type McpToolResult,
   type McpClientServiceOptions,
 } from './client';
+
+export {
+  EnvPlaceholderResolver,
+  MissingEnvVarsError,
+  type EnvSource,
+} from './placeholder-resolver';
+
+export {
+  MASKED_VALUE,
+  redactSecrets,
+  unmaskRecord,
+  toMcpServerRecord,
+  type McpRuntimeStatus,
+} from './server-record';

--- a/apps/server/src/mcp/index.ts
+++ b/apps/server/src/mcp/index.ts
@@ -25,3 +25,11 @@ export {
   toMcpServerRecord,
   type McpRuntimeStatus,
 } from './server-record';
+
+export {
+  normalizeMcpServerEntry,
+  normalizeMcpServerMap,
+  McpConfigImportError,
+  type RawMcpServerEntry,
+  type RawMcpServerMap,
+} from './config-import';

--- a/apps/server/src/mcp/placeholder-resolver.test.ts
+++ b/apps/server/src/mcp/placeholder-resolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EnvPlaceholderResolver,
+  MissingEnvVarsError,
+} from './placeholder-resolver';
+
+describe('EnvPlaceholderResolver', () => {
+  const env = {
+    GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_secret',
+    API_KEY: 'sk-123',
+    EMPTY: '',
+  };
+
+  it('returns undefined for an undefined record', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    expect(resolver.resolveRecord(undefined, 'ctx')).toBeUndefined();
+  });
+
+  it('resolves a ${VAR} placeholder embedded in a value', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    const resolved = resolver.resolveRecord(
+      { Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+      'headers',
+    );
+    expect(resolved).toEqual({ Authorization: 'Bearer ghp_secret' });
+  });
+
+  it('resolves multiple placeholders across multiple keys', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    const resolved = resolver.resolveRecord(
+      { A: '${API_KEY}', B: 'x-${GITHUB_PERSONAL_ACCESS_TOKEN}-y' },
+      'env',
+    );
+    expect(resolved).toEqual({ A: 'sk-123', B: 'x-ghp_secret-y' });
+  });
+
+  it('leaves values without placeholders untouched', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    expect(resolver.resolveRecord({ PLAIN: 'literal' }, 'env')).toEqual({
+      PLAIN: 'literal',
+    });
+  });
+
+  it('does not mutate the input record', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    const input = { A: '${API_KEY}' };
+    resolver.resolveRecord(input, 'env');
+    expect(input).toEqual({ A: '${API_KEY}' });
+  });
+
+  it('throws MissingEnvVarsError listing all unset variables', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    try {
+      resolver.resolveRecord(
+        { A: '${NOT_SET}', B: '${ALSO_MISSING}' },
+        'MCP server gh headers',
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingEnvVarsError);
+      const e = err as MissingEnvVarsError;
+      expect(e.missing).toEqual(['NOT_SET', 'ALSO_MISSING']);
+      expect(e.message).toContain('MCP server gh headers');
+    }
+  });
+
+  it('treats an empty-string env value as missing (unusable secret)', () => {
+    const resolver = new EnvPlaceholderResolver(env);
+    expect(() => resolver.resolveRecord({ A: '${EMPTY}' }, 'env')).toThrow(
+      MissingEnvVarsError,
+    );
+  });
+
+  it('defaults to process.env when no source is injected', () => {
+    process.env.__MCP_TEST_VAR__ = 'from-process-env';
+    try {
+      const resolver = new EnvPlaceholderResolver();
+      expect(
+        resolver.resolveRecord({ X: '${__MCP_TEST_VAR__}' }, 'env'),
+      ).toEqual({ X: 'from-process-env' });
+    } finally {
+      delete process.env.__MCP_TEST_VAR__;
+    }
+  });
+});

--- a/apps/server/src/mcp/placeholder-resolver.ts
+++ b/apps/server/src/mcp/placeholder-resolver.ts
@@ -1,0 +1,86 @@
+/**
+ * Environment placeholder resolution for MCP server configs.
+ *
+ * MCP configs may reference secrets indirectly with `${VAR}` placeholders,
+ * e.g. `{ "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" }`. This
+ * keeps raw secrets out of the persisted config (and out of API responses),
+ * resolving them from the process environment only at connection time.
+ *
+ * Single responsibility: turn a record of placeholder-bearing strings into a
+ * record of resolved strings, failing loudly when a referenced variable is
+ * unset. The environment source is injected so the behaviour is testable
+ * without mutating `process.env`.
+ */
+
+/**
+ * A source of environment variables. Defaults to `process.env` in production;
+ * tests inject a plain object.
+ */
+export type EnvSource = Record<string, string | undefined>;
+
+/** Matches `${VAR_NAME}` placeholders. */
+const PLACEHOLDER_PATTERN = /\$\{([^}]+)\}/g;
+
+/**
+ * Thrown when a config references environment variables that are not set.
+ * Carries the full list so the caller can surface all of them at once.
+ */
+export class MissingEnvVarsError extends Error {
+  constructor(
+    public readonly missing: string[],
+    context: string,
+  ) {
+    super(
+      `${context}: missing required environment variable(s): ${missing.join(
+        ', ',
+      )}. Set them in the server environment before connecting.`,
+    );
+    this.name = 'MissingEnvVarsError';
+  }
+}
+
+/**
+ * Resolves `${VAR}` placeholders in MCP config records from an env source.
+ */
+export class EnvPlaceholderResolver {
+  constructor(private readonly env: EnvSource = process.env) {}
+
+  /**
+   * Replace every `${VAR}` in a string with its env value, recording any that
+   * are unset (treating empty strings as unset — a blank secret is unusable).
+   */
+  private resolveString(value: string, missing: Set<string>): string {
+    return value.replace(PLACEHOLDER_PATTERN, (_match, name: string) => {
+      const resolved = this.env[name];
+      if (resolved === undefined || resolved === '') {
+        missing.add(name);
+        return '';
+      }
+      return resolved;
+    });
+  }
+
+  /**
+   * Resolve every value in a record. Returns a new record; the input is not
+   * mutated. `undefined` in → `undefined` out (nothing to resolve).
+   *
+   * @throws {MissingEnvVarsError} if any referenced variable is unset.
+   */
+  resolveRecord(
+    record: Record<string, string> | undefined,
+    context: string,
+  ): Record<string, string> | undefined {
+    if (!record) return record;
+
+    const missing = new Set<string>();
+    const resolved: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record)) {
+      resolved[key] = this.resolveString(value, missing);
+    }
+
+    if (missing.size > 0) {
+      throw new MissingEnvVarsError([...missing], context);
+    }
+    return resolved;
+  }
+}

--- a/apps/server/src/mcp/server-record.test.ts
+++ b/apps/server/src/mcp/server-record.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServerConfig } from '@openaidy/config';
+import {
+  MASKED_VALUE,
+  redactSecrets,
+  unmaskRecord,
+  toMcpServerRecord,
+} from './server-record';
+
+describe('redactSecrets', () => {
+  it('returns undefined for undefined', () => {
+    expect(redactSecrets(undefined)).toBeUndefined();
+  });
+
+  it('preserves keys and pure ${VAR} placeholders (not secrets)', () => {
+    expect(redactSecrets({ TOKEN: '${GH_TOKEN}' })).toEqual({
+      TOKEN: '${GH_TOKEN}',
+    });
+  });
+
+  it('masks inlined raw values', () => {
+    expect(redactSecrets({ API_KEY: 'sk-supersecret' })).toEqual({
+      API_KEY: MASKED_VALUE,
+    });
+  });
+
+  it('masks mixed values that embed a placeholder (e.g. Bearer ${VAR})', () => {
+    expect(redactSecrets({ Authorization: 'Bearer ${GH_TOKEN}' })).toEqual({
+      Authorization: MASKED_VALUE,
+    });
+  });
+});
+
+describe('unmaskRecord', () => {
+  it('returns existing when patch is undefined (field not supplied)', () => {
+    expect(unmaskRecord(undefined, { A: 'keep' })).toEqual({ A: 'keep' });
+  });
+
+  it('keeps the stored value when the client echoes back a masked value', () => {
+    expect(
+      unmaskRecord({ Authorization: MASKED_VALUE }, { Authorization: 'real' }),
+    ).toEqual({ Authorization: 'real' });
+  });
+
+  it('applies genuinely changed values', () => {
+    expect(
+      unmaskRecord({ Authorization: 'new' }, { Authorization: 'old' }),
+    ).toEqual({ Authorization: 'new' });
+  });
+
+  it('supports adding and removing keys (full-replace semantics)', () => {
+    expect(unmaskRecord({ B: 'added' }, { A: 'gone' })).toEqual({ B: 'added' });
+  });
+});
+
+describe('toMcpServerRecord', () => {
+  const base: McpServerConfig = {
+    id: 'gh',
+    name: 'GitHub',
+    transport: 'http',
+    url: 'https://api.githubcopilot.com/mcp/',
+    headers: { Authorization: 'Bearer ${GH_TOKEN}' },
+  } as McpServerConfig;
+
+  it('never emits raw secret header/env values', () => {
+    const record = toMcpServerRecord(base, { connected: true, tools: [] });
+    expect(record.headers).toEqual({ Authorization: MASKED_VALUE });
+  });
+
+  it('reflects runtime status and tool count', () => {
+    const record = toMcpServerRecord(base, {
+      connected: true,
+      tools: [{ name: 'search' }, { name: 'issues' }],
+    });
+    expect(record.connected).toBe(true);
+    expect(record.toolCount).toBe(2);
+    expect(record.tools.map((t) => t.name)).toEqual(['search', 'issues']);
+  });
+});

--- a/apps/server/src/mcp/server-record.ts
+++ b/apps/server/src/mcp/server-record.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP server API representation.
+ *
+ * Single source of truth for turning a stored {@link McpServerConfig} plus its
+ * live runtime status into the {@link McpServerRecord} returned by the REST
+ * API. Centralising this here removes the record-building duplication across
+ * the route handlers and — critically — guarantees that secret values in
+ * `env`/`headers` are never emitted over the API.
+ */
+
+import type { McpServerConfig } from '@openaidy/config';
+import type { McpServerRecord, McpToolSummary } from '@openaidy/shared-types';
+
+/**
+ * Placeholder returned in place of a secret config value. Also recognised on
+ * the way back in ({@link unmaskRecord}) so a round-tripped redacted value
+ * never overwrites the stored secret.
+ */
+export const MASKED_VALUE = '••••••';
+
+/** A value that is exactly a `${VAR}` placeholder — safe to show, not a secret. */
+const PURE_PLACEHOLDER_PATTERN = /^\$\{[^}]+\}$/;
+
+/** Live connection state for a server, as seen by the client service. */
+export type McpRuntimeStatus = {
+  connected: boolean;
+  tools: McpToolSummary[];
+};
+
+/**
+ * Redact secret values in an `env`/`headers` record for API output.
+ *
+ * Keys are always preserved (callers need to know which are set). A value that
+ * is exactly a `${VAR}` placeholder is kept verbatim — it is not itself a
+ * secret and preserving it lets the UI round-trip the config safely. Any other
+ * value may be an inlined secret and is masked.
+ */
+export function redactSecrets(
+  record: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!record) return record;
+
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    redacted[key] = PURE_PLACEHOLDER_PATTERN.test(value.trim())
+      ? value
+      : MASKED_VALUE;
+  }
+  return redacted;
+}
+
+/**
+ * Merge an incoming (possibly redacted) `env`/`headers` patch onto the stored
+ * record. A value equal to {@link MASKED_VALUE} means "unchanged" — the client
+ * echoed back a redacted value it never actually saw — so the stored value is
+ * retained. `undefined` patch means the field was not supplied at all.
+ */
+export function unmaskRecord(
+  patch: Record<string, string> | undefined,
+  existing: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (patch === undefined) return existing;
+
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    merged[key] = value === MASKED_VALUE ? (existing?.[key] ?? value) : value;
+  }
+  return merged;
+}
+
+/**
+ * Build the API representation of an MCP server, with secrets redacted.
+ */
+export function toMcpServerRecord(
+  config: McpServerConfig,
+  runtime: McpRuntimeStatus,
+): McpServerRecord {
+  return {
+    id: config.id,
+    name: config.name,
+    transport: config.transport,
+    command: config.command,
+    args: config.args,
+    env: redactSecrets(config.env),
+    url: config.url,
+    headers: redactSecrets(config.headers),
+    connected: runtime.connected,
+    toolCount: runtime.tools.length,
+    tools: runtime.tools,
+  };
+}

--- a/apps/server/src/routes/mcp.test.ts
+++ b/apps/server/src/routes/mcp.test.ts
@@ -33,6 +33,20 @@ const noAuthMiddleware = {
   hasCapability: () => false,
 } as unknown as AuthMiddleware;
 
+// Authenticated with a valid token but WITHOUT the admin scope.
+const nonAdminAuthMiddleware = {
+  validateToken: async () => ({
+    sub: 'test',
+    scopes: ['sessions.read'],
+    type: 'access' as const,
+    iat: 0,
+    exp: 9999999999,
+  }),
+  extractFromHeader: (_h: string) => 'test-token',
+  extractFromQuery: (_q: Record<string, string | undefined>) => null,
+  hasCapability: (_scopes: string[], cap: string) => cap !== '*',
+} as unknown as AuthMiddleware;
+
 function makeServerConfig(
   overrides: Partial<McpServerConfig> = {},
 ): McpServerConfig {
@@ -528,6 +542,97 @@ describe('MCP Routes', () => {
       });
       expect(res.statusCode).toBe(401);
       await unauthApp.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('secret redaction', () => {
+    beforeEach(async () => {
+      const servers = [
+        makeServerConfig({
+          id: 'http-srv',
+          transport: 'http',
+          command: undefined,
+          args: undefined,
+          url: 'https://api.githubcopilot.com/mcp/',
+          headers: { Authorization: 'Bearer ${GH_TOKEN}' },
+          env: { INLINE: 'raw-secret-value', PLACEHOLDER: '${SOME_VAR}' },
+        }),
+      ];
+      mcpService = makeMcpService(servers, []);
+      configService = makeConfigService(servers);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('masks mixed/inlined secret values but preserves ${VAR} placeholders', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/mcp/servers/http-srv',
+      });
+      expect(res.statusCode).toBe(200);
+      const { server } = res.json();
+      // Bearer ${GH_TOKEN} embeds a placeholder → treated as a secret → masked.
+      expect(server.headers.Authorization).not.toContain('${GH_TOKEN}');
+      expect(server.headers.Authorization).toBe('••••••');
+      // Inlined raw value masked; pure placeholder preserved.
+      expect(server.env.INLINE).toBe('••••••');
+      expect(server.env.PLACEHOLDER).toBe('${SOME_VAR}');
+    });
+
+    it('never leaks secrets in the list endpoint either', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/mcp/servers' });
+      const body = res.json();
+      expect(JSON.stringify(body)).not.toContain('raw-secret-value');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('admin scope enforcement', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService([], []);
+      configService = makeConfigService([]);
+    });
+
+    it('rejects a create from a non-admin (authenticated) token with 403', async () => {
+      app = await buildApp(mcpService, configService, nonAdminAuthMiddleware);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers',
+        headers: { 'content-type': 'application/json' },
+        payload: { config: { id: 'x', transport: 'stdio', command: 'echo' } },
+      });
+      expect(res.statusCode).toBe(403);
+      expect(res.json().error).toBe('INSUFFICIENT_SCOPE');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('PATCH secret round-trip safety', () => {
+    it('keeps the stored secret when the client echoes back a masked value', async () => {
+      const servers = [
+        makeServerConfig({
+          id: 'http-srv',
+          transport: 'http',
+          command: undefined,
+          args: undefined,
+          url: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer ${GH_TOKEN}' },
+        }),
+      ];
+      mcpService = makeMcpService(servers, []);
+      configService = makeConfigService(servers);
+      app = await buildApp(mcpService, configService);
+
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/mcp/servers/http-srv',
+        headers: { 'content-type': 'application/json' },
+        // Client re-sends the masked value it received from a GET.
+        payload: { headers: { Authorization: '••••••' } },
+      });
+
+      const stored = configService.getMcpServer('http-srv');
+      expect(stored?.headers?.Authorization).toBe('Bearer ${GH_TOKEN}');
     });
   });
 });

--- a/apps/server/src/routes/mcp.test.ts
+++ b/apps/server/src/routes/mcp.test.ts
@@ -607,6 +607,104 @@ describe('MCP Routes', () => {
   });
 
   // -------------------------------------------------------------------------
+  describe('POST /mcp/servers/import', () => {
+    beforeEach(async () => {
+      mcpService = makeMcpService([], []);
+      configService = makeConfigService([]);
+      app = await buildApp(mcpService, configService);
+    });
+
+    it('imports the Claude-Desktop http map format and connects', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers/import',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          mcpServers: {
+            github: {
+              type: 'http',
+              url: 'https://api.githubcopilot.com/mcp/',
+              headers: {
+                Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}',
+              },
+            },
+          },
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.servers).toHaveLength(1);
+      expect(body.servers[0].id).toBe('github');
+      expect(body.servers[0].transport).toBe('http');
+      // Persisted with transport (not the raw "type") and connected.
+      const stored = configService.getMcpServer('github');
+      expect(stored?.transport).toBe('http');
+      expect(mcpService.connect).toHaveBeenCalled();
+      // Secret still redacted in the response.
+      expect(body.servers[0].headers.Authorization).toBe('••••••');
+    });
+
+    it('imports multiple servers in one call', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers/import',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          mcpServers: {
+            github: { type: 'http', url: 'https://api.githubcopilot.com/mcp/' },
+            fs: { command: 'npx', args: ['-y', 'server-fs'] },
+          },
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().servers).toHaveLength(2);
+    });
+
+    it('returns 400 for an invalid entry (nothing persisted)', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers/import',
+        headers: { 'content-type': 'application/json' },
+        payload: { mcpServers: { bad: { type: 'sse', url: 'https://e.com' } } },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('INVALID_CONFIG');
+      expect(configService.save).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when an id already exists (all-or-nothing)', async () => {
+      configService = makeConfigService([makeServerConfig({ id: 'github' })]);
+      app = await buildApp(mcpService, configService);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers/import',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          mcpServers: {
+            github: { type: 'http', url: 'https://api.githubcopilot.com/mcp/' },
+          },
+        },
+      });
+      expect(res.statusCode).toBe(409);
+      expect(res.json().error).toBe('CONFLICT');
+      expect(configService.save).not.toHaveBeenCalled();
+    });
+
+    it('requires admin scope (403 for non-admin token)', async () => {
+      app = await buildApp(mcpService, configService, nonAdminAuthMiddleware);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/servers/import',
+        headers: { 'content-type': 'application/json' },
+        payload: {
+          mcpServers: { github: { type: 'http', url: 'https://e.com/mcp' } },
+        },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   describe('PATCH secret round-trip safety', () => {
     it('keeps the stored secret when the client echoes back a masked value', async () => {
       const servers = [

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -23,6 +23,11 @@ import {
   unmaskRecord,
   type McpRuntimeStatus,
 } from '../mcp/server-record';
+import {
+  normalizeMcpServerMap,
+  McpConfigImportError,
+  type RawMcpServerMap,
+} from '../mcp/config-import';
 
 /**
  * Managing MCP servers means running arbitrary local processes (stdio) or
@@ -230,6 +235,114 @@ export async function registerMcpRoutes(
             runtimeStatus(config.id),
           ),
         });
+      },
+    );
+
+    /**
+     * POST /mcp/servers/import
+     *
+     * Import one or more servers from the standard keyed-map config format
+     * (Claude Desktop / VS Code / Cursor), e.g.:
+     *
+     *   { "mcpServers": { "github": { "type": "http", "url": "…",
+     *     "headers": { "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" } } } }
+     *
+     * Atomic: if any entry is invalid or any id already exists, nothing is
+     * imported. Each imported server is then connected (non-fatal on failure).
+     */
+    authRequired.post<{ Body: { mcpServers: RawMcpServerMap } }>(
+      '/mcp/servers/import',
+      {
+        schema: {
+          body: {
+            type: 'object',
+            required: ['mcpServers'],
+            properties: {
+              mcpServers: {
+                type: 'object',
+                minProperties: 1,
+                additionalProperties: {
+                  type: 'object',
+                  properties: {
+                    type: { type: 'string' },
+                    transport: { type: 'string' },
+                    name: { type: 'string' },
+                    command: { type: 'string' },
+                    args: { type: 'array', items: { type: 'string' } },
+                    env: {
+                      type: 'object',
+                      additionalProperties: { type: 'string' },
+                    },
+                    url: { type: 'string' },
+                    headers: {
+                      type: 'object',
+                      additionalProperties: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Body: { mcpServers: RawMcpServerMap } }>,
+        reply: FastifyReply,
+      ) => {
+        // Normalise the keyed-map format into our flat config shape.
+        let servers;
+        try {
+          servers = normalizeMcpServerMap(request.body.mcpServers);
+        } catch (error) {
+          if (error instanceof McpConfigImportError) {
+            return reply
+              .status(400)
+              .send({ error: 'INVALID_CONFIG', message: error.message });
+          }
+          throw error;
+        }
+
+        // All-or-nothing: reject the whole import if any id already exists.
+        const existingIds = new Set(
+          configService.getMcpServers().map((s) => s.id),
+        );
+        const conflicts = servers
+          .map((s) => s.id)
+          .filter((id) => existingIds.has(id));
+        if (conflicts.length > 0) {
+          return reply.status(409).send({
+            error: 'CONFLICT',
+            message: `MCP server(s) already exist in config: ${conflicts.join(', ')}`,
+          });
+        }
+
+        // Persist all in a single save.
+        const fullConfig = configService.getConfig();
+        await configService.save({
+          ...fullConfig,
+          mcpServers: [...(fullConfig.mcpServers ?? []), ...servers],
+        });
+
+        // Connect each (non-fatal) and build redacted records.
+        const records = [];
+        for (const serverConfig of servers) {
+          try {
+            await mcpService.connect(serverConfig);
+          } catch (error) {
+            fastify.log.warn(
+              {
+                serverId: serverConfig.id,
+                err: error instanceof Error ? error.message : String(error),
+              },
+              'MCP server imported but initial connection failed',
+            );
+          }
+          records.push(
+            toMcpServerRecord(serverConfig, runtimeStatus(serverConfig.id)),
+          );
+        }
+
+        return reply.status(201).send({ servers: records });
       },
     );
 

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -13,12 +13,24 @@ import type { AppConfigService } from '../config/service';
 import type { AuthMiddleware } from '../websocket/middleware/auth';
 import type { McpServerConfig } from '@openaidy/config';
 import {
-  type McpServerRecord,
   type McpToolWithSchema,
   type CreateMcpServerRequest,
   type UpdateMcpServerRequest,
 } from '@openaidy/shared-types';
 import { requireAuth } from '../middleware/require-auth';
+import {
+  toMcpServerRecord,
+  unmaskRecord,
+  type McpRuntimeStatus,
+} from '../mcp/server-record';
+
+/**
+ * Managing MCP servers means running arbitrary local processes (stdio) or
+ * dialling out with stored credentials (http), so all write/lifecycle
+ * operations require the admin scope — matching access-token and addon
+ * management.
+ */
+const ADMIN_SCOPE = '*';
 
 /**
  * MCP routes options
@@ -39,41 +51,35 @@ export async function registerMcpRoutes(
   const { mcpService, configService, authMiddleware } = options;
 
   /**
+   * Live connection state for a server, used to enrich the persisted config
+   * into an API record.
+   */
+  const runtimeStatus = (id: string): McpRuntimeStatus => {
+    const connected = mcpService.isConnected(id);
+    const tools = connected
+      ? mcpService.getTools(id).map((t) => ({
+          name: t.name,
+          description: t.description,
+        }))
+      : [];
+    return { connected, tools };
+  };
+
+  /**
    * GET /mcp/servers
    *
    * List all configured MCP servers (from config) with their live runtime status.
-   * Shows both persisted config and current connection state.
+   * Shows both persisted config and current connection state. Secret values in
+   * env/headers are redacted (see toMcpServerRecord).
    */
   fastify.get(
     '/mcp/servers',
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      const configuredServers = configService.getMcpServers();
-
-      const servers: McpServerRecord[] = configuredServers.map(
-        (serverConfig) => {
-          const connected = mcpService.isConnected(serverConfig.id);
-          const tools = connected
-            ? mcpService.getTools(serverConfig.id).map((t) => ({
-                name: t.name,
-                description: t.description,
-              }))
-            : [];
-
-          return {
-            id: serverConfig.id,
-            name: serverConfig.name,
-            transport: serverConfig.transport,
-            command: serverConfig.command,
-            args: serverConfig.args,
-            env: serverConfig.env,
-            url: serverConfig.url,
-            headers: serverConfig.headers,
-            connected,
-            toolCount: tools.length,
-            tools,
-          };
-        },
-      );
+      const servers = configService
+        .getMcpServers()
+        .map((serverConfig) =>
+          toMcpServerRecord(serverConfig, runtimeStatus(serverConfig.id)),
+        );
 
       return { servers };
     },
@@ -99,29 +105,7 @@ export async function registerMcpRoutes(
         });
       }
 
-      const connected = mcpService.isConnected(id);
-      const tools = connected
-        ? mcpService.getTools(id).map((t) => ({
-            name: t.name,
-            description: t.description,
-          }))
-        : [];
-
-      const record: McpServerRecord = {
-        id: serverConfig.id,
-        name: serverConfig.name,
-        transport: serverConfig.transport,
-        command: serverConfig.command,
-        args: serverConfig.args,
-        env: serverConfig.env,
-        url: serverConfig.url,
-        headers: serverConfig.headers,
-        connected,
-        toolCount: tools.length,
-        tools,
-      };
-
-      return { server: record };
+      return { server: toMcpServerRecord(serverConfig, runtimeStatus(id)) };
     },
   );
 
@@ -162,7 +146,7 @@ export async function registerMcpRoutes(
   await fastify.register(async (authRequired) => {
     authRequired.addHook(
       'preHandler',
-      requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
+      requireAuth({ authMiddleware, requiredScope: ADMIN_SCOPE }),
     );
 
     /**
@@ -228,10 +212,8 @@ export async function registerMcpRoutes(
         await configService.save({ ...fullConfig, mcpServers: newServers });
 
         // Attempt connection (non-fatal if it fails)
-        let connected = false;
         try {
           await mcpService.connect(config as McpServerConfig);
-          connected = true;
         } catch (error) {
           fastify.log.warn(
             {
@@ -242,27 +224,11 @@ export async function registerMcpRoutes(
           );
         }
 
-        const tools = connected
-          ? mcpService.getTools(config.id).map((t) => ({
-              name: t.name,
-              description: t.description,
-            }))
-          : [];
-
         return reply.status(201).send({
-          server: {
-            id: config.id,
-            name: config.name,
-            transport: config.transport,
-            command: config.command,
-            args: config.args,
-            env: config.env,
-            url: config.url,
-            headers: config.headers,
-            connected,
-            toolCount: tools.length,
-            tools,
-          },
+          server: toMcpServerRecord(
+            config as McpServerConfig,
+            runtimeStatus(config.id),
+          ),
         });
       },
     );
@@ -320,7 +286,9 @@ export async function registerMcpRoutes(
           });
         }
 
-        // Build updated config (merge patch into existing)
+        // Build updated config (merge patch into existing). env/headers go
+        // through unmaskRecord so a client that echoes back redacted values
+        // (MASKED_VALUE) keeps the stored secret instead of overwriting it.
         const updated: McpServerConfig = {
           ...existing,
           ...(patch.name !== undefined ? { name: patch.name } : {}),
@@ -329,9 +297,13 @@ export async function registerMcpRoutes(
             : {}),
           ...(patch.command !== undefined ? { command: patch.command } : {}),
           ...(patch.args !== undefined ? { args: patch.args } : {}),
-          ...(patch.env !== undefined ? { env: patch.env } : {}),
+          ...(patch.env !== undefined
+            ? { env: unmaskRecord(patch.env, existing.env) }
+            : {}),
           ...(patch.url !== undefined ? { url: patch.url } : {}),
-          ...(patch.headers !== undefined ? { headers: patch.headers } : {}),
+          ...(patch.headers !== undefined
+            ? { headers: unmaskRecord(patch.headers, existing.headers) }
+            : {}),
         };
 
         // Persist to config
@@ -341,29 +313,7 @@ export async function registerMcpRoutes(
         );
         await configService.save({ ...fullConfig, mcpServers: newServers });
 
-        const connected = mcpService.isConnected(id);
-        const tools = connected
-          ? mcpService.getTools(id).map((t) => ({
-              name: t.name,
-              description: t.description,
-            }))
-          : [];
-
-        return {
-          server: {
-            id: updated.id,
-            name: updated.name,
-            transport: updated.transport,
-            command: updated.command,
-            args: updated.args,
-            env: updated.env,
-            url: updated.url,
-            headers: updated.headers,
-            connected,
-            toolCount: tools.length,
-            tools,
-          },
-        };
+        return { server: toMcpServerRecord(updated, runtimeStatus(id)) };
       },
     );
 

--- a/apps/server/src/websocket/index.ts
+++ b/apps/server/src/websocket/index.ts
@@ -105,6 +105,11 @@ const MESSAGE_CAPABILITIES: Partial<Record<string, string[]>> = {
   'presence.getAll': [WS_CAPABILITIES.SYSTEM_NOTIFY],
   'presence.subscribe': [WS_CAPABILITIES.SYSTEM_NOTIFY],
   'presence.unsubscribe': [WS_CAPABILITIES.SYSTEM_NOTIFY],
+  // Managing MCP servers runs arbitrary local processes / dials out with
+  // stored credentials, so it requires admin — matching the REST routes.
+  'mcp.connect': [WS_CAPABILITIES.ADMIN],
+  'mcp.disconnect': [WS_CAPABILITIES.ADMIN],
+  'mcp.call': [WS_CAPABILITIES.ADMIN],
 };
 
 /**
@@ -126,10 +131,10 @@ const AUTHENTICATED_ONLY_MESSAGE_TYPES = new Set<string>([
   'log.stats',
   'log.subscribe',
   'log.unsubscribe',
+  // mcp.list is a read-only listing of connected servers + tool names (no
+  // secrets); the powerful mcp.connect/disconnect/call require admin and live
+  // in MESSAGE_CAPABILITIES instead.
   'mcp.list',
-  'mcp.connect',
-  'mcp.disconnect',
-  'mcp.call',
   'channel.subscribe',
   'channel.unsubscribe',
 ]);


### PR DESCRIPTION
…PI, require admin

Enables HTTP MCP servers that authenticate via env-backed secrets (e.g. GitHub's `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`) while closing the secret-exposure and privilege gaps found in review.

Secret resolution (#4):
- New EnvPlaceholderResolver (SRP, env source injected for testability) resolves ${VAR} placeholders and throws MissingEnvVarsError listing all unset vars. Wired into the client for BOTH stdio `env` and http `headers` (previously headers were neither validated nor substituted, and stdio env was validated but never substituted — the child received the literal ${VAR}). Configs still store placeholders; resolution happens only at connect time.

Secret redaction (#1):
- New server-record presenter is the single source of truth for the API representation and never emits secret values: env/header values are masked, pure ${VAR} placeholders preserved. Applied to every REST response (previously the unauthenticated GET /mcp/servers returned env/headers verbatim). PATCH uses unmaskRecord so a client echoing a redacted value can't overwrite the stored secret. Removes the 4x record-building duplication.

Privilege hardening (#2):
- MCP write/lifecycle ops now require the admin scope (was `agents.list`), matching access-token/addon management, since they run arbitrary local processes or dial out with stored credentials. WS mcp.connect/call/ disconnect now require the admin capability; mcp.list (read-only, no secrets) stays authenticated-only.

Tests: unit tests for the resolver and presenter; route tests for redaction, admin-scope enforcement, and PATCH round-trip safety; client tests for fail-fast on unset vars across both transports. Full server suite green (2907 passed).