### PR TITLE
feat(mcp): import UI + CLI for keyed-map server configs

### DIFF
--- a/apps/server/src/mcp/config-import.ts
+++ b/apps/server/src/mcp/config-import.ts
@@ -20,22 +20,17 @@
  */
 
 import type { McpServerConfig } from '@openaidy/config';
-import type { McpServerTransport } from '@openaidy/shared-types';
+import type {
+  McpServerTransport,
+  McpServerImportEntry,
+} from '@openaidy/shared-types';
 
 /**
  * A raw MCP server entry in the keyed-map format. Transport may be given as
- * `type` or `transport`, or omitted and inferred.
+ * `type` or `transport`, or omitted and inferred. Shared with the web/CLI
+ * clients via {@link McpServerImportEntry}.
  */
-export type RawMcpServerEntry = {
-  type?: string;
-  transport?: string;
-  name?: string;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
-};
+export type RawMcpServerEntry = McpServerImportEntry;
 
 /** The standard `mcpServers` map: server id → entry. */
 export type RawMcpServerMap = Record<string, RawMcpServerEntry>;

--- a/apps/web/src/components/pages/McpsPage.tsx
+++ b/apps/web/src/components/pages/McpsPage.tsx
@@ -7,11 +7,13 @@ import {
   deleteMcpServer,
   connectMcpServer,
   disconnectMcpServer,
+  importMcpServers,
   type McpServerRecord,
 } from '../../lib/api';
 import type {
   CreateMcpServerRequest,
   UpdateMcpServerRequest,
+  ImportMcpServersRequest,
 } from '../../lib/api';
 
 function StatusBadge(props: { connected: boolean }) {
@@ -302,6 +304,122 @@ function ServerFormModal(props: {
   );
 }
 
+const IMPORT_PLACEHOLDER = `{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}`;
+
+function ImportModal(props: {
+  onImport: (body: ImportMcpServersRequest) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [text, setText] = createSignal('');
+  const [importing, setImporting] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const handleImport = async () => {
+    setError(null);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text());
+    } catch {
+      setError('Invalid JSON — paste a valid MCP server config.');
+      return;
+    }
+
+    // Accept either the standard `{ "mcpServers": { … } }` wrapper or a bare
+    // `{ "<id>": { … } }` map.
+    const map =
+      parsed && typeof parsed === 'object' && 'mcpServers' in parsed
+        ? (parsed as { mcpServers: unknown }).mcpServers
+        : parsed;
+
+    if (!map || typeof map !== 'object' || Array.isArray(map)) {
+      setError('Expected an object mapping server ids to their config.');
+      return;
+    }
+
+    setImporting(true);
+    try {
+      await props.onImport({
+        mcpServers: map as ImportMcpServersRequest['mcpServers'],
+      });
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to import servers');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div class="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Import MCP Servers
+          </h2>
+          <button
+            onClick={props.onClose}
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div class="p-4 space-y-3">
+          <Show when={error()}>
+            <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+              {error()}
+            </div>
+          </Show>
+
+          <p class="text-sm text-text-secondary">
+            Paste a standard MCP config (Claude Desktop / VS Code / Cursor).
+            Secrets stay safe: reference them with{' '}
+            <code class="text-xs px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">
+              ${'{ENV_VAR}'}
+            </code>{' '}
+            placeholders resolved from the server environment.
+          </p>
+
+          <textarea
+            value={text()}
+            onInput={(e) => setText(e.currentTarget.value)}
+            placeholder={IMPORT_PLACEHOLDER}
+            rows={12}
+            class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+          />
+        </div>
+
+        <div class="flex items-center justify-end gap-3 p-4 border-t dark:border-gray-700">
+          <button
+            onClick={props.onClose}
+            class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleImport()}
+            disabled={importing() || !text().trim()}
+            class="px-4 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {importing() ? 'Importing…' : 'Import'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ConfirmDeleteModal(props: {
   server: McpServerRecord;
   onConfirm: () => Promise<void>;
@@ -380,6 +498,7 @@ export function McpsPage() {
   const [showDelete, setShowDelete] = createSignal<McpServerRecord | null>(
     null,
   );
+  const [showImport, setShowImport] = createSignal(false);
 
   const selected = createMemo(() =>
     servers().find((s) => s.id === selectedId()),
@@ -472,6 +591,12 @@ export function McpsPage() {
     }
   };
 
+  const handleImport = async (body: ImportMcpServersRequest) => {
+    await importMcpServers(body);
+    // Refetch so the list reflects the newly imported + connected servers.
+    await loadServers();
+  };
+
   const connectedCount = () => servers().filter((s) => s.connected).length;
   const totalTools = () =>
     servers()
@@ -483,12 +608,20 @@ export function McpsPage() {
       title="MCP Servers"
       description="Manage Model Context Protocol server connections"
       actions={
-        <button
-          onClick={() => setShowForm({ mode: 'create' })}
-          class="flex items-center gap-2 px-3 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
-        >
-          + Add Server
-        </button>
+        <div class="flex items-center gap-2">
+          <button
+            onClick={() => setShowImport(true)}
+            class="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Import
+          </button>
+          <button
+            onClick={() => setShowForm({ mode: 'create' })}
+            class="flex items-center gap-2 px-3 py-2 text-sm text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            + Add Server
+          </button>
+        </div>
       }
     >
       {/* Action-level error banner */}
@@ -845,6 +978,13 @@ export function McpsPage() {
           server={showDelete()!}
           onConfirm={handleDelete}
           onClose={() => setShowDelete(null)}
+        />
+      </Show>
+
+      <Show when={showImport()}>
+        <ImportModal
+          onImport={handleImport}
+          onClose={() => setShowImport(false)}
         />
       </Show>
     </Layout>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -65,6 +65,7 @@ export type {
   McpToolWithSchema,
   CreateMcpServerRequest,
   UpdateMcpServerRequest,
+  ImportMcpServersRequest,
   ChannelStatusResponse,
 } from './types';
 
@@ -110,6 +111,7 @@ import type {
   McpToolWithSchema,
   CreateMcpServerRequest,
   UpdateMcpServerRequest,
+  ImportMcpServersRequest,
   ChannelStatusResponse,
 } from './types';
 
@@ -701,6 +703,26 @@ export async function createMcpServer(
   if (!response.ok) {
     const body = (await response.json().catch(() => ({}))) as ApiError;
     throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Import one or more MCP servers from the standard keyed-map config format
+ * (Claude Desktop / VS Code / Cursor). Atomic on the server: nothing is
+ * imported if any entry is invalid or any id already exists.
+ */
+export async function importMcpServers(
+  body: ImportMcpServersRequest,
+): Promise<{ servers: McpServerRecord[] }> {
+  const response = await apiFetch(`${API_BASE}/api/mcp/servers/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as ApiError;
+    throw new ApiRequestError(response.status, errBody);
   }
   return response.json();
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -22,6 +22,7 @@ export type {
   McpToolWithSchema,
   CreateMcpServerRequest,
   UpdateMcpServerRequest,
+  ImportMcpServersRequest,
   ChannelStatusResponse,
   Session,
   MessageRole,

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -593,6 +593,28 @@ openaidy sessions runs <sessionId>
 
 ---
 
+### `mcp` - MCP Server Management
+
+Commands for managing Model Context Protocol servers.
+
+#### `mcp import`
+
+Import one or more MCP servers from a standard config file (or stdin) in the
+keyed-map format used by Claude Desktop, VS Code and Cursor. Accepts either the
+full `{ "mcpServers": { … } }` wrapper or a bare `{ "<id>": { … } }` map;
+transport is taken from `type`/`transport` or inferred from `command`/`url`.
+Reference secrets with `${ENV_VAR}` placeholders — they are resolved from the
+server environment at connection time and never persisted in plaintext.
+
+```bash
+openaidy mcp import ./mcp.json
+cat ~/.config/mcp.json | openaidy mcp import
+```
+
+Requires an admin token.
+
+---
+
 ### `providers` - Provider Management
 
 Commands for managing LLM provider connections.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -990,3 +990,32 @@ registerCommand(
     examples: ['pnpm openaidy providers disconnect openai'],
   },
 );
+
+// MCP commands
+registerGroup({
+  name: 'mcp',
+  description: 'Manage Model Context Protocol servers',
+  commands: {
+    'mcp import': {
+      description: 'Import MCP servers from a standard config file or stdin',
+      usage: 'openaidy mcp import [file]',
+      examples: [
+        'openaidy mcp import ./mcp.json',
+        'cat ~/.config/mcp.json | openaidy mcp import',
+      ],
+    },
+  },
+});
+
+registerCommand(
+  'mcp import',
+  async (args: string[]) => {
+    const { mcpImportHandler } = await import('./mcp/import.js');
+    return mcpImportHandler(args);
+  },
+  {
+    description: 'Import MCP servers from a standard config file or stdin',
+    usage: 'openaidy mcp import [file]',
+    examples: ['openaidy mcp import ./mcp.json'],
+  },
+);

--- a/packages/cli/src/commands/mcp/import.test.ts
+++ b/packages/cli/src/commands/mcp/import.test.ts
@@ -1,0 +1,143 @@
+/**
+ * MCP Import Command Tests
+ *
+ * Mocks @clack/prompts, admin-token, node:fs/promises and global fetch so the
+ * handler can be exercised without a real server or file system.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mockClack = vi.hoisted(() => ({
+  log: { error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+vi.mock('@clack/prompts', () => mockClack);
+
+const mockReadAdminToken = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ ok: true, token: 'fake-token' })),
+);
+vi.mock('../../lib/admin-token.js', () => ({
+  readAdminToken: mockReadAdminToken,
+}));
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+vi.mock('node:fs/promises', () => ({ readFile: mockReadFile }));
+
+function mockFetchJson(data: unknown, status = 200) {
+  return vi.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'STATUS',
+      json: () => Promise.resolve(data),
+    }),
+  ) as unknown as typeof fetch;
+}
+
+const originalServerUrl = process.env.OPENAIDY_SERVER_URL;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClack.spinner.mockReturnValue({ start: vi.fn(), stop: vi.fn() });
+  mockReadAdminToken.mockResolvedValue({ ok: true, token: 'fake-token' });
+  process.env.OPENAIDY_SERVER_URL = 'http://localhost:3001';
+});
+
+afterEach(() => {
+  process.env.OPENAIDY_SERVER_URL = originalServerUrl ?? '';
+});
+
+const { mcpImportHandler } = await import('./import.js');
+
+const GITHUB_CONFIG = JSON.stringify({
+  mcpServers: {
+    github: {
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+    },
+  },
+});
+
+describe('mcp import', () => {
+  it('shows help with --help and exits 0', async () => {
+    const result = await mcpImportHandler(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(mockClack.note).toHaveBeenCalled();
+  });
+
+  it('posts the config to /api/mcp/servers/import and exits 0', async () => {
+    mockReadFile.mockResolvedValue(GITHUB_CONFIG);
+    global.fetch = mockFetchJson({
+      servers: [
+        { id: 'github', transport: 'http', connected: true, toolCount: 3 },
+      ],
+    });
+
+    const result = await mcpImportHandler(['./mcp.json']);
+
+    expect(result.exitCode).toBe(0);
+    const [url, init] = (
+      global.fetch as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:3001/api/mcp/servers/import');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.mcpServers.github.type).toBe('http');
+  });
+
+  it('accepts a bare map without the mcpServers wrapper', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({ github: { type: 'http', url: 'https://e.com/mcp' } }),
+    );
+    global.fetch = mockFetchJson({
+      servers: [
+        { id: 'github', transport: 'http', connected: false, toolCount: 0 },
+      ],
+    });
+
+    const result = await mcpImportHandler(['./mcp.json']);
+    expect(result.exitCode).toBe(0);
+    const [, init] = (
+      global.fetch as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] as [string, RequestInit];
+    // Wrapped into { mcpServers } before sending.
+    expect(JSON.parse(init.body as string).mcpServers.github).toBeDefined();
+  });
+
+  it('exits 2 on invalid JSON', async () => {
+    mockReadFile.mockResolvedValue('{ not json');
+    const result = await mcpImportHandler(['./mcp.json']);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 2 when the config is not an object map', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify(['a', 'b']));
+    const result = await mcpImportHandler(['./mcp.json']);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 1 with the server message when the import is rejected', async () => {
+    mockReadFile.mockResolvedValue(GITHUB_CONFIG);
+    global.fetch = mockFetchJson(
+      { error: 'CONFLICT', message: 'MCP server(s) already exist: github' },
+      409,
+    );
+
+    const result = await mcpImportHandler(['./mcp.json']);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain('already exist');
+  });
+
+  it('exits 1 when not authenticated', async () => {
+    mockReadFile.mockResolvedValue(GITHUB_CONFIG);
+    mockReadAdminToken.mockResolvedValueOnce({
+      ok: false,
+      error: 'No admin token found',
+    });
+    const result = await mcpImportHandler(['./mcp.json']);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toBe('No admin token found');
+  });
+});

--- a/packages/cli/src/commands/mcp/import.ts
+++ b/packages/cli/src/commands/mcp/import.ts
@@ -1,0 +1,162 @@
+/**
+ * MCP Import Command Handler
+ *
+ * Implements `openaidy mcp import [file]`.
+ *
+ * Reads a standard MCP config in the keyed-map format (Claude Desktop /
+ * VS Code / Cursor) from a file argument or stdin and POSTs it to
+ * POST /api/mcp/servers/import. Secrets are referenced with ${ENV_VAR}
+ * placeholders and resolved server-side from the server environment.
+ */
+
+import * as p from '@clack/prompts';
+import { readFile } from 'node:fs/promises';
+import { readAdminToken } from '../../lib/admin-token.js';
+import { resolveCLIConfig } from '../../lib/config.js';
+import type { CommandResult } from '../../types.js';
+import type { ImportMcpServersRequest } from '@openaidy/shared-types';
+
+/** Read all of stdin as a UTF-8 string (for `… | openaidy mcp import`). */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export async function mcpImportHandler(args: string[]): Promise<CommandResult> {
+  if (args.includes('-h') || args.includes('--help')) {
+    p.note(
+      `Usage: openaidy mcp import [file]
+
+Import one or more MCP servers from a standard config file (or stdin).
+Accepts the keyed-map format used by Claude Desktop, VS Code and Cursor —
+either the full { "mcpServers": { … } } wrapper or a bare { "<id>": { … } }
+map. Transport is taken from "type"/"transport" or inferred from command/url.
+
+Reference secrets with \${ENV_VAR} placeholders; they are resolved from the
+server environment at connection time and never persisted in plaintext.
+
+Arguments:
+  file    Path to a JSON config file. Omit (or use "-") to read from stdin.
+
+Examples:
+  openaidy mcp import ./mcp.json
+  cat ~/.config/mcp.json | openaidy mcp import
+
+Exit Codes:
+  0  Servers imported successfully
+  1  Server unreachable, not authenticated, or import rejected
+  2  Missing/invalid input`,
+      'mcp import',
+    );
+    return { exitCode: 0 };
+  }
+
+  const fileArg = args.find((a) => !a.startsWith('-'));
+
+  // Load raw config from the file argument, or stdin when omitted / "-".
+  let raw: string;
+  try {
+    raw =
+      fileArg && fileArg !== '-'
+        ? await readFile(fileArg, 'utf8')
+        : await readStdin();
+  } catch (err) {
+    const msg = `Cannot read config: ${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 2, error: msg };
+  }
+
+  if (!raw.trim()) {
+    const msg = 'No config provided. Pass a file path or pipe JSON via stdin.';
+    p.log.error(msg);
+    return { exitCode: 2, error: msg };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const msg = 'Invalid JSON in MCP config.';
+    p.log.error(msg);
+    return { exitCode: 2, error: msg };
+  }
+
+  // Accept the standard `{ "mcpServers": { … } }` wrapper or a bare map.
+  const map =
+    parsed && typeof parsed === 'object' && 'mcpServers' in parsed
+      ? (parsed as { mcpServers: unknown }).mcpServers
+      : parsed;
+
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    const msg = 'Expected an object mapping server ids to their config.';
+    p.log.error(msg);
+    return { exitCode: 2, error: msg };
+  }
+
+  const config = resolveCLIConfig();
+  const token = await readAdminToken(config.tokenPath);
+  if (!token.ok) {
+    p.log.error(token.error);
+    return { exitCode: 1, error: token.error };
+  }
+
+  const body: ImportMcpServersRequest = {
+    mcpServers: map as ImportMcpServersRequest['mcpServers'],
+  };
+
+  const s = p.spinner();
+  s.start('Importing MCP servers…');
+
+  let res: Response;
+  try {
+    res = await fetch(`${config.httpUrl}/api/mcp/servers/import`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    s.stop('Failed.');
+    const msg = `Cannot reach server at ${config.httpUrl}.\n${err instanceof Error ? err.message : String(err)}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  if (!res.ok) {
+    s.stop('Failed.');
+    const errBody = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      message?: string;
+    };
+    const msg =
+      errBody.message ?? `Server returned ${res.status}: ${res.statusText}`;
+    p.log.error(msg);
+    return { exitCode: 1, error: msg };
+  }
+
+  const { servers } = (await res.json()) as {
+    servers: Array<{
+      id: string;
+      transport: string;
+      connected: boolean;
+      toolCount: number;
+    }>;
+  };
+
+  s.stop(
+    `Imported ${servers.length} MCP server${servers.length !== 1 ? 's' : ''}.`,
+  );
+  for (const srv of servers) {
+    const status = srv.connected
+      ? `connected · ${srv.toolCount} tool${srv.toolCount !== 1 ? 's' : ''}`
+      : 'not connected';
+    p.log.success(`✓ ${srv.id} (${srv.transport}) — ${status}`);
+  }
+
+  return { exitCode: 0 };
+}

--- a/packages/shared-types/src/mcp.ts
+++ b/packages/shared-types/src/mcp.ts
@@ -63,3 +63,29 @@ export type McpToolWithSchema = {
   description?: string | undefined;
   inputSchema: Record<string, unknown>;
 };
+
+/**
+ * A single MCP server entry in the widely-used keyed-map config format
+ * (Claude Desktop / VS Code / Cursor). Transport may be given as `type` or
+ * `transport`, or omitted and inferred from `command` (stdio) vs `url` (http).
+ * Values are intentionally permissive strings — the server normalises and
+ * validates them.
+ */
+export type McpServerImportEntry = {
+  type?: string | undefined;
+  transport?: string | undefined;
+  name?: string | undefined;
+  command?: string | undefined;
+  args?: string[] | undefined;
+  env?: Record<string, string> | undefined;
+  url?: string | undefined;
+  headers?: Record<string, string> | undefined;
+};
+
+/**
+ * Request body for POST /mcp/servers/import — the standard `mcpServers` map
+ * keyed by server id.
+ */
+export type ImportMcpServersRequest = {
+  mcpServers: Record<string, McpServerImportEntry>;
+};


### PR DESCRIPTION
## Summary
Follow-up to the MCP HTTP/secrets work (#345). Adds two clients for the existing `POST /mcp/servers/import` endpoint so a standard MCP config (Claude Desktop / VS Code / Cursor) can be imported without hand-crafting requests.

## Web UI
- `importMcpServers()` API client + an **Import** modal on the MCP page.
- Accepts the full `{ "mcpServers": … }` wrapper **or** a bare `id→config` map; refetches the list on success; surfaces server errors (400/409).

## CLI
- **`openaidy mcp import [file]`** — reads a config from a file arg or **stdin**, wraps a bare map, POSTs with the admin token.
- Clear exit codes: `0` ok / `1` server-or-auth / `2` bad input. Registered under a new `mcp` group and documented in the command reference.

## Shared types / cleanup
- New `ImportMcpServersRequest` / `McpServerImportEntry` in `@openaidy/shared-types` — now the single definition also backing the server's `config-import` module (removes the duplicated raw-entry type).

## Tests
- CLI handler: happy path, bare map, invalid JSON, non-object, server rejection, unauthenticated.
- Doc-validation passes (new command documented).
- server / cli / web typecheck; web (349) + affected suites green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)