### PR TITLE
fix(providers): run the bundled mmx-cli for MiniMax OAuth

### DIFF
--- a/apps/server/src/providers/oauth/cli-bridge.test.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shQuote, buildPtyCommand } from './cli-bridge';
+import { shQuote, buildPtyCommand, buildSpawnArgs } from './cli-bridge';
 
 /**
  * Unit tests for the shell-quoting used to build the command string
@@ -54,5 +54,48 @@ describe('buildPtyCommand', () => {
 
   it('handles an empty argv (just the binary)', () => {
     expect(buildPtyCommand('mmx', [])).toBe(`'mmx'`);
+  });
+});
+
+describe('buildSpawnArgs', () => {
+  const argv = [
+    '/opt/mmx-cli/dist/mmx.mjs',
+    'auth',
+    'login',
+    '--region=global',
+  ];
+
+  it('wraps the CLI in a `script` PTY on Linux', () => {
+    const { file, args } = buildSpawnArgs('/usr/bin/node', argv, 'linux');
+    expect(file).toBe('script');
+    expect(args[0]).toBe('-qec');
+    expect(args[2]).toBe('/dev/null');
+    // The command is the shell-quoted single string.
+    expect(args[1]).toBe(buildPtyCommand('/usr/bin/node', argv));
+  });
+
+  it('wraps the CLI in a `script` PTY on macOS', () => {
+    const { file } = buildSpawnArgs('/usr/bin/node', argv, 'darwin');
+    expect(file).toBe('script');
+  });
+
+  it('spawns the CLI directly on Windows (no `script`, no /dev/null)', () => {
+    const { file, args } = buildSpawnArgs('C:\\node\\node.exe', argv, 'win32');
+    // Regression guard: Windows has no script(1) — spawning it would
+    // ENOENT and turn a clean flow into a confusing error.
+    expect(file).toBe('C:\\node\\node.exe');
+    expect(file).not.toBe('script');
+    // argv is passed straight through (spawn quotes natively on Windows).
+    expect(args).toEqual(argv);
+    expect(args).not.toContain('/dev/null');
+  });
+
+  it('does not shell-quote on Windows, preserving spaced paths as one arg', () => {
+    const { args } = buildSpawnArgs(
+      'C:\\Program Files\\node\\node.exe',
+      ['C:\\my apps\\mmx.mjs', 'auth'],
+      'win32',
+    );
+    expect(args).toEqual(['C:\\my apps\\mmx.mjs', 'auth']);
   });
 });

--- a/apps/server/src/providers/oauth/cli-bridge.test.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { shQuote, buildPtyCommand } from './cli-bridge';
+
+/**
+ * Unit tests for the shell-quoting used to build the command string
+ * handed to `script -qec`. The command is re-parsed by a shell, so
+ * tokens that contain spaces or metacharacters must survive intact —
+ * this is what lets us invoke an absolute node path plus a bundled
+ * script path (see mmx-bridge's resolveMmxInvocation).
+ */
+
+describe('shQuote', () => {
+  it('wraps a plain token in single quotes', () => {
+    expect(shQuote('mmx')).toBe(`'mmx'`);
+  });
+
+  it('preserves spaces so a path is passed as one argument', () => {
+    expect(shQuote('/opt/Program Files/node')).toBe(
+      `'/opt/Program Files/node'`,
+    );
+  });
+
+  it('neutralizes shell metacharacters', () => {
+    // Without quoting these would be interpreted by the shell.
+    expect(shQuote('a;rm -rf b')).toBe(`'a;rm -rf b'`);
+    expect(shQuote('$(whoami)')).toBe(`'$(whoami)'`);
+    expect(shQuote('a b && c')).toBe(`'a b && c'`);
+  });
+
+  it("escapes an embedded single quote as '\\''", () => {
+    // POSIX has no way to escape ' inside '...'; you close, emit an
+    // escaped ', and reopen: it's -> 'it'\''s'
+    expect(shQuote("it's")).toBe(`'it'\\''s'`);
+  });
+});
+
+describe('buildPtyCommand', () => {
+  it('quotes every token including the binary', () => {
+    expect(buildPtyCommand('mmx', ['auth', 'login', '--recommend'])).toBe(
+      `'mmx' 'auth' 'login' '--recommend'`,
+    );
+  });
+
+  it('keeps a spaced node path and script path as two separate args', () => {
+    const cmd = buildPtyCommand('/usr/bin/node', [
+      '/opt/my apps/mmx-cli/dist/mmx.mjs',
+      'auth',
+      'login',
+    ]);
+    expect(cmd).toBe(
+      `'/usr/bin/node' '/opt/my apps/mmx-cli/dist/mmx.mjs' 'auth' 'login'`,
+    );
+  });
+
+  it('handles an empty argv (just the binary)', () => {
+    expect(buildPtyCommand('mmx', [])).toBe(`'mmx'`);
+  });
+});

--- a/apps/server/src/providers/oauth/cli-bridge.test.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.test.ts
@@ -74,9 +74,16 @@ describe('buildSpawnArgs', () => {
     expect(args[1]).toBe(buildPtyCommand('/usr/bin/node', argv));
   });
 
-  it('wraps the CLI in a `script` PTY on macOS', () => {
-    const { file } = buildSpawnArgs('/usr/bin/node', argv, 'darwin');
+  it('wraps the CLI in a BSD `script` PTY on macOS (command as argv, not `-qec`)', () => {
+    const { file, args } = buildSpawnArgs('/usr/bin/node', argv, 'darwin');
     expect(file).toBe('script');
+    // BSD `script` (macOS) has no -c/-e: the command is trailing argv
+    // after the typescript file, run directly with no shell re-parse.
+    expect(args).toEqual(['-q', '/dev/null', '/usr/bin/node', ...argv]);
+    // Regression guard: the util-linux `-qec` string form errors out on
+    // macOS with "illegal option" before the CLI ever runs.
+    expect(args).not.toContain('-qec');
+    expect(args).not.toContain(buildPtyCommand('/usr/bin/node', argv));
   });
 
   it('spawns the CLI directly on Windows (no `script`, no /dev/null)', () => {

--- a/apps/server/src/providers/oauth/cli-bridge.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.ts
@@ -205,14 +205,16 @@ export function spawnCliOAuth(
       const argv = descriptor.args(
         options.extraArgs ? { extraArgs: options.extraArgs } : {},
       );
-      child = spawn(
-        'script',
-        ['-qec', `${descriptor.binary} ${argv.join(' ')}`, '/dev/null'],
-        {
-          env: childEnv,
-          stdio: ['ignore', 'pipe', 'pipe'],
-        },
-      );
+      // `script -qec` takes a single command STRING that a shell parses,
+      // so every token must be shell-quoted. This matters now that the
+      // binary can be an absolute path to node plus a bundled script
+      // path (see mmx-bridge's resolveMmxInvocation) — either of which
+      // may contain spaces on some systems.
+      const command = [descriptor.binary, ...argv].map(shQuote).join(' ');
+      child = spawn('script', ['-qec', command, '/dev/null'], {
+        env: childEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
     } catch (err) {
       rejectUserCode(err instanceof Error ? err : new Error(String(err)));
       finish({
@@ -369,6 +371,16 @@ export function spawnCliOAuth(
       }
     },
   };
+}
+
+/**
+ * POSIX shell single-quote a token so `script -qec "<command>"` passes
+ * it through unmangled even when it contains spaces or metacharacters.
+ * Wraps in single quotes and escapes any embedded single quote as
+ * `'\''`.
+ */
+function shQuote(token: string): string {
+  return `'${token.replace(/'/g, `'\\''`)}'`;
 }
 
 /**

--- a/apps/server/src/providers/oauth/cli-bridge.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.ts
@@ -205,12 +205,7 @@ export function spawnCliOAuth(
       const argv = descriptor.args(
         options.extraArgs ? { extraArgs: options.extraArgs } : {},
       );
-      // `script -qec` takes a single command STRING that a shell parses,
-      // so every token must be shell-quoted. This matters now that the
-      // binary can be an absolute path to node plus a bundled script
-      // path (see mmx-bridge's resolveMmxInvocation) — either of which
-      // may contain spaces on some systems.
-      const command = [descriptor.binary, ...argv].map(shQuote).join(' ');
+      const command = buildPtyCommand(descriptor.binary, argv);
       child = spawn('script', ['-qec', command, '/dev/null'], {
         env: childEnv,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -378,9 +373,24 @@ export function spawnCliOAuth(
  * it through unmangled even when it contains spaces or metacharacters.
  * Wraps in single quotes and escapes any embedded single quote as
  * `'\''`.
+ *
+ * Exported for unit testing.
  */
-function shQuote(token: string): string {
+export function shQuote(token: string): string {
   return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the single command string handed to `script -qec`, which a
+ * shell re-parses. Every token is shell-quoted because the binary can
+ * be an absolute path to node plus a bundled script path (see
+ * mmx-bridge's resolveMmxInvocation) — either of which may contain
+ * spaces on some systems.
+ *
+ * Exported for unit testing.
+ */
+export function buildPtyCommand(binary: string, argv: string[]): string {
+  return [binary, ...argv].map(shQuote).join(' ');
 }
 
 /**

--- a/apps/server/src/providers/oauth/cli-bridge.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.ts
@@ -187,8 +187,11 @@ export function spawnCliOAuth(
       });
     });
 
-    // 2. Spawn the CLI inside a pseudo-TTY so it enters the interactive
-    //    (browser) flow. `script(1)` (util-linux) provides the PTY.
+    // 2. Spawn the CLI so it enters the interactive (browser) flow.
+    //    On POSIX we wrap it in a pseudo-TTY via `script(1)` (util-linux)
+    //    because the CLI drops to non-interactive mode without a TTY.
+    //    Windows has no `script`, so we spawn the CLI directly — see
+    //    buildSpawnArgs for the platform split.
     try {
       const childEnv: NodeJS.ProcessEnv = { ...process.env };
       for (const key of descriptor.envVarsToStrip) {
@@ -205,8 +208,8 @@ export function spawnCliOAuth(
       const argv = descriptor.args(
         options.extraArgs ? { extraArgs: options.extraArgs } : {},
       );
-      const command = buildPtyCommand(descriptor.binary, argv);
-      child = spawn('script', ['-qec', command, '/dev/null'], {
+      const { file, args } = buildSpawnArgs(descriptor.binary, argv);
+      child = spawn(file, args, {
         env: childEnv,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
@@ -391,6 +394,37 @@ export function shQuote(token: string): string {
  */
 export function buildPtyCommand(binary: string, argv: string[]): string {
   return [binary, ...argv].map(shQuote).join(' ');
+}
+
+/**
+ * Resolve the actual `spawn(file, args)` for the current platform.
+ *
+ * POSIX wraps the CLI in `script -qec "<command>" /dev/null` to give it
+ * a pseudo-TTY (many CLIs, mmx included, fall back to non-interactive
+ * mode without one). Windows has no `script(1)` and no `/dev/null`, so
+ * we spawn the CLI directly with an argv array — spawn handles spaces
+ * natively there, so no shell quoting is involved. The interactive
+ * region prompt is avoided by passing `--region` as a flag, and the
+ * device-code/browser flow needs no stdin, so the CLI can still print
+ * its user_code. If a CLI insists on a TTY it will exit non-zero and
+ * surface a clear error rather than a confusing `spawn script ENOENT`.
+ *
+ * `platform` is injectable for unit testing; it defaults to the host.
+ *
+ * Exported for unit testing.
+ */
+export function buildSpawnArgs(
+  binary: string,
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): { file: string; args: string[] } {
+  if (platform === 'win32') {
+    return { file: binary, args: argv };
+  }
+  return {
+    file: 'script',
+    args: ['-qec', buildPtyCommand(binary, argv), '/dev/null'],
+  };
 }
 
 /**

--- a/apps/server/src/providers/oauth/cli-bridge.ts
+++ b/apps/server/src/providers/oauth/cli-bridge.ts
@@ -399,15 +399,26 @@ export function buildPtyCommand(binary: string, argv: string[]): string {
 /**
  * Resolve the actual `spawn(file, args)` for the current platform.
  *
- * POSIX wraps the CLI in `script -qec "<command>" /dev/null` to give it
- * a pseudo-TTY (many CLIs, mmx included, fall back to non-interactive
- * mode without one). Windows has no `script(1)` and no `/dev/null`, so
- * we spawn the CLI directly with an argv array — spawn handles spaces
- * natively there, so no shell quoting is involved. The interactive
- * region prompt is avoided by passing `--region` as a flag, and the
- * device-code/browser flow needs no stdin, so the CLI can still print
- * its user_code. If a CLI insists on a TTY it will exit non-zero and
- * surface a clear error rather than a confusing `spawn script ENOENT`.
+ * `script` wraps the CLI in a pseudo-TTY (many CLIs, mmx included, fall
+ * back to non-interactive mode without one), but the three platforms
+ * need different invocations:
+ *
+ * - **Linux** (util-linux `script`): the command is one string re-parsed
+ *   by a shell — `script -qec "<command>" /dev/null` — so every token is
+ *   shell-quoted via buildPtyCommand.
+ * - **macOS** (BSD `script`): has neither `-c` nor `-e`; it takes the
+ *   command as trailing argv after the typescript file and runs it
+ *   directly (no shell) — `script -q /dev/null <binary> <argv...>`, so no
+ *   quoting is needed. Using the Linux `-qec` form here fails with an
+ *   "illegal option" usage error before the CLI ever runs.
+ * - **Windows**: no `script(1)` and no `/dev/null`, so spawn the CLI
+ *   directly with an argv array (spawn quotes spaces natively).
+ *
+ * The interactive region prompt is avoided by passing `--region` as a
+ * flag, and the device-code/browser flow needs no stdin, so the CLI can
+ * still print its user_code. If a CLI insists on a TTY it will exit
+ * non-zero and surface a clear error rather than a confusing
+ * `spawn script ENOENT`.
  *
  * `platform` is injectable for unit testing; it defaults to the host.
  *
@@ -420,6 +431,9 @@ export function buildSpawnArgs(
 ): { file: string; args: string[] } {
   if (platform === 'win32') {
     return { file: binary, args: argv };
+  }
+  if (platform === 'darwin') {
+    return { file: 'script', args: ['-q', '/dev/null', binary, ...argv] };
   }
   return {
     file: 'script',

--- a/apps/server/src/providers/oauth/minimax.ts
+++ b/apps/server/src/providers/oauth/minimax.ts
@@ -93,8 +93,9 @@ export async function startMiniMaxOAuth(
       ok: false,
       error: 'mmx_not_installed',
       message:
-        'The mmx-cli tool is not on PATH. OpenAidy depends on it for MiniMax OAuth. ' +
-        'Install it with: pnpm add -g mmx-cli',
+        'The mmx-cli tool could not be found. OpenAidy bundles it as a ' +
+        'server dependency, so this usually means dependencies are not ' +
+        'installed — run: pnpm install',
     };
   }
 

--- a/apps/server/src/providers/oauth/mmx-bridge.test.ts
+++ b/apps/server/src/providers/oauth/mmx-bridge.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { resolveMmxInvocation, isMmxInstalled } from './mmx-bridge';
 import { buildPtyCommand } from './cli-bridge';
 
@@ -32,6 +34,23 @@ describe('resolveMmxInvocation', () => {
     const scriptPath = inv.prefixArgs[0]!;
     expect(scriptPath.endsWith('mmx.mjs')).toBe(true);
     expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  it('derives the entry from the package `bin` field, not a hardcoded path', () => {
+    // Guards against reverting to a hardcoded `dist/mmx.mjs`: the resolved
+    // script must match whatever mmx-cli declares in its own `bin`, so a
+    // future entry relocation is followed instead of silently missed.
+    const require = createRequire(import.meta.url);
+    const pkgJsonPath = require.resolve('mmx-cli/package.json');
+    const pkg = require(pkgJsonPath) as {
+      bin?: string | Record<string, string>;
+    };
+    const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.['mmx'];
+    expect(binRel).toBeTruthy();
+    const expected = join(dirname(pkgJsonPath), binRel!);
+
+    const inv = resolveMmxInvocation();
+    expect(inv.prefixArgs[0]).toBe(expected);
   });
 
   it('produces a shell command referencing node and the bundled script', () => {

--- a/apps/server/src/providers/oauth/mmx-bridge.test.ts
+++ b/apps/server/src/providers/oauth/mmx-bridge.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { resolveMmxInvocation, isMmxInstalled } from './mmx-bridge';
+import { buildPtyCommand } from './cli-bridge';
+
+/**
+ * Tests for the plug-and-play mmx resolution.
+ *
+ * `mmx-cli` is a declared dependency of `apps/server`, so `pnpm install`
+ * ships it into node_modules. These tests assert we invoke that bundled
+ * copy directly rather than a bare `mmx` on PATH (which pnpm never
+ * installs there — the regression this guards against).
+ *
+ * NOTE: unlike minimax.test.ts, this file does NOT mock mmx-bridge — it
+ * exercises the real resolution against the installed dependency.
+ */
+
+describe('resolveMmxInvocation', () => {
+  it('resolves the bundled mmx-cli instead of a bare PATH binary', () => {
+    const inv = resolveMmxInvocation();
+
+    // The whole point: not a bare `mmx` that relies on a global install.
+    expect(inv.binary).not.toBe('mmx');
+    // We run the bundled script with the current node executable.
+    expect(inv.binary).toBe(process.execPath);
+  });
+
+  it('points at an mmx.mjs script that actually exists on disk', () => {
+    const inv = resolveMmxInvocation();
+
+    expect(inv.prefixArgs).toHaveLength(1);
+    const scriptPath = inv.prefixArgs[0]!;
+    expect(scriptPath.endsWith('mmx.mjs')).toBe(true);
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  it('produces a shell command referencing node and the bundled script', () => {
+    const inv = resolveMmxInvocation();
+    const cmd = buildPtyCommand(inv.binary, [
+      ...inv.prefixArgs,
+      'auth',
+      'login',
+      '--recommend',
+    ]);
+
+    // Both paths are single-quoted (space-safe) and the mmx entry is present.
+    expect(cmd).toContain(`'${process.execPath}'`);
+    expect(cmd).toContain(`mmx.mjs'`);
+    expect(cmd).toContain(`'auth' 'login' '--recommend'`);
+  });
+});
+
+describe('isMmxInstalled', () => {
+  it('reports true when the bundled copy is present (no PATH probe needed)', async () => {
+    // The bundled dependency is present in this workspace, so this must
+    // resolve true without depending on a global `mmx` being installed.
+    await expect(isMmxInstalled()).resolves.toBe(true);
+  });
+});

--- a/apps/server/src/providers/oauth/mmx-bridge.ts
+++ b/apps/server/src/providers/oauth/mmx-bridge.ts
@@ -119,8 +119,10 @@ type MmxInvocation = { binary: string; prefixArgs: string[] };
  * flow should work immediately after install, with no extra manual
  * step. Falls back to a bare `mmx` on PATH if the bundled copy can't
  * be resolved for some reason.
+ *
+ * Exported for unit testing.
  */
-function resolveMmxInvocation(): MmxInvocation {
+export function resolveMmxInvocation(): MmxInvocation {
   try {
     const require = createRequire(import.meta.url);
     const pkgJsonPath = require.resolve('mmx-cli/package.json');

--- a/apps/server/src/providers/oauth/mmx-bridge.ts
+++ b/apps/server/src/providers/oauth/mmx-bridge.ts
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process';
 import { readFile, writeFile, chmod } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { homedir, userInfo } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   spawnCliOAuth,
   defaultIsInstalled,
@@ -103,14 +104,48 @@ export type SpawnMmxLoginOptions = MmxLoginOptions;
 export type MmxLoginHandle = CliOAuthHandle;
 
 /**
+ * How to invoke mmx: either the bundled copy shipped as an
+ * `apps/server` dependency (preferred — no separate install step) or
+ * a global `mmx` binary on PATH (fallback for anyone who already has
+ * one installed).
+ */
+type MmxInvocation = { binary: string; prefixArgs: string[] };
+
+/**
+ * OpenAidy is plug-and-play: `mmx-cli` is declared as a normal
+ * dependency of `apps/server` (see package.json) so `pnpm install`
+ * pulls it in automatically. Resolve its bundled entry script here
+ * instead of requiring a global `pnpm add -g mmx-cli` — the OAuth
+ * flow should work immediately after install, with no extra manual
+ * step. Falls back to a bare `mmx` on PATH if the bundled copy can't
+ * be resolved for some reason.
+ */
+function resolveMmxInvocation(): MmxInvocation {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkgJsonPath = require.resolve('mmx-cli/package.json');
+    const scriptPath = join(dirname(pkgJsonPath), 'dist', 'mmx.mjs');
+    if (existsSync(scriptPath)) {
+      return { binary: process.execPath, prefixArgs: [scriptPath] };
+    }
+  } catch {
+    // mmx-cli isn't resolvable from here — fall back to PATH lookup.
+  }
+  return { binary: 'mmx', prefixArgs: [] };
+}
+
+const mmxInvocation = resolveMmxInvocation();
+
+/**
  * The MiniMax-specific descriptor fed to the generic CLI bridge.
  * Kept private — callers go through `spawnMmxLogin` (which adds the
  * region flag and the MMX_CONFIG_DIR env var).
  */
 const mmxDescriptor: CliOAuthDescriptor = {
   providerId: 'minimax',
-  binary: 'mmx',
+  binary: mmxInvocation.binary,
   args: ({ extraArgs }) => [
+    ...mmxInvocation.prefixArgs,
     'auth',
     'login',
     '--recommend',
@@ -131,9 +166,11 @@ const mmxDescriptor: CliOAuthDescriptor = {
 };
 
 /**
- * Check whether mmx-cli is installed and on PATH.
+ * Check whether mmx is available: either the bundled copy resolved at
+ * module load, or a global `mmx` on PATH.
  */
 export async function isMmxInstalled(): Promise<boolean> {
+  if (mmxInvocation.binary !== 'mmx') return true;
   return defaultIsInstalled('mmx');
 }
 

--- a/apps/server/src/providers/oauth/mmx-bridge.ts
+++ b/apps/server/src/providers/oauth/mmx-bridge.ts
@@ -126,9 +126,22 @@ export function resolveMmxInvocation(): MmxInvocation {
   try {
     const require = createRequire(import.meta.url);
     const pkgJsonPath = require.resolve('mmx-cli/package.json');
-    const scriptPath = join(dirname(pkgJsonPath), 'dist', 'mmx.mjs');
-    if (existsSync(scriptPath)) {
-      return { binary: process.execPath, prefixArgs: [scriptPath] };
+    // Read the entry script from the package's own `bin` field rather than
+    // hardcoding `dist/mmx.mjs`. The two can drift across mmx-cli versions,
+    // and a silent miss here falls back to a (usually absent) global `mmx`,
+    // reintroducing the "not installed" failure this resolution prevents.
+    const pkg = require(pkgJsonPath) as {
+      bin?: string | Record<string, string>;
+    };
+    const binRel =
+      typeof pkg.bin === 'string'
+        ? pkg.bin
+        : (pkg.bin?.['mmx'] ?? Object.values(pkg.bin ?? {})[0]);
+    if (binRel) {
+      const scriptPath = join(dirname(pkgJsonPath), binRel);
+      if (existsSync(scriptPath)) {
+        return { binary: process.execPath, prefixArgs: [scriptPath] };
+      }
     }
   } catch {
     // mmx-cli isn't resolvable from here — fall back to PATH lookup.


### PR DESCRIPTION
## Problem

MiniMax OAuth delegates the device-code flow to the official `mmx-cli` (its auth `client_id` is only embedded in that binary). `mmx-cli` is **already** a declared dependency of `apps/server`, so `pnpm install` ships it — but the OAuth bridge invoked a **bare `mmx` on `PATH`** (`binary: 'mmx'`, `defaultIsInstalled('mmx')`).

pnpm never puts dependency bins on the global PATH — they live in `node_modules`. So on a fresh install the flow failed with **"mmx-cli is not on PATH"** and told the user to `pnpm add -g mmx-cli`. That defeats OpenAidy's plug-and-play goal.

## Changes

**`mmx-bridge.ts` — use the bundled copy**
- New `resolveMmxInvocation()`: resolves the bundled package via `createRequire(...).resolve('mmx-cli/package.json')` → `dist/mmx.mjs` and runs it with the current node (`process.execPath`).
- Falls back to a global `mmx` on PATH only if the bundled copy can't be resolved.
- `isMmxInstalled()` returns `true` immediately when the bundled copy is present.

**`cli-bridge.ts` — cross-platform spawn + safe quoting**
- The `script -qec` PTY wrapper takes a single command **string** that a shell re-parses. Added `shQuote()` + `buildPtyCommand()` and quote every token (the command is now an absolute node path + bundled script path, either may contain spaces).
- **Windows:** `script(1)` and `/dev/null` are Unix-only. Since `isMmxInstalled()` now returns true on Windows too, the old code would proceed and then die with a confusing `spawn script ENOENT`. New `buildSpawnArgs(binary, argv, platform)` spawns the CLI **directly** on `win32` (argv array, spawn quotes natively) and keeps the `script` PTY on POSIX. Region is passed as a flag and the browser flow needs no stdin, so the CLI can still print its user_code without a TTY; if it insists on one it now fails with a clear error instead of ENOENT.

**`minimax.ts`**
- Updated the stale `mmx_not_installed` message (was "install with `pnpm add -g mmx-cli`" → now "run `pnpm install`").

## Tests

New regression coverage (the existing `minimax.test.ts` mocks `mmx-bridge` entirely, so none of this logic was exercised before):

- **`mmx-bridge.test.ts`** — `resolveMmxInvocation` resolves the bundled copy (not a bare `mmx`), points at an `mmx.mjs` that exists on disk; `isMmxInstalled()` true without a PATH probe. Does **not** mock the bridge.
- **`cli-bridge.test.ts`** — `shQuote` / `buildPtyCommand` quoting; `buildSpawnArgs` platform split (Linux/macOS → `script` PTY; Windows → direct spawn, no `script`, no shell-quoting).

`shQuote`, `buildPtyCommand`, `buildSpawnArgs`, and `resolveMmxInvocation` are exported for testing (no behavior change).

## Verification

- On a machine with **no global `mmx`**, `isMmxInstalled()` → `true` (bundled copy).
- Bundled `dist/mmx.mjs` runs under node → `mmx 1.0.16`.
- `pnpm --filter @openaidy/server build` (typecheck) ✅, `lint` ✅, oauth suite **26/26** ✅.

## Net effect

A fresh `pnpm install` (via `install.sh` **or** `install.ps1`, both of which clone `main` + build from source) gives a working MiniMax OAuth setup with no separate global CLI install. On Windows the flow at least attempts the real spawn and fails cleanly if a TTY is required, instead of a confusing `spawn script ENOENT`.

## Follow-up (not in this PR)

If mmx turns out to require a real TTY on Windows, a follow-up could add a ConPTY (node-pty) — deferred to avoid a heavy native dependency in the self-provisioning installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)