### PR TITLE
feat(skills): add default engineering and action-oriented skills

### DIFF
--- a/apps/server/src/skills/parser.test.ts
+++ b/apps/server/src/skills/parser.test.ts
@@ -96,6 +96,21 @@ describe('parseSkillMd', () => {
     });
   });
 
+  it('leaves a value with the same quote reappearing inside untouched', () => {
+    const content = [
+      '---',
+      'name: Plain',
+      'description: "foo" or "bar"',
+      '---',
+      'Body.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'plain', '/path/to/SKILL.md');
+
+    // Not a single quoted scalar — must not be mangled into `foo" or "bar`.
+    expect(result).toMatchObject({ description: '"foo" or "bar"' });
+  });
+
   it('leaves an unquoted description untouched', () => {
     const content = [
       '---',

--- a/apps/server/src/skills/parser.test.ts
+++ b/apps/server/src/skills/parser.test.ts
@@ -62,6 +62,54 @@ describe('parseSkillMd', () => {
     });
   });
 
+  it('strips surrounding single quotes from name and description', () => {
+    const content = [
+      '---',
+      "name: 'Quoted Skill'",
+      "description: 'Do the thing, then the other thing.'",
+      '---',
+      'Body.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'quoted', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      name: 'Quoted Skill',
+      description: 'Do the thing, then the other thing.',
+    });
+  });
+
+  it('strips surrounding double quotes but preserves inner quotes', () => {
+    const content = [
+      '---',
+      'name: "Reviewer"',
+      'description: "Review the user\'s diff for bugs"',
+      '---',
+      'Body.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'reviewer', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({
+      name: 'Reviewer',
+      description: "Review the user's diff for bugs",
+    });
+  });
+
+  it('leaves an unquoted description untouched', () => {
+    const content = [
+      '---',
+      'name: Plain',
+      'description: No quotes here',
+      '---',
+      'Body.',
+    ].join('\n');
+
+    const result = parseSkillMd(content, 'plain', '/path/to/SKILL.md');
+
+    expect(result).toMatchObject({ description: 'No quotes here' });
+  });
+
   it('returns error when name is missing', () => {
     const content = [
       '---',

--- a/apps/server/src/skills/parser.ts
+++ b/apps/server/src/skills/parser.ts
@@ -14,15 +14,23 @@ import { isBodySizeValid } from './sanitize.js';
  * The frontmatter is read by line-scan rather than a real YAML parser, so
  * a quoted value like `description: 'Do the thing.'` would otherwise keep
  * its quotes literally and surface them in the UI and in skill-selection
- * prompts. Only an outer pair of matching `'` or `"` is removed; inner
- * quotes are left untouched.
+ * prompts. Only an outer pair of matching `'` or `"` wrapping a genuine
+ * single quoted scalar is removed — a value in which that quote char
+ * reappears (e.g. `"foo" or "bar"`) is left untouched. Quotes of the
+ * other kind (the apostrophe in `"it's"`) are always preserved.
  */
 function unquote(value: string): string {
   if (value.length >= 2) {
     const first = value[0];
     const last = value[value.length - 1];
     if ((first === '"' || first === "'") && last === first) {
-      return value.slice(1, -1);
+      const inner = value.slice(1, -1);
+      // Only unwrap a genuine single quoted scalar. If the same quote char
+      // reappears inside, this isn't one (e.g. `"foo" or "bar"`) — leave it
+      // untouched rather than mangle it into `foo" or "bar`.
+      if (!inner.includes(first)) {
+        return inner;
+      }
     }
   }
   return value;

--- a/apps/server/src/skills/parser.ts
+++ b/apps/server/src/skills/parser.ts
@@ -8,6 +8,26 @@
 
 import { isBodySizeValid } from './sanitize.js';
 
+/**
+ * Strip a single matching pair of surrounding quotes from a YAML scalar.
+ *
+ * The frontmatter is read by line-scan rather than a real YAML parser, so
+ * a quoted value like `description: 'Do the thing.'` would otherwise keep
+ * its quotes literally and surface them in the UI and in skill-selection
+ * prompts. Only an outer pair of matching `'` or `"` is removed; inner
+ * quotes are left untouched.
+ */
+function unquote(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' || first === "'") && last === first) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
 export type SkillDefinition = {
   /** Directory name — the canonical skill ID */
   id: string;
@@ -82,11 +102,11 @@ export function parseSkillMd(
     const line = lines[i];
     if (!line) continue;
     if (line.startsWith('name:')) {
-      name = line.substring('name:'.length).trim();
+      name = unquote(line.substring('name:'.length).trim());
     } else if (line.startsWith('description:')) {
-      description = line.substring('description:'.length).trim();
+      description = unquote(line.substring('description:'.length).trim());
     } else if (line.startsWith('version:')) {
-      version = line.substring('version:'.length).trim();
+      version = unquote(line.substring('version:'.length).trim());
     }
   }
 

--- a/apps/server/src/skills/seed.test.ts
+++ b/apps/server/src/skills/seed.test.ts
@@ -275,4 +275,101 @@ describe('seedBundledSkills', () => {
       expect(existsSync(join(destDir, 'my-skill', 'SKILL.md'))).toBe(true);
     });
   });
+
+  describe('skills with subdirectories (references, scripts, templates)', () => {
+    function writeRichSkill(dir: string, skillId: string): void {
+      const skillDir = join(dir, skillId);
+      mkdirSync(join(skillDir, 'references'), { recursive: true });
+      mkdirSync(join(skillDir, 'scripts'), { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), skillV1, 'utf8');
+      writeFileSync(
+        join(skillDir, 'references', 'guide.md'),
+        '# guide\n',
+        'utf8',
+      );
+      writeFileSync(
+        join(skillDir, 'scripts', 'run.mjs'),
+        'console.log("hi");\n',
+        'utf8',
+      );
+    }
+
+    it('does not throw on a skill dir containing subdirectories', () => {
+      // Regression: the seeder used to call readFileSync/copyFileSync on
+      // subdirectory entries, throwing EISDIR and aborting startup.
+      writeRichSkill(srcDir, 'rich-skill');
+      expect(() => seedBundledSkills(srcDir, destDir)).not.toThrow();
+    });
+
+    it('copies nested files preserving directory structure', () => {
+      writeRichSkill(srcDir, 'rich-skill');
+      seedBundledSkills(srcDir, destDir);
+
+      expect(existsSync(join(destDir, 'rich-skill', 'SKILL.md'))).toBe(true);
+      expect(
+        readFileSync(
+          join(destDir, 'rich-skill', 'references', 'guide.md'),
+          'utf8',
+        ),
+      ).toBe('# guide\n');
+      expect(
+        readFileSync(join(destDir, 'rich-skill', 'scripts', 'run.mjs'), 'utf8'),
+      ).toBe('console.log("hi");\n');
+    });
+
+    it('records nested files in the manifest under forward-slash keys', () => {
+      writeRichSkill(srcDir, 'rich-skill');
+      seedBundledSkills(srcDir, destDir);
+
+      const manifest = readManifest(destDir);
+      expect(manifest['rich-skill/SKILL.md']).toBeDefined();
+      expect(manifest['rich-skill/references/guide.md']).toBeDefined();
+      expect(manifest['rich-skill/scripts/run.mjs']).toBeDefined();
+    });
+
+    it('preserves a user-modified nested file while updating an unmodified sibling', () => {
+      writeRichSkill(srcDir, 'rich-skill');
+      seedBundledSkills(srcDir, destDir);
+
+      // User edits one reference file locally.
+      writeFileSync(
+        join(destDir, 'rich-skill', 'references', 'guide.md'),
+        '# my edit\n',
+        'utf8',
+      );
+
+      // App ships new content for both nested files (no version → content-based).
+      writeFileSync(
+        join(srcDir, 'rich-skill', 'references', 'guide.md'),
+        '# upstream guide v2\n',
+        'utf8',
+      );
+      writeFileSync(
+        join(srcDir, 'rich-skill', 'scripts', 'run.mjs'),
+        'console.log("v2");\n',
+        'utf8',
+      );
+      seedBundledSkills(srcDir, destDir);
+
+      expect(
+        readFileSync(
+          join(destDir, 'rich-skill', 'references', 'guide.md'),
+          'utf8',
+        ),
+      ).toBe('# my edit\n'); // preserved
+      expect(
+        readFileSync(join(destDir, 'rich-skill', 'scripts', 'run.mjs'), 'utf8'),
+      ).toBe('console.log("v2");\n'); // updated
+    });
+
+    it('is idempotent on re-seed with unchanged source', () => {
+      writeRichSkill(srcDir, 'rich-skill');
+      seedBundledSkills(srcDir, destDir);
+      const first = readManifest(destDir);
+
+      expect(() => seedBundledSkills(srcDir, destDir)).not.toThrow();
+      const second = readManifest(destDir);
+      expect(second).toEqual(first);
+    });
+  });
 });

--- a/apps/server/src/skills/seed.ts
+++ b/apps/server/src/skills/seed.ts
@@ -68,6 +68,86 @@ function saveManifest(targetDir: string, manifest: SeedManifest): void {
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
 }
 
+/**
+ * List every file under `dir` recursively, returned as paths relative to
+ * `dir` with forward-slash separators (so manifest keys are stable across
+ * platforms). Directories themselves are not returned — only files.
+ */
+function listRelativeFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string, prefix: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(path.join(current, entry.name), rel);
+      } else if (entry.isFile()) {
+        out.push(rel);
+      }
+    }
+  };
+  walk(dir, '');
+  return out;
+}
+
+/**
+ * Apply the seed/update policy to a single file. Returns true if the
+ * manifest was mutated (so the caller knows to persist it).
+ *
+ * Policy (unchanged from the original per-file behavior):
+ * - Never seeded → copy, record version+hash.
+ * - Exists but predates the manifest → treat as user-owned, record it.
+ * - User modified the file (hash differs from manifest) → never overwrite.
+ * - Unmodified → overwrite only if source has a newer semver version, or
+ *   (when neither side is versioned) the content changed.
+ */
+function seedFile(
+  srcFile: string,
+  destFile: string,
+  manifestKey: string,
+  manifest: SeedManifest,
+): boolean {
+  const srcHash = hashFile(srcFile);
+  const srcVersion = extractVersion(srcFile);
+
+  if (!fs.existsSync(destFile)) {
+    fs.mkdirSync(path.dirname(destFile), { recursive: true });
+    fs.copyFileSync(srcFile, destFile);
+    manifest[manifestKey] = { version: srcVersion, hash: srcHash };
+    return true;
+  }
+
+  const entry = manifest[manifestKey];
+  const destHash = hashFile(destFile);
+
+  if (entry === undefined) {
+    manifest[manifestKey] = {
+      version: extractVersion(destFile),
+      hash: destHash,
+    };
+    return true;
+  }
+
+  if (destHash !== entry.hash) {
+    // User modified the file — never overwrite.
+    return false;
+  }
+
+  const hasNewerVersion =
+    srcVersion != null &&
+    entry.version != null &&
+    semver.gt(srcVersion, entry.version);
+  const noVersioning = srcVersion == null || entry.version == null;
+  const contentChanged = srcHash !== entry.hash;
+
+  if (hasNewerVersion || (noVersioning && contentChanged)) {
+    fs.copyFileSync(srcFile, destFile);
+    manifest[manifestKey] = { version: srcVersion, hash: srcHash };
+    return true;
+  }
+
+  return false;
+}
+
 export function seedBundledSkills(sourceDir: string, targetDir: string): void {
   if (!fs.existsSync(sourceDir)) return;
 
@@ -80,50 +160,17 @@ export function seedBundledSkills(sourceDir: string, targetDir: string): void {
     const srcSkillDir = path.join(sourceDir, skillId);
     if (!fs.statSync(srcSkillDir).isDirectory()) continue;
 
-    const destSkillDir = path.join(targetDir, skillId);
-    fs.mkdirSync(destSkillDir, { recursive: true });
+    // Skills may bundle reference files and scripts in subdirectories, so
+    // walk the whole tree rather than assuming a flat SKILL.md. Copying a
+    // directory as if it were a file would throw EISDIR and abort startup.
+    for (const rel of listRelativeFiles(srcSkillDir)) {
+      const relParts = rel.split('/');
+      const srcFile = path.join(srcSkillDir, ...relParts);
+      const destFile = path.join(targetDir, skillId, ...relParts);
+      const manifestKey = `${skillId}/${rel}`;
 
-    for (const file of fs.readdirSync(srcSkillDir)) {
-      const srcFile = path.join(srcSkillDir, file);
-      const destFile = path.join(destSkillDir, file);
-      const manifestKey = `${skillId}/${file}`;
-
-      const srcHash = hashFile(srcFile);
-      const srcVersion = extractVersion(srcFile);
-
-      if (!fs.existsSync(destFile)) {
-        // Never seeded — copy unconditionally
-        fs.copyFileSync(srcFile, destFile);
-        manifest[manifestKey] = { version: srcVersion, hash: srcHash };
+      if (seedFile(srcFile, destFile, manifestKey, manifest)) {
         manifestDirty = true;
-      } else {
-        const entry = manifest[manifestKey];
-        const destHash = hashFile(destFile);
-
-        if (entry === undefined) {
-          // File exists but predates the manifest — treat as user-owned, record current state
-          manifest[manifestKey] = {
-            version: extractVersion(destFile),
-            hash: destHash,
-          };
-          manifestDirty = true;
-        } else if (destHash !== entry.hash) {
-          // User modified the file — never overwrite
-        } else {
-          // File is unmodified by user — overwrite only if source has a newer version
-          const hasNewerVersion =
-            srcVersion != null &&
-            entry.version != null &&
-            semver.gt(srcVersion, entry.version);
-          const noVersioning = srcVersion == null || entry.version == null;
-          const contentChanged = srcHash !== entry.hash;
-
-          if (hasNewerVersion || (noVersioning && contentChanged)) {
-            fs.copyFileSync(srcFile, destFile);
-            manifest[manifestKey] = { version: srcVersion, hash: srcHash };
-            manifestDirty = true;
-          }
-        }
       }
     }
   }

--- a/config/skills/browser-automation/SKILL.md
+++ b/config/skills/browser-automation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: Browser Automation
+description: Use when a task needs a real browser — navigating sites, filling and submitting forms, clicking through flows, extracting page data, or taking screenshots — driving whatever browser tool or MCP server is available.
+version: 1.0.0
+---
+
+# Browser Automation
+
+Some things only exist behind a page: a login-walled dashboard, a form with
+no API, a site that renders with JavaScript. Drive a browser to do them —
+deliberately, one observable step at a time.
+
+## Before you start
+
+- Confirm a browser tool or configured MCP server (Playwright, Puppeteer, a
+  browser MCP, etc.) is available. If not, tell the user what to set up
+  instead of pretending to click.
+- Restate the goal as a concrete end state — "reach the order-confirmation
+  page", "extract the table rows". You need to know when you're done.
+- Flag any step that spends money, sends a message, or changes someone
+  else's data, and get explicit approval before running it.
+
+## Method
+
+- Navigate, then observe before acting. Read the actual page — visible
+  text, form fields, current URL — rather than assuming the layout.
+- Prefer stable selectors: visible labels, roles, and text over brittle
+  CSS/xpath tied to generated class names.
+- Do one action, then re-check the result. Don't fire a long sequence blind
+  and hope it worked.
+- Wait for the page to settle — network idle, element present — instead of
+  fixed-duration sleeps.
+- Capture a screenshot at decision points and on failure. It's your
+  evidence of what actually happened.
+
+## Guardrails
+
+- Never submit a purchase, booking, message, or account change without
+  confirming first.
+- Don't enter credentials the user didn't give you; use the browser's
+  existing session or profile where possible.
+- Stop and report if you hit a login wall, a CAPTCHA, or a page you didn't
+  expect — don't thrash.
+
+See `references/automation-recipe.md`.
+
+## Anti-patterns
+
+- Assuming a selector still exists instead of checking the current page.
+- Chaining many clicks with no verification between them.
+- Treating a fixed "wait 5 seconds" as a substitute for a real condition.
+- Auto-accepting consent or purchase dialogs that have real consequences.

--- a/config/skills/browser-automation/references/automation-recipe.md
+++ b/config/skills/browser-automation/references/automation-recipe.md
@@ -1,0 +1,34 @@
+# Automation recipe
+
+A reliable browser flow is a loop of small, verified steps — not one long
+script. Repeat this loop per step.
+
+## The step loop
+
+1. **Observe** — capture the current URL and the relevant page content.
+2. **Locate** — find the target element by visible label, role, or text.
+3. **Act** — one action (click, type, select, navigate).
+4. **Wait** — for the condition that means the action landed (URL change,
+   new element, network idle) — not a fixed timer.
+5. **Verify** — confirm the expected result appeared before the next step.
+6. **Capture** — screenshot at decisions and on any failure.
+
+## Selector priority
+
+1. Accessible role + name / visible label text.
+2. Stable `id`, `name`, or `data-testid` attributes.
+3. Text content of a unique element.
+4. CSS/xpath tied to generated class names — last resort, brittle.
+
+## When to stop and ask
+
+- [ ] A login wall or CAPTCHA blocks the flow.
+- [ ] The page differs from what the task assumed.
+- [ ] The next step spends money, sends something, or deletes data.
+- [ ] The same step failed twice — report, don't keep retrying.
+
+## Extraction
+
+- Pull structured data (rows, fields), not a flattened text blob.
+- Record the source URL and time alongside extracted values.
+- Note pagination; don't assume page 1 is the whole result set.

--- a/config/skills/code-review/SKILL.md
+++ b/config/skills/code-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: Code Review
+description: Use when reviewing a diff or pull request — find correctness bugs first, then reuse/simplification cleanups, and report each finding with a concrete failure scenario ranked by severity.
+version: 1.0.0
+---
+
+# Code Review
+
+A review's job is to catch what tests and the type checker won't. Read
+the diff for correctness first; treat style and cleanup as secondary.
+
+## Scope
+
+- The **diff** is the scope. But read the _enclosing_ function of each
+  hunk — a change can re-expose or fail to fix a bug in nearby lines.
+- Check callers and callees of anything the diff changes: a new
+  precondition, a changed return shape, or a new thrown error can break
+  a call site the diff doesn't touch.
+
+## Look for, in order
+
+1. **Correctness** — the highest-value findings:
+   - Inverted/wrong conditions, off-by-one, wrong variable (copy-paste).
+   - Null/undefined access, missing `await`, unhandled promise rejection.
+   - Falsy-zero / empty-string bugs (`if (!count)` when `0` is valid).
+   - Removed guards or validation with nothing re-establishing them.
+   - Error swallowed in a `catch` that should propagate.
+2. **Cleanup** — only after correctness:
+   - Reinvented helpers that already exist in the codebase.
+   - Duplicated logic, dead code, needless complexity, redundant state.
+   - Wasted work: repeated I/O, sequential calls that could be parallel.
+3. **Conventions** — clear violations of the repo's stated rules, quoted.
+
+## Reporting a finding
+
+Every finding needs a **concrete failure scenario**, not a vibe:
+
+> `src/foo.ts:42` — `parseId` returns `undefined` for empty input, but the
+> caller indexes into it → `TypeError` when the list is empty.
+
+- Rank most-severe first. A correctness bug always outranks a cleanup.
+- Say how sure you are. If you can't name inputs that break it, mark it
+  as "possible" rather than asserting a bug.
+- Prefer "here's the failing case" over "consider refactoring."
+
+## Restraint
+
+Don't flag style the linter already enforces, don't rewrite to personal
+taste, and don't invent requirements. A short list of real bugs beats a
+long list of nitpicks. See `references/review-checklist.md`.

--- a/config/skills/code-review/references/review-checklist.md
+++ b/config/skills/code-review/references/review-checklist.md
@@ -1,0 +1,48 @@
+# Review checklist
+
+Work top-down. Correctness findings are worth more than everything below
+them combined.
+
+## Correctness
+
+- [ ] Conditions: any inverted logic, `&&`/`||` mixups, off-by-one?
+- [ ] Wrong variable used (copy-paste from the line above)?
+- [ ] Null/undefined: every access guaranteed non-null, or guarded?
+- [ ] `await` on every promise; no floating async work?
+- [ ] Falsy traps: `0`, `''`, `false` treated as "missing" when valid?
+- [ ] Boundaries: empty collection, single element, max size, duplicates?
+- [ ] Errors: caught only where handled; nothing swallowed silently?
+- [ ] Removed code: did a deleted line enforce an invariant? Where is it now?
+
+## Cross-file
+
+- [ ] Callers updated for a changed signature / return shape / new throw?
+- [ ] A parallel change in the same diff doesn't make another call unsafe?
+- [ ] Concurrency/ordering assumptions still hold?
+
+## Reuse & simplification
+
+- [ ] Does this reinvent an existing helper? Name it.
+- [ ] Duplicated logic that should be factored?
+- [ ] Dead code, unreachable branch, unused export left behind?
+- [ ] Simpler form that does the same job?
+
+## Efficiency
+
+- [ ] Repeated I/O or computation that could be hoisted or cached?
+- [ ] Independent async operations run sequentially?
+- [ ] Work added to a hot path or startup that doesn't belong there?
+
+## Tests & docs
+
+- [ ] New behavior covered by a test that would fail without the change?
+- [ ] Bug fix accompanied by a regression test?
+- [ ] Public API change reflected where the project documents such things?
+
+## Severity ranking
+
+1. Data loss / security / crash on a realistic input
+2. Wrong result on a common case
+3. Wrong result on an edge case
+4. Cleanup / reuse / efficiency
+5. Style not covered by the linter (usually skip)

--- a/config/skills/conventional-commits/SKILL.md
+++ b/config/skills/conventional-commits/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: Conventional Commits
+description: Use when writing a git commit message or PR title — format it as a Conventional Commit (type(scope): summary) with a body that explains why, matching this repo's history.
+version: 1.0.0
+---
+
+# Conventional Commits
+
+Commit messages are read far more often than they're written. A
+consistent, structured message makes history skimmable and explains _why_
+a change exists — which the diff can't.
+
+## Format
+
+```
+type(scope): short summary in the imperative
+
+Optional body: what changed and, more importantly, WHY. Wrap at ~72
+columns. Reference the problem this solves, not a restatement of the diff.
+
+Optional footer: BREAKING CHANGE: ..., refs #123, Co-Authored-By: ...
+```
+
+- **type** — the kind of change (see cheatsheet). Required.
+- **scope** — the area touched, e.g. `mcp`, `skills`, `cli`, `server`.
+  Optional but encouraged; match scopes already used in `git log`.
+- **summary** — imperative mood ("add", "fix", not "added"/"fixes"),
+  lower-case, no trailing period, ≤ ~72 chars.
+
+## Common types
+
+`feat` new feature · `fix` bug fix · `refactor` behavior-preserving
+change · `test` tests only · `docs` docs only · `chore` tooling/deps ·
+`perf` performance · `ci` pipeline. Full list in
+`references/cheatsheet.md`.
+
+## Writing the body
+
+The summary says _what_; the body says _why_. Good bodies answer:
+
+- What problem or symptom prompted this?
+- Why this approach over the obvious alternative?
+- Anything a future reader would be surprised by?
+
+Skip the body only for truly self-evident one-liners.
+
+## Match this repo
+
+- Look at recent `git log --oneline` and reuse existing scopes and
+  phrasing rather than inventing new conventions.
+- One logical change per commit. If the summary needs "and", it's
+  probably two commits.
+- Never bypass hooks (`--no-verify`) or signing unless explicitly asked.
+
+## Breaking changes
+
+Add a `BREAKING CHANGE:` footer (or `!` after the type/scope, e.g.
+`feat(api)!:`) describing what breaks and how to migrate.

--- a/config/skills/conventional-commits/references/cheatsheet.md
+++ b/config/skills/conventional-commits/references/cheatsheet.md
@@ -1,0 +1,48 @@
+# Conventional Commits cheatsheet
+
+## Types
+
+| Type       | Use for                                                 |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | A new user-facing feature or capability                 |
+| `fix`      | A bug fix                                               |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf`     | A change that improves performance                      |
+| `test`     | Adding or correcting tests only                         |
+| `docs`     | Documentation only                                      |
+| `style`    | Formatting/whitespace, no code-behavior change          |
+| `chore`    | Build, deps, tooling, config                            |
+| `ci`       | CI/pipeline changes                                     |
+| `revert`   | Reverts a previous commit                               |
+
+## Anatomy
+
+```
+feat(skills): recursively seed skill subdirectories
+^    ^         ^
+type scope     imperative summary, lower-case, no period, ~72 chars max
+
+<blank line>
+Body: why this change exists and why this approach. Wrap ~72 cols.
+<blank line>
+BREAKING CHANGE: <what breaks + migration>   (only if applicable)
+refs #123
+```
+
+## Do / Don't
+
+| Do                                           | Don't                              |
+| -------------------------------------------- | ---------------------------------- |
+| `fix(cli): correct exit code on empty input` | `Fixed stuff`                      |
+| `feat(mcp): resolve ${VAR} secrets for http` | `feat: MCP changes and also a fix` |
+| imperative: "add", "remove", "correct"       | past tense: "added", "removed"     |
+| one logical change per commit                | bundle unrelated changes           |
+| reuse scopes seen in `git log`               | invent a new scope per commit      |
+
+## Quick self-check before committing
+
+- [ ] Does the type match the actual change?
+- [ ] Is the summary in the imperative and under ~72 chars?
+- [ ] Does the body explain _why_, not just restate the diff?
+- [ ] Is this one logical change (no "and" in the summary)?
+- [ ] Breaking? Then there's a `BREAKING CHANGE:` footer.

--- a/config/skills/data-and-apis/SKILL.md
+++ b/config/skills/data-and-apis/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: Data and APIs
+description: Use when calling external REST APIs or querying databases on the user's behalf through available tools or MCP servers — read-only by default, parametrized queries, and confirmation before any write.
+version: 1.0.0
+---
+
+# Data and APIs
+
+Pulling data from an API or a database is routine; a careless write or an
+unbounded query is not. Default to read-only, be precise about what you
+request, and treat every write as something to confirm first.
+
+## Before the call
+
+- Confirm the right tool or configured MCP server is available and already
+  holds the credentials. Don't ask the user to paste secrets into chat.
+- Know the shape of what you're hitting: the endpoint or table, the
+  parameters, and what a successful response looks like.
+- Read the auth and rate-limit rules. Respect pagination instead of
+  demanding everything at once.
+
+## Querying safely
+
+- Start read-only. A `SELECT` or `GET` to understand the data before any
+  change.
+- Parametrize inputs. Never splice raw user text into a query string —
+  build filters from typed values.
+- Bound your reads: add a `LIMIT`, a date range, or a page size. An
+  unfiltered pull on a large table is a mistake, not thoroughness.
+- Handle failures explicitly. A 4xx/5xx or an empty result is information,
+  not a reason to retry blindly.
+
+## Writes and side effects
+
+- Any insert, update, delete, POST, or payment is outward-facing: state
+  exactly what will change and confirm before running it.
+- Prefer a dry run or a one-record test before a bulk operation.
+- After a write, read the affected record back to confirm the change took.
+
+See `references/request-checklist.md`.
+
+## Anti-patterns
+
+- Splicing untrusted input into a query instead of parametrizing it.
+- Running an unbounded full export when a filter would do.
+- Performing a write or bulk update without confirmation.
+- Retrying a failing call in a loop instead of reading the error.

--- a/config/skills/data-and-apis/references/request-checklist.md
+++ b/config/skills/data-and-apis/references/request-checklist.md
@@ -1,0 +1,25 @@
+# Request checklist
+
+Read is cheap and reversible; write is neither. Treat them differently.
+
+## Any request
+
+- [ ] Tool/MCP server available and holding its own credentials.
+- [ ] Endpoint or table, parameters, and expected response shape known.
+- [ ] Auth and rate limits respected; pagination handled.
+- [ ] Secrets never printed, logged, or pasted into chat.
+
+## Reads
+
+- [ ] Started read-only to understand the data.
+- [ ] Inputs parametrized, not string-concatenated.
+- [ ] Result bounded — `LIMIT`, date range, or page size.
+- [ ] Errors and empty results read and reported, not retried blindly.
+
+## Writes / side effects
+
+- [ ] Stated exactly what will change, to which records.
+- [ ] User confirmed the write (or clearly pre-authorized it).
+- [ ] Tried a dry run or single-record test before any bulk operation.
+- [ ] Read the affected record back afterward to confirm the change.
+- [ ] Idempotency considered so a retry can't double-apply.

--- a/config/skills/scheduling/SKILL.md
+++ b/config/skills/scheduling/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: Scheduling
+description: Use when working with calendars — checking availability, finding meeting times, and creating or updating events through an available calendar integration — with careful timezone handling and confirmation before inviting others.
+version: 1.0.0
+---
+
+# Scheduling
+
+Calendar mistakes are public and awkward: a meeting at 3 AM someone's time,
+a double-booking, an invite to the wrong people. Get the timezone and the
+guest list right, then confirm before it lands on anyone else's calendar.
+
+## Before you touch a calendar
+
+- Confirm a calendar tool or configured MCP server is available. If not,
+  say what to connect.
+- Establish the timezone explicitly — the user's, and each attendee's if
+  they differ. Never assume UTC or your own.
+- Know whether this is the user's own event or one that invites others; the
+  latter needs confirmation.
+
+## Finding a time
+
+- Read existing events before proposing slots. Respect working hours and
+  commitments already on the calendar.
+- Offer 2–3 concrete options with the timezone spelled out — "Tue 2pm PT /
+  5pm ET" — not a vague "sometime Tuesday."
+- Account for travel or buffer between back-to-back meetings when it
+  matters.
+
+## Creating or changing events
+
+- Include a clear title, the correct start/end with timezone, and a short
+  agenda or context in the body.
+- Add attendees only when asked, and confirm the list before sending
+  invites.
+- For an edit or cancel, state what's changing and who gets notified before
+  you do it.
+- Afterward, report the final details and the local time for each key
+  attendee.
+
+See `references/scheduling-checklist.md`.
+
+## Anti-patterns
+
+- Creating an event in the wrong timezone because none was confirmed.
+- Inviting people before the user approved the guest list.
+- Overwriting or deleting an existing event without flagging it.
+- Proposing times that collide with commitments already on the calendar.

--- a/config/skills/scheduling/references/scheduling-checklist.md
+++ b/config/skills/scheduling/references/scheduling-checklist.md
@@ -1,0 +1,30 @@
+# Scheduling checklist
+
+Timezones and guest lists are where this goes wrong. Confirm both.
+
+## Timezones
+
+- [ ] User's timezone known (not assumed from your own or UTC).
+- [ ] Each attendee's timezone known where they differ.
+- [ ] Proposed times stated in every relevant zone.
+- [ ] Daylight-saving handled — the offset on the actual date, not today's.
+
+## Availability
+
+- [ ] Read existing events before proposing or booking.
+- [ ] Proposed slots fall within working hours.
+- [ ] No collision with an existing commitment.
+- [ ] Travel/buffer between adjacent meetings accounted for.
+
+## The event
+
+- [ ] Clear title.
+- [ ] Correct start and end, with timezone.
+- [ ] Agenda or context in the body.
+- [ ] Attendee list confirmed with the user before invites go out.
+- [ ] Location or meeting link included when needed.
+
+## Edits and cancels
+
+- [ ] Stated what changes and who gets notified — before doing it.
+- [ ] Reported the final details and each key attendee's local time.

--- a/config/skills/sending-messages/SKILL.md
+++ b/config/skills/sending-messages/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: Sending Messages
+description: Use when posting to chat or email on the user's behalf — Slack, Discord, Telegram, or mail — through an available integration. Get the recipient and content right, and confirm before anything goes out.
+version: 1.0.0
+---
+
+# Sending Messages
+
+A sent message can't be unsent. When you post to a channel or send mail as
+the user, you're speaking with their voice to real people — so verify the
+destination and the words before they leave.
+
+## Before sending
+
+- Confirm a messaging or email tool (or a configured MCP server) exists for
+  the target platform. If not, say what to configure.
+- Nail down three things: **who** — the exact channel, DM, or address;
+  **what** — the final text; and **as whom** — which account or identity.
+- Draft first. Show the user the recipient and the message and get a yes
+  before sending, unless they've clearly pre-authorized this exact send.
+
+## Writing the message
+
+- Match the register of the channel: a team chat is not a formal email.
+  Mirror how the user writes there if you have examples.
+- Lead with the point. People skim — put the ask or the update in the first
+  line.
+- Keep formatting native to the platform (chat markup, or an email with a
+  clear subject and body).
+- Don't mention groups, reply to everyone, or cross-post widely unless
+  asked. The blast radius is easy to underestimate.
+
+## After sending
+
+- Report exactly what went where — channel or address, plus a copy of the
+  text.
+- If a send fails, surface the error. Do not silently retry to a different
+  recipient.
+
+See `references/message-checklist.md`.
+
+## Anti-patterns
+
+- Sending before confirming recipient and content.
+- Guessing an address or channel from a partial name.
+- Adding commitments or opinions the user didn't authorize.
+- Firing the same message repeatedly after an ambiguous failure.

--- a/config/skills/sending-messages/references/message-checklist.md
+++ b/config/skills/sending-messages/references/message-checklist.md
@@ -1,0 +1,29 @@
+# Message checklist
+
+Outward-facing and irreversible. Clear every box before you send.
+
+## Destination
+
+- [ ] Exact recipient confirmed — full channel name, DM, or email address.
+- [ ] Right workspace / server / account, not a look-alike.
+- [ ] Sending as the intended identity.
+- [ ] Group mentions, reply-all, and wide cross-posts are intended, not
+      accidental.
+
+## Content
+
+- [ ] The point is in the first line.
+- [ ] Register matches the channel (casual vs. formal).
+- [ ] Email has a clear subject.
+- [ ] No commitments, dates, or claims the user didn't authorize.
+- [ ] Links and attachments are the right ones and actually resolve.
+
+## Consent
+
+- [ ] User approved this recipient + this text — or pre-authorized this
+      exact kind of send.
+
+## After
+
+- [ ] Reported where it went and included a copy of what was sent.
+- [ ] On failure: surfaced the error; did not silently retry elsewhere.

--- a/config/skills/systematic-debugging/SKILL.md
+++ b/config/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: Systematic Debugging
+description: Use when a bug, failing test, crash, or wrong output needs fixing — a four-phase method to find the root cause before changing code, instead of guessing.
+version: 1.0.0
+---
+
+# Systematic Debugging
+
+Guessing at fixes wastes time and often adds new bugs. Work the problem in
+four phases and do not skip ahead. You may only edit code in Phase 3.
+
+## Phase 1 — Reproduce
+
+You cannot fix what you cannot trigger.
+
+- Find the smallest, most reliable way to make the bug happen. Prefer a
+  failing test or a single command over "click around the UI."
+- Write down the exact inputs, state, and environment. If it only fails
+  sometimes, note how often and what varies between runs.
+- If you cannot reproduce it, stop and gather more data (logs, a report
+  with steps, the failing payload). Do not fix blind.
+
+See `references/reproduction-checklist.md`.
+
+## Phase 2 — Isolate
+
+Narrow _where_ the fault is before asking _why_.
+
+- Confirm the expected vs. actual behavior in one sentence each.
+- Bisect: halve the search space repeatedly. Comment out a branch, add a
+  log at the midpoint, or `git bisect` across commits. Each step should
+  rule out roughly half of what's left.
+- Trace the value backward from the wrong output to the first point where
+  it became wrong. That point, not the crash site, is usually the bug.
+
+## Phase 3 — Hypothesize and test
+
+- State a single, falsifiable hypothesis: "X is wrong because Y." Record
+  it (see `references/hypothesis-log.md`).
+- Predict what you'd observe if it were true, then check that prediction
+  with a log/test/breakpoint — before editing.
+- Only once a hypothesis is confirmed, make the smallest change that
+  addresses the root cause. Resist fixing symptoms.
+- If the hypothesis is wrong, write down what you learned and form the
+  next one. Do not stack speculative changes.
+
+## Phase 4 — Verify and harden
+
+- Re-run the Phase 1 reproduction. The bug is fixed only when the thing
+  that used to fail now passes.
+- Add a regression test that fails without your change and passes with it.
+- Check for siblings: the same root cause often hides in nearby code.
+- Remove debug logging and temporary scaffolding before you finish.
+
+## Anti-patterns
+
+- Changing several things at once so you can't tell what worked.
+- "Fixing" by adding a retry, sleep, or try/catch that hides the error.
+- Trusting the stack-trace location without tracing the value backward.
+- Declaring victory without re-running the original reproduction.

--- a/config/skills/systematic-debugging/references/hypothesis-log.md
+++ b/config/skills/systematic-debugging/references/hypothesis-log.md
@@ -1,0 +1,32 @@
+# Hypothesis log
+
+Debugging is a search. Writing down each hypothesis and its outcome keeps
+you from re-testing the same idea and makes the trail auditable.
+
+Keep a running list while you work:
+
+```
+## Bug: <one-line summary>
+
+Repro: <command / steps>
+Expected: <...>
+Actual: <...>
+
+### H1: <what you think is wrong and why>
+Prediction if true: <what you'd observe>
+Test: <log / breakpoint / experiment>
+Result: CONFIRMED | REFUTED — <what you saw>
+Notes: <what this rules in or out>
+
+### H2: ...
+```
+
+## Rules
+
+- One hypothesis at a time. Falsifiable. Predict before you check.
+- A refuted hypothesis is progress — it shrinks the search space. Record
+  what it ruled out.
+- Don't edit product code to test a hypothesis; use a log or breakpoint.
+  Save edits for the confirmed root cause.
+- When confirmed, the log entry becomes your commit rationale and the basis
+  for the regression test.

--- a/config/skills/systematic-debugging/references/reproduction-checklist.md
+++ b/config/skills/systematic-debugging/references/reproduction-checklist.md
@@ -1,0 +1,31 @@
+# Reproduction checklist
+
+A bug you can't trigger on demand is a bug you can't verify fixed. Before
+touching code, pin down a reliable reproduction.
+
+## Capture
+
+- [ ] Exact command, request, or user action that triggers it
+- [ ] Full inputs (payload, args, file, env vars) — copy real values
+- [ ] Expected result, in one sentence
+- [ ] Actual result, in one sentence (error message, wrong value, crash)
+- [ ] Environment: OS, runtime version, branch/commit, config that differs
+      from defaults
+
+## Shrink
+
+- [ ] Remove unrelated steps until only the failing path remains
+- [ ] Replace the UI with a direct call (test, script, curl) where possible
+- [ ] Hard-code the triggering input so the repro is one deterministic step
+
+## Intermittent bugs
+
+If it fails only sometimes, treat the _rate_ as data:
+
+- [ ] How often (1 in 3? 1 in 100?)
+- [ ] What differs between pass and fail runs — timing, ordering,
+      concurrency, cache state, clock, network?
+- [ ] Can you raise the rate? (add load, shrink a timeout, run in a loop)
+
+A reproduction that fails 100% of the time is worth the effort — it turns
+verification from "seems better" into "provably fixed."

--- a/config/skills/test-driven-development/SKILL.md
+++ b/config/skills/test-driven-development/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: Test-Driven Development
+description: Use when implementing a new function, endpoint, bug fix, or behavior change — write a failing test first, then the code, following RED-GREEN-REFACTOR.
+version: 1.0.0
+---
+
+# Test-Driven Development
+
+Write the test before the code. The test defines "done," catches
+regressions for free, and forces you to design the interface from the
+caller's side.
+
+## The loop
+
+1. **RED** — Write one small test for the next slice of behavior. Run it.
+   Watch it fail _for the reason you expect_ (assertion failed — not a
+   typo or import error). A test that has never failed proves nothing.
+2. **GREEN** — Write the minimum code to make it pass. Not the elegant
+   version — the passing version. Run the test; see it go green.
+3. **REFACTOR** — Now clean up implementation _and_ test while green:
+   remove duplication, rename, extract. Re-run after each change.
+
+Repeat, one behavior at a time. Commit at green points.
+
+## What to test first
+
+- The normal case that describes the feature's purpose.
+- Then edge cases: empty, zero, null/undefined, boundary values, large
+  input, wrong types.
+- Then failure modes: what _should_ throw or return an error, and does it?
+
+Write these as separate tiny tests, not one giant test — a focused test
+names exactly what broke when it fails.
+
+## For a bug fix
+
+Reverse the order: first write a test that reproduces the bug (RED — it
+fails on the current, broken code). Then fix the code (GREEN). The test
+now guards against the bug returning. This is the fastest way to be sure
+you actually fixed it.
+
+## Discipline
+
+- Never write production code without a failing test demanding it.
+- Never write more of a test than needed to fail; never more production
+  code than needed to pass.
+- If a test passes the moment you write it, be suspicious — you either
+  already had the behavior or the test asserts nothing.
+
+See `references/red-green-example.md` for a worked vitest example that
+matches this repo's conventions.

--- a/config/skills/test-driven-development/references/red-green-example.md
+++ b/config/skills/test-driven-development/references/red-green-example.md
@@ -1,0 +1,67 @@
+# RED-GREEN example (vitest)
+
+This repo uses **vitest**, with tests colocated next to the file under
+test as `*.test.ts`. Here is one full loop for a small function.
+
+## RED — write the failing test first
+
+`src/lib/slugify.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { slugify } from './slugify.js';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates words', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+});
+```
+
+Run only this file while iterating:
+
+```bash
+pnpm --filter @openaidy/server exec vitest run src/lib/slugify.test.ts
+```
+
+It fails because `slugify` doesn't exist yet. Good — that's RED for the
+right reason.
+
+## GREEN — minimum code to pass
+
+`src/lib/slugify.ts`:
+
+```ts
+export function slugify(input: string): string {
+  return input.toLowerCase().replace(/\s+/g, '-');
+}
+```
+
+Re-run: green.
+
+## Extend, still one behavior per test
+
+```ts
+it('strips punctuation', () => {
+  expect(slugify('Hello, World!')).toBe('hello-world');
+});
+
+it('collapses repeated separators', () => {
+  expect(slugify('a  --  b')).toBe('a-b');
+});
+```
+
+Each new test fails first, then you extend `slugify` minimally to pass.
+
+## REFACTOR
+
+Once green, tidy the implementation (e.g. a single normalize pipeline)
+and re-run the whole file after each edit. Green stays green.
+
+## Conventions to match
+
+- Import the unit under test with a `.js` extension (`./slugify.js`) —
+  the repo's module resolution requires it even in `.ts` files.
+- Keep tests deterministic: no real network, clock, or filesystem unless
+  the test sets them up and tears them down.
+- Prefer many small `it(...)` cases over one case with many assertions.

--- a/config/skills/web-research/SKILL.md
+++ b/config/skills/web-research/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: Web Research
+description: Use when you need current or external facts — searching the web, reading multiple sources, cross-checking claims, and synthesizing an answer with citations instead of guessing from memory.
+version: 1.0.0
+---
+
+# Web Research
+
+Your training data is stale and incomplete. When a question turns on
+current events, prices, versions, docs, or any fact you're not sure of,
+look it up — and show where the answer came from.
+
+## When to reach for the web
+
+- The answer could have changed since your knowledge cutoff — releases,
+  prices, news, who holds a role.
+- The user asks about a specific product, library version, API, or company.
+- You're about to state a number, date, or quote you can't verify from the
+  conversation.
+- Do _not_ search for things you already know reliably or that are already
+  in the repo or context.
+
+## Method
+
+1. Check for a search/fetch tool or a configured MCP server. If none is
+   available, say so and answer from what you know — flagged as unverified.
+   Do not invent a citation.
+2. Start broad, then narrow. Turn the question into 2–4 focused queries,
+   not one vague one.
+3. Open the primary source. Prefer official docs, the vendor's own site, or
+   the original report over a blog summarizing it.
+4. Cross-check anything surprising or load-bearing against a second,
+   independent source before you rely on it.
+5. Note the date on each source — a confident older page can be wrong now.
+
+## Reporting
+
+- Cite each non-obvious claim with its source (title + link), and end with
+  a short "Sources" list.
+- Separate what the sources say from your own inference. Don't launder a
+  guess as a finding.
+- If sources conflict, say so and give the most credible reading rather
+  than averaging them.
+
+See `references/source-checklist.md`.
+
+## Anti-patterns
+
+- Answering a "what's the latest…" question from memory without checking.
+- Citing a single source for a contested or high-stakes claim.
+- Quoting a page you never actually opened.
+- Dumping raw search results instead of synthesizing an answer.

--- a/config/skills/web-research/references/source-checklist.md
+++ b/config/skills/web-research/references/source-checklist.md
@@ -1,0 +1,25 @@
+# Source checklist
+
+Run each load-bearing claim through this before you rely on it.
+
+## Judging a source
+
+- [ ] Who published it? Official/primary beats aggregator beats anonymous.
+- [ ] When? Check the publish/update date against how fast the topic moves.
+- [ ] Does it show its evidence (data, quote, link) or just assert?
+- [ ] Any incentive to mislead (advertising, promotion, an axe to grind)?
+- [ ] Does an independent second source agree on the key fact?
+
+## Query strategy
+
+- [ ] Broke the question into distinct sub-queries, not one vague search?
+- [ ] Tried the specific vendor/library/site name where relevant?
+- [ ] Searched for the primary source, not just commentary about it?
+- [ ] Looked for a more recent result when the topic changes over time?
+
+## Before you answer
+
+- [ ] Every non-obvious number, date, and quote traces to an opened source.
+- [ ] Conflicts between sources are surfaced, not silently averaged.
+- [ ] Inference is labeled as inference, separate from what sources state.
+- [ ] A "Sources" list with links is included.

--- a/config/skills/working-with-documents/SKILL.md
+++ b/config/skills/working-with-documents/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: Working with Documents
+description: Use when reading, extracting from, or generating real-world document files — PDFs, spreadsheets (CSV/Excel/Sheets), and slide decks — with available tools; preserve the source and verify the output.
+version: 1.0.0
+---
+
+# Working with Documents
+
+Documents are where real data lives: an invoice PDF, a budget spreadsheet,
+a deck to update. The job is extracting exactly what's there and producing
+files that open cleanly — with no silent data loss.
+
+## Reading and extracting
+
+- Confirm you have a tool that can actually parse the format — PDF text,
+  spreadsheet cells, slide contents. A scanned PDF needs OCR, not a text
+  parser; say so if that's the case.
+- Pull structure, not just text: tables as rows and columns, not a
+  flattened blob. Preserve headers and units.
+- Quote figures exactly as they appear, and note the page, sheet, or cell
+  so the user can check.
+- Never fill gaps with invented numbers. If a value is unreadable, mark it
+  unreadable.
+
+## Generating and editing
+
+- Work on a copy. Don't overwrite the user's original unless they ask.
+- Match the format's conventions: real formulas in spreadsheets rather than
+  pre-computed constants, consistent number and date formatting, sensible
+  column widths.
+- For an edit, change only what was requested and keep the rest intact —
+  other sheets, other pages, existing styles.
+- After writing, verify: reopen or re-parse the output and confirm the key
+  values and structure survived.
+
+## Handling tabular data
+
+- Keep types honest — a number stays a number, a date stays a date. Don't
+  turn IDs into rounded decimals.
+- Watch encoding and delimiters on CSV: commas inside values, quoting, and
+  UTF-8.
+
+See `references/formats-and-tools.md`.
+
+## Anti-patterns
+
+- Overwriting the source file in place with no backup.
+- Reporting numbers you couldn't actually read from the document.
+- Flattening a table into prose and losing the columns.
+- Writing constants where the spreadsheet should hold formulas.

--- a/config/skills/working-with-documents/references/formats-and-tools.md
+++ b/config/skills/working-with-documents/references/formats-and-tools.md
@@ -1,0 +1,30 @@
+# Formats and tools
+
+Pick the right parser/generator for the format, and know each one's traps.
+
+## PDF
+
+- Digital PDF → text/table extraction works directly.
+- Scanned PDF (image pages) → needs OCR; flag lower confidence on figures.
+- Preserve page numbers so quoted values can be traced.
+- Forms: fill named fields; don't flatten a form you were asked to edit.
+
+## Spreadsheets (CSV / Excel / Sheets)
+
+- Keep cell types: number, date, text, boolean — don't stringify numbers.
+- Preserve or write real formulas; don't bake in computed constants.
+- CSV: quote values containing commas/newlines; write UTF-8; keep a header.
+- Excel/Sheets: edit the target sheet only; leave other sheets untouched.
+- IDs and codes stay text — never let them round or lose leading zeros.
+
+## Slides / decks
+
+- Edit the requested slides; keep the template, master, and other slides.
+- Match existing fonts, colors, and layout rather than restyling.
+
+## Verification (every format)
+
+- [ ] Re-open or re-parse the output file.
+- [ ] Key values and totals match the intended result.
+- [ ] Structure intact — tables, sheets, pages, formatting.
+- [ ] Original source left unmodified (worked on a copy).

--- a/config/skills/writing-plans/SKILL.md
+++ b/config/skills/writing-plans/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: Writing Plans
+description: Use before implementing anything non-trivial — turn a task into a short, ordered list of small, verifiable steps with concrete file paths, so work is reviewable before code is written.
+version: 1.0.0
+---
+
+# Writing Plans
+
+A plan is a cheap place to be wrong. Sketch the work as small, ordered,
+verifiable steps _before_ writing code — it surfaces unknowns, gets
+agreement on approach, and prevents half-built dead ends.
+
+## When to plan
+
+Plan when the task touches more than one file, has an unclear approach,
+or is easy to get wrong. Skip the ceremony for a one-line fix.
+
+## What a good plan contains
+
+1. **Goal** — one or two sentences: what will be true when this is done.
+2. **Constraints & assumptions** — what must not change, and what you're
+   taking as given (call these out so a reviewer can correct them).
+3. **Steps** — an ordered list of small tasks. Each step should name the
+   concrete file(s) it touches and how you'll know it worked.
+4. **Risks / open questions** — what might go wrong or needs a decision.
+
+## Sizing steps
+
+- Each step should be independently checkable — ideally it ends with a
+  test passing, a command succeeding, or an observable behavior.
+- If a step can't be verified until three later steps land, it's too big
+  or out of order. Split it or resequence.
+- Order so that something works as early as possible. Prefer a thin
+  end-to-end slice over building all the plumbing first.
+
+Good: "Add `parseRange()` to `src/lib/range.ts` + unit tests for empty,
+single, and inverted ranges."
+Too vague: "Implement the range feature."
+
+## Working the plan
+
+- Do the steps in order. When reality diverges from the plan, update the
+  plan — don't silently improvise.
+- Check off steps as their verification passes.
+- A plan is a tool, not a contract: revise it when you learn something,
+  but keep it reflecting the current intended path.
+
+See `references/plan-template.md` for a fill-in template and a
+good-vs-bad task-sizing example.

--- a/config/skills/writing-plans/references/plan-template.md
+++ b/config/skills/writing-plans/references/plan-template.md
@@ -1,0 +1,45 @@
+# Plan template
+
+Copy, fill in, keep it short. A plan longer than the change is a smell.
+
+```markdown
+# <task name>
+
+## Goal
+
+<1–2 sentences: what is true when this is done>
+
+## Constraints & assumptions
+
+- <what must NOT change / public API to preserve>
+- <assumption a reviewer could correct>
+
+## Steps
+
+1. [ ] <action> — `path/to/file.ts` — verify: <test/command/observation>
+2. [ ] <action> — `path/to/other.ts` — verify: <...>
+3. [ ] ...
+
+## Risks / open questions
+
+- <thing that might break, or a decision needed before step N>
+```
+
+## Task sizing: good vs. bad
+
+| Bad (vague / too big)  | Good (small / verifiable)                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| "Add authentication"   | "Add `verifyToken()` to `auth.ts` + tests for valid, expired, malformed tokens"       |
+| "Wire up the endpoint" | "Add `POST /skills` route returning 201 + a route test asserting the shape"           |
+| "Refactor the parser"  | "Extract `unquote()` from `parser.ts`; no behavior change; existing tests still pass" |
+
+## Sequencing rule of thumb
+
+Prefer a thin working slice first:
+
+1. Make the smallest end-to-end path work (even hard-coded).
+2. Replace the hard-coded parts with real logic, one step at a time.
+3. Handle edge cases and errors last.
+
+This way you always have something demonstrable, and integration problems
+show up on step 1 instead of step 10.


### PR DESCRIPTION
## What

Adds a set of default **agent skills** seeded to every user, split into two groups:

**Engineering / process skills** (first 5 commits + parser/seed fixes)
- `systematic-debugging`, `test-driven-development`, `writing-plans`, `code-review`, `conventional-commits`
- Parser fix: strip surrounding quotes from frontmatter values
- Seed fix: recursively seed skill subdirectories

**Action / integration skills** (this round — things beyond programming/writing/docs)
- `web-research` — search the web, read primary sources, cross-check, cite
- `browser-automation` — drive a browser via an observe-act-verify loop
- `sending-messages` — post to chat/email (Slack/Discord/Telegram/mail)
- `scheduling` — calendar availability & events with explicit timezones
- `working-with-documents` — read/generate PDFs, spreadsheets, decks
- `data-and-apis` — call REST APIs / query databases safely

## Design

The action skills are **vendor-neutral** and lean on whatever MCP server or tool the
user has configured, degrading gracefully (with setup guidance) when none is available —
rather than one brittle skill per vendor. A safety thread runs through all of them:
confirm before any outward-facing or irreversible action, and never handle secrets in chat.

The skill catalog and categories were researched across the OpenClaw, Claude, and Hermes
skill ecosystems; these six are the action categories common to all three.

## Verification

- Every `SKILL.md` parses with the real parser (valid `name`/`description`/`version`).
- No skill body trips the prompt-injection sanitizer.
- Skills test suite: **73 tests pass**, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
