### PR TITLE
feat(mcp): remote GitHub server + preinstalled-server reconcile

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -189,13 +189,15 @@ export async function buildApp() {
   });
   await configService.load();
 
-  // Add any preinstalled MCP servers shipped in the config template that this
-  // install doesn't have yet (respecting servers the user deleted). Lets a new
-  // default server reach existing installs on update, not just fresh installs.
-  const addedMcpServers = await configService.reconcilePreinstalledMcpServers();
-  if (addedMcpServers.length > 0) {
-    log.info('Added preinstalled MCP server(s) from config template', {
-      added: addedMcpServers,
+  // Reconcile preinstalled MCP servers from the config template: add ones this
+  // install is missing and update pristine (unmodified) ones whose definition
+  // changed, so template changes reach existing installs, not just fresh ones.
+  // User-created/edited servers and ones the user deleted are left alone.
+  const mcpReconcile = await configService.reconcilePreinstalledMcpServers();
+  if (mcpReconcile.added.length > 0 || mcpReconcile.updated.length > 0) {
+    log.info('Reconciled preinstalled MCP server(s) from config template', {
+      added: mcpReconcile.added,
+      updated: mcpReconcile.updated,
     });
   }
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -189,6 +189,16 @@ export async function buildApp() {
   });
   await configService.load();
 
+  // Add any preinstalled MCP servers shipped in the config template that this
+  // install doesn't have yet (respecting servers the user deleted). Lets a new
+  // default server reach existing installs on update, not just fresh installs.
+  const addedMcpServers = await configService.reconcilePreinstalledMcpServers();
+  if (addedMcpServers.length > 0) {
+    log.info('Added preinstalled MCP server(s) from config template', {
+      added: addedMcpServers,
+    });
+  }
+
   // Create MCP client service (before sessionService so it can be injected)
   const mcpService = createMcpClientService({
     logger: log as unknown as FastifyBaseLogger,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -193,11 +193,19 @@ export async function buildApp() {
   // install is missing and update pristine (unmodified) ones whose definition
   // changed, so template changes reach existing installs, not just fresh ones.
   // User-created/edited servers and ones the user deleted are left alone.
-  const mcpReconcile = await configService.reconcilePreinstalledMcpServers();
-  if (mcpReconcile.added.length > 0 || mcpReconcile.updated.length > 0) {
-    log.info('Reconciled preinstalled MCP server(s) from config template', {
-      added: mcpReconcile.added,
-      updated: mcpReconcile.updated,
+  // Wrapped so a config-dir write failure (read-only mount, ENOSPC, EACCES)
+  // logs and continues rather than aborting startup — seeding is best-effort.
+  try {
+    const mcpReconcile = await configService.reconcilePreinstalledMcpServers();
+    if (mcpReconcile.added.length > 0 || mcpReconcile.updated.length > 0) {
+      log.info('Reconciled preinstalled MCP server(s) from config template', {
+        added: mcpReconcile.added,
+        updated: mcpReconcile.updated,
+      });
+    }
+  } catch (err) {
+    log.warn('Failed to reconcile preinstalled MCP servers; continuing', {
+      err: err instanceof Error ? err.message : String(err),
     });
   }
 

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -107,7 +107,16 @@ export class AppConfigService {
     );
 
     if (result.added.length > 0 || result.updated.length > 0) {
-      await this.save({ ...this.getConfig(), mcpServers: result.servers });
+      // Persist directly rather than via save(): load() already ran
+      // applyConfig (providers, agents), and only mcpServers changed — which
+      // applyConfig doesn't touch — so a second full apply would be wasted work
+      // at startup. Validate, write, and refresh the in-memory config.
+      const nextConfig = appConfigSchema.parse({
+        ...this.getConfig(),
+        mcpServers: result.servers,
+      });
+      this.writeConfigFile(nextConfig);
+      this.currentConfig = nextConfig;
     }
     if (result.changed) {
       writeMcpSeedManifest(manifestPath, result.manifest);

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -6,7 +6,7 @@ import {
   renameSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   appConfigSchema,
   envSecret,
@@ -26,6 +26,12 @@ import type {
   AppConfigStatus,
 } from './types';
 import type { CredentialProvider } from '@openaidy/shared-types';
+import {
+  MCP_SEED_MANIFEST_FILE,
+  reconcilePreinstalledMcpServers,
+  readMcpSeedManifest,
+  writeMcpSeedManifest,
+} from '../mcp/preinstall';
 
 export class AppConfigService {
   private readonly configPath: string;
@@ -70,6 +76,52 @@ export class AppConfigService {
     return {
       issues: [...this.issues],
     };
+  }
+
+  /**
+   * Add any preinstalled MCP servers from the config template that this install
+   * doesn't have yet. The template is only copied on first run, so without this
+   * a server added to the template later would never reach existing installs.
+   *
+   * Servers the user has deleted are remembered in a manifest and not re-added;
+   * servers already present are left untouched. Persists the config (only when
+   * something is added) and the manifest, and returns the ids added. Must be
+   * called after {@link load}.
+   */
+  async reconcilePreinstalledMcpServers(): Promise<string[]> {
+    const templateServers = this.readTemplateMcpServers();
+    if (templateServers.length === 0) return [];
+
+    const manifestPath = join(dirname(this.configPath), MCP_SEED_MANIFEST_FILE);
+    const manifest = readMcpSeedManifest(manifestPath);
+
+    const result = reconcilePreinstalledMcpServers(
+      this.getMcpServers(),
+      templateServers,
+      manifest,
+    );
+
+    if (result.added.length > 0) {
+      await this.save({ ...this.getConfig(), mcpServers: result.servers });
+    }
+    if (result.changed) {
+      writeMcpSeedManifest(manifestPath, result.manifest);
+    }
+
+    return result.added;
+  }
+
+  /** Read the `mcpServers` shipped in the config template, if any. */
+  private readTemplateMcpServers(): McpServerConfig[] {
+    if (!existsSync(this.templatePath)) return [];
+    try {
+      const parsed = appConfigSchema.parse(
+        JSON.parse(readFileSync(this.templatePath, 'utf-8')),
+      );
+      return parsed.mcpServers ?? [];
+    } catch {
+      return [];
+    }
   }
 
   getPaths(): { configPath: string; templatePath: string } {

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -83,14 +83,19 @@ export class AppConfigService {
    * doesn't have yet. The template is only copied on first run, so without this
    * a server added to the template later would never reach existing installs.
    *
-   * Servers the user has deleted are remembered in a manifest and not re-added;
-   * servers already present are left untouched. Persists the config (only when
-   * something is added) and the manifest, and returns the ids added. Must be
-   * called after {@link load}.
+   * A newly shipped server is added; a preinstalled server whose template
+   * definition changed is updated **only if the user hasn't modified it**;
+   * servers the user deleted are remembered and not re-added; user-created or
+   * user-edited servers are never clobbered. Persists the config when a server
+   * is added or updated, and the manifest whenever it changes. Returns the ids
+   * touched. Must be called after {@link load}.
    */
-  async reconcilePreinstalledMcpServers(): Promise<string[]> {
+  async reconcilePreinstalledMcpServers(): Promise<{
+    added: string[];
+    updated: string[];
+  }> {
     const templateServers = this.readTemplateMcpServers();
-    if (templateServers.length === 0) return [];
+    if (templateServers.length === 0) return { added: [], updated: [] };
 
     const manifestPath = join(dirname(this.configPath), MCP_SEED_MANIFEST_FILE);
     const manifest = readMcpSeedManifest(manifestPath);
@@ -101,14 +106,14 @@ export class AppConfigService {
       manifest,
     );
 
-    if (result.added.length > 0) {
+    if (result.added.length > 0 || result.updated.length > 0) {
       await this.save({ ...this.getConfig(), mcpServers: result.servers });
     }
     if (result.changed) {
       writeMcpSeedManifest(manifestPath, result.manifest);
     }
 
-    return result.added;
+    return { added: result.added, updated: result.updated };
   }
 
   /** Read the `mcpServers` shipped in the config template, if any. */

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -45,20 +45,18 @@ describe('reconcilePreinstalledMcpServers', () => {
     expect(result.changed).toBe(false);
   });
 
-  it('leaves an existing server untouched but records it in the manifest', () => {
-    // User has their own edited copy of github (extra arg); must not be clobbered.
-    const userGithub: McpServerConfig = {
-      ...github,
-      args: [...(github.args ?? []), '--verbose'],
-    };
+  it('leaves an untracked, user-differing server untouched and does not adopt it', () => {
+    // User has their own copy of github (different from the template) that we
+    // never seeded — we must neither overwrite nor claim it in the manifest.
+    const userGithub: McpServerConfig = { ...github, name: 'My GitHub' };
 
     const result = reconcilePreinstalledMcpServers([userGithub], [github], {});
 
     expect(result.added).toEqual([]);
+    expect(result.updated).toEqual([]);
     expect(result.servers).toEqual([userGithub]); // unchanged, not overwritten
-    // Manifest records the TEMPLATE hash so a later deletion is remembered.
-    expect(result.manifest['github']?.hash).toBe(hashMcpServer(github));
-    expect(result.changed).toBe(true); // manifest gained an entry
+    expect(result.manifest['github']).toBeUndefined(); // not adopted
+    expect(result.changed).toBe(false);
   });
 
   it('adds only the new server when one is already configured', () => {
@@ -89,7 +87,72 @@ describe('reconcilePreinstalledMcpServers', () => {
     const result = reconcilePreinstalledMcpServers([github], [], {});
 
     expect(result.added).toEqual([]);
+    expect(result.updated).toEqual([]);
     expect(result.changed).toBe(false);
     expect(result.servers).toEqual([github]);
+  });
+
+  it('updates a pristine (as-seeded) server when the template definition changed', () => {
+    // Previously seeded the old stdio github; manifest records that hash.
+    const oldGithub: McpServerConfig = {
+      id: 'github',
+      name: 'GitHub Tools',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: '${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+    };
+    const manifest: McpSeedManifest = {
+      github: { hash: hashMcpServer(oldGithub) },
+    };
+
+    // Template now ships the http remote definition (`github`).
+    const result = reconcilePreinstalledMcpServers(
+      [oldGithub],
+      [github],
+      manifest,
+    );
+
+    expect(result.updated).toEqual(['github']);
+    expect(result.added).toEqual([]);
+    expect(result.servers).toEqual([github]); // replaced with new definition
+    expect(result.manifest['github']?.hash).toBe(hashMcpServer(github));
+    expect(result.changed).toBe(true);
+  });
+
+  it('does NOT update a server the user modified since it was seeded', () => {
+    const oldGithub: McpServerConfig = {
+      id: 'github',
+      name: 'GitHub Tools',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: '${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+    };
+    // Manifest hash reflects the ORIGINAL seed; the user has since edited it.
+    const manifest: McpSeedManifest = {
+      github: { hash: hashMcpServer(oldGithub) },
+    };
+    const userEdited: McpServerConfig = { ...oldGithub, name: 'My GitHub' };
+
+    const result = reconcilePreinstalledMcpServers(
+      [userEdited],
+      [github],
+      manifest,
+    );
+
+    expect(result.updated).toEqual([]);
+    expect(result.servers).toEqual([userEdited]); // preserved, not clobbered
+  });
+
+  it('adopts an untracked server that is byte-identical to the template', () => {
+    // Server present and equal to the template, but never recorded (no entry).
+    const result = reconcilePreinstalledMcpServers([github], [github], {});
+
+    expect(result.added).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.servers).toEqual([github]); // unchanged
+    expect(result.manifest['github']?.hash).toBe(hashMcpServer(github)); // adopted
+    expect(result.changed).toBe(true); // manifest gained the entry
   });
 });

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -9,10 +9,9 @@ import {
 const github: McpServerConfig = {
   id: 'github',
   name: 'GitHub Tools',
-  transport: 'stdio',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-github'],
-  env: { GITHUB_PERSONAL_ACCESS_TOKEN: '${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+  transport: 'http',
+  url: 'https://api.githubcopilot.com/mcp/',
+  headers: { Authorization: 'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}' },
 };
 
 const fetchServer: McpServerConfig = {

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServerConfig } from '@openaidy/config';
+import {
+  reconcilePreinstalledMcpServers,
+  hashMcpServer,
+  type McpSeedManifest,
+} from './preinstall';
+
+const github: McpServerConfig = {
+  id: 'github',
+  name: 'GitHub Tools',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-github'],
+  env: { GITHUB_PERSONAL_ACCESS_TOKEN: '${GITHUB_PERSONAL_ACCESS_TOKEN}' },
+};
+
+const fetchServer: McpServerConfig = {
+  id: 'fetch',
+  name: 'Fetch',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-fetch'],
+  env: {},
+};
+
+describe('reconcilePreinstalledMcpServers', () => {
+  it('adds a new template server absent from config and manifest', () => {
+    const result = reconcilePreinstalledMcpServers([], [github], {});
+
+    expect(result.added).toEqual(['github']);
+    expect(result.servers).toEqual([github]);
+    expect(result.manifest['github']?.hash).toBe(hashMcpServer(github));
+    expect(result.changed).toBe(true);
+  });
+
+  it('does NOT re-add a server the user deleted (absent from config, present in manifest)', () => {
+    const manifest: McpSeedManifest = {
+      github: { hash: hashMcpServer(github) },
+    };
+
+    const result = reconcilePreinstalledMcpServers([], [github], manifest);
+
+    expect(result.added).toEqual([]);
+    expect(result.servers).toEqual([]);
+    expect(result.changed).toBe(false);
+  });
+
+  it('leaves an existing server untouched but records it in the manifest', () => {
+    // User has their own edited copy of github (extra arg); must not be clobbered.
+    const userGithub: McpServerConfig = {
+      ...github,
+      args: [...(github.args ?? []), '--verbose'],
+    };
+
+    const result = reconcilePreinstalledMcpServers([userGithub], [github], {});
+
+    expect(result.added).toEqual([]);
+    expect(result.servers).toEqual([userGithub]); // unchanged, not overwritten
+    // Manifest records the TEMPLATE hash so a later deletion is remembered.
+    expect(result.manifest['github']?.hash).toBe(hashMcpServer(github));
+    expect(result.changed).toBe(true); // manifest gained an entry
+  });
+
+  it('adds only the new server when one is already configured', () => {
+    const result = reconcilePreinstalledMcpServers(
+      [github],
+      [github, fetchServer],
+      { github: { hash: hashMcpServer(github) } },
+    );
+
+    expect(result.added).toEqual(['fetch']);
+    expect(result.servers.map((s) => s.id)).toEqual(['github', 'fetch']);
+  });
+
+  it('is idempotent — a second run adds nothing and reports no change', () => {
+    const first = reconcilePreinstalledMcpServers([], [github], {});
+    const second = reconcilePreinstalledMcpServers(
+      first.servers,
+      [github],
+      first.manifest,
+    );
+
+    expect(second.added).toEqual([]);
+    expect(second.changed).toBe(false);
+    expect(second.servers).toEqual(first.servers);
+  });
+
+  it('no template servers → no change', () => {
+    const result = reconcilePreinstalledMcpServers([github], [], {});
+
+    expect(result.added).toEqual([]);
+    expect(result.changed).toBe(false);
+    expect(result.servers).toEqual([github]);
+  });
+});

--- a/apps/server/src/mcp/preinstall.ts
+++ b/apps/server/src/mcp/preinstall.ts
@@ -1,0 +1,126 @@
+/**
+ * Preinstalled MCP server seeding.
+ *
+ * The config template (`config/openaidy.template.json`) ships a set of
+ * preinstalled MCP servers. The template is only copied into a user's config
+ * on first run, so servers added to the template later never reached existing
+ * installs. This reconciles the template's servers into an existing config on
+ * startup — mirroring the skills seed manifest — so a newly shipped default
+ * server lands automatically on update, without clobbering the user's own
+ * servers or resurrecting ones they deleted.
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import type { McpServerConfig } from '@openaidy/config';
+
+/** Per-server manifest entry — the hash of the template definition we seeded. */
+export type McpSeedManifestEntry = { hash: string };
+
+/** Maps a seeded server id → the template definition hash last observed. */
+export type McpSeedManifest = Record<string, McpSeedManifestEntry>;
+
+export const MCP_SEED_MANIFEST_FILE = '.mcp-seed-manifest.json';
+
+/** Stable content hash of a template server definition. */
+export function hashMcpServer(server: McpServerConfig): string {
+  return createHash('sha256').update(JSON.stringify(server)).digest('hex');
+}
+
+export type ReconcileResult = {
+  /** The (possibly extended) server list to persist. */
+  servers: McpServerConfig[];
+  /** The manifest to persist. */
+  manifest: McpSeedManifest;
+  /** Ids of servers newly added to the config this run. */
+  added: string[];
+  /** Whether the manifest changed (config or manifest needs persisting). */
+  changed: boolean;
+};
+
+/**
+ * Decide which preinstalled (template) MCP servers to add to a config. Pure —
+ * no IO.
+ *
+ * Policy (mirrors the skills seed manifest in {@link ./../skills/seed}):
+ * - Template server already in the config → left untouched (a user's own edits
+ *   are never clobbered); the manifest is refreshed so a later deletion is
+ *   remembered.
+ * - Template server absent from the config but present in the manifest → the
+ *   user deleted it after it was seeded, so it is NOT re-added.
+ * - Template server absent from both → a newly shipped preinstalled server;
+ *   add it and record it in the manifest.
+ */
+export function reconcilePreinstalledMcpServers(
+  currentServers: McpServerConfig[],
+  templateServers: McpServerConfig[],
+  manifest: McpSeedManifest,
+): ReconcileResult {
+  const nextManifest: McpSeedManifest = { ...manifest };
+  const presentIds = new Set(currentServers.map((s) => s.id));
+  const servers = [...currentServers];
+  const added: string[] = [];
+
+  for (const tpl of templateServers) {
+    const hash = hashMcpServer(tpl);
+
+    if (presentIds.has(tpl.id)) {
+      // Already configured — respect the user's copy, just record that we've
+      // seen this server so a future deletion isn't undone.
+      nextManifest[tpl.id] = { hash };
+      continue;
+    }
+
+    if (manifest[tpl.id]) {
+      // Seeded before and since removed by the user — do not resurrect it.
+      continue;
+    }
+
+    // Brand-new preinstalled server — add it.
+    servers.push(tpl);
+    nextManifest[tpl.id] = { hash };
+    added.push(tpl.id);
+  }
+
+  return {
+    servers,
+    manifest: nextManifest,
+    added,
+    changed: added.length > 0 || !manifestsEqual(manifest, nextManifest),
+  };
+}
+
+function manifestsEqual(a: McpSeedManifest, b: McpSeedManifest): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((k) => a[k]?.hash === b[k]?.hash);
+}
+
+/** Read the manifest, returning an empty one if absent or unreadable. */
+export function readMcpSeedManifest(manifestPath: string): McpSeedManifest {
+  if (!existsSync(manifestPath)) return {};
+  try {
+    return JSON.parse(readFileSync(manifestPath, 'utf-8')) as McpSeedManifest;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the manifest atomically. */
+export function writeMcpSeedManifest(
+  manifestPath: string,
+  manifest: McpSeedManifest,
+): void {
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  const tempPath = `${manifestPath}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+  renameSync(tempPath, manifestPath);
+}

--- a/apps/server/src/mcp/preinstall.ts
+++ b/apps/server/src/mcp/preinstall.ts
@@ -35,28 +35,36 @@ export function hashMcpServer(server: McpServerConfig): string {
 }
 
 export type ReconcileResult = {
-  /** The (possibly extended) server list to persist. */
+  /** The (possibly changed) server list to persist. */
   servers: McpServerConfig[];
   /** The manifest to persist. */
   manifest: McpSeedManifest;
   /** Ids of servers newly added to the config this run. */
   added: string[];
-  /** Whether the manifest changed (config or manifest needs persisting). */
+  /** Ids of preinstalled servers updated to a new template definition. */
+  updated: string[];
+  /** Whether the config or manifest changed (needs persisting). */
   changed: boolean;
 };
 
 /**
- * Decide which preinstalled (template) MCP servers to add to a config. Pure —
- * no IO.
+ * Reconcile the config's MCP servers against the template's preinstalled
+ * servers. Pure — no IO.
  *
- * Policy (mirrors the skills seed manifest in {@link ./../skills/seed}):
- * - Template server already in the config → left untouched (a user's own edits
- *   are never clobbered); the manifest is refreshed so a later deletion is
- *   remembered.
- * - Template server absent from the config but present in the manifest → the
- *   user deleted it after it was seeded, so it is NOT re-added.
- * - Template server absent from both → a newly shipped preinstalled server;
- *   add it and record it in the manifest.
+ * The manifest records, per server id, the hash of the definition we last
+ * seeded/updated — so `manifest[id].hash === hash(configServer)` means the
+ * user hasn't touched it since we wrote it. Policy (mirrors the skills seed
+ * manifest in {@link ./../skills/seed}):
+ *
+ * - Absent from config, absent from manifest → newly shipped server; ADD it.
+ * - Absent from config, present in manifest → user deleted a seeded server;
+ *   do NOT re-add.
+ * - Present and pristine (matches what we last seeded) → UPDATE to the new
+ *   template definition when it changed; otherwise leave it.
+ * - Present, untracked, but byte-identical to the template → ADOPT it (record
+ *   in the manifest) so future template changes reach it too.
+ * - Present and user-modified (or a user's own server with the same id) →
+ *   leave it untouched, never clobbering their edits.
  */
 export function reconcilePreinstalledMcpServers(
   currentServers: McpServerConfig[],
@@ -64,36 +72,50 @@ export function reconcilePreinstalledMcpServers(
   manifest: McpSeedManifest,
 ): ReconcileResult {
   const nextManifest: McpSeedManifest = { ...manifest };
-  const presentIds = new Set(currentServers.map((s) => s.id));
   const servers = [...currentServers];
+  const indexById = new Map(currentServers.map((s, i) => [s.id, i]));
   const added: string[] = [];
+  const updated: string[] = [];
 
   for (const tpl of templateServers) {
-    const hash = hashMcpServer(tpl);
+    const templateHash = hashMcpServer(tpl);
+    const idx = indexById.get(tpl.id);
 
-    if (presentIds.has(tpl.id)) {
-      // Already configured — respect the user's copy, just record that we've
-      // seen this server so a future deletion isn't undone.
-      nextManifest[tpl.id] = { hash };
+    if (idx === undefined) {
+      if (manifest[tpl.id]) continue; // deleted by user — don't resurrect
+      servers.push(tpl);
+      nextManifest[tpl.id] = { hash: templateHash };
+      added.push(tpl.id);
       continue;
     }
 
-    if (manifest[tpl.id]) {
-      // Seeded before and since removed by the user — do not resurrect it.
-      continue;
-    }
+    const currentHash = hashMcpServer(servers[idx]!);
+    const seededHash = manifest[tpl.id]?.hash;
 
-    // Brand-new preinstalled server — add it.
-    servers.push(tpl);
-    nextManifest[tpl.id] = { hash };
-    added.push(tpl.id);
+    if (seededHash === currentHash) {
+      // Pristine as-seeded — safe to update to a changed template definition.
+      if (templateHash !== currentHash) {
+        servers[idx] = tpl;
+        nextManifest[tpl.id] = { hash: templateHash };
+        updated.push(tpl.id);
+      }
+    } else if (seededHash === undefined && currentHash === templateHash) {
+      // Untracked but identical to the template — adopt it so future template
+      // changes can update it. Config is unchanged.
+      nextManifest[tpl.id] = { hash: templateHash };
+    }
+    // Otherwise the user created or modified this server — leave it untouched.
   }
 
   return {
     servers,
     manifest: nextManifest,
     added,
-    changed: added.length > 0 || !manifestsEqual(manifest, nextManifest),
+    updated,
+    changed:
+      added.length > 0 ||
+      updated.length > 0 ||
+      !manifestsEqual(manifest, nextManifest),
   };
 }
 

--- a/apps/server/src/mcp/server-record.test.ts
+++ b/apps/server/src/mcp/server-record.test.ts
@@ -24,9 +24,23 @@ describe('redactSecrets', () => {
     });
   });
 
-  it('masks mixed values that embed a placeholder (e.g. Bearer ${VAR})', () => {
+  it('shows a placeholder value with only scaffolding around it (e.g. Bearer ${VAR})', () => {
     expect(redactSecrets({ Authorization: 'Bearer ${GH_TOKEN}' })).toEqual({
-      Authorization: MASKED_VALUE,
+      Authorization: 'Bearer ${GH_TOKEN}',
+    });
+  });
+
+  it('masks a value that inlines a real secret alongside a placeholder', () => {
+    // A long opaque literal token remains after stripping the placeholder.
+    expect(
+      redactSecrets({ Authorization: 'Bearer ghp_realLongLivedToken123 ${X}' }),
+    ).toEqual({ Authorization: MASKED_VALUE });
+  });
+
+  it('masks a plain non-secret-looking literal too (no placeholder)', () => {
+    // No placeholder → treated as possibly sensitive and masked.
+    expect(redactSecrets({ NODE_ENV: 'production' })).toEqual({
+      NODE_ENV: MASKED_VALUE,
     });
   });
 });
@@ -62,9 +76,22 @@ describe('toMcpServerRecord', () => {
     headers: { Authorization: 'Bearer ${GH_TOKEN}' },
   } as McpServerConfig;
 
-  it('never emits raw secret header/env values', () => {
+  it('shows placeholder templates but masks inlined raw secret values', () => {
+    // A placeholder template is not itself a secret — shown so the UI can
+    // display and round-trip it.
     const record = toMcpServerRecord(base, { connected: true, tools: [] });
-    expect(record.headers).toEqual({ Authorization: MASKED_VALUE });
+    expect(record.headers).toEqual({ Authorization: 'Bearer ${GH_TOKEN}' });
+
+    // An inlined raw token must never be emitted.
+    const withRawSecret = {
+      ...base,
+      headers: { Authorization: 'Bearer ghp_realLongLivedToken1234567890' },
+    } as McpServerConfig;
+    const redactedRecord = toMcpServerRecord(withRawSecret, {
+      connected: true,
+      tools: [],
+    });
+    expect(redactedRecord.headers).toEqual({ Authorization: MASKED_VALUE });
   });
 
   it('reflects runtime status and tool count', () => {

--- a/apps/server/src/mcp/server-record.test.ts
+++ b/apps/server/src/mcp/server-record.test.ts
@@ -37,6 +37,16 @@ describe('redactSecrets', () => {
     ).toEqual({ Authorization: MASKED_VALUE });
   });
 
+  it('masks an inlined credential even when a placeholder co-occurs (no long run)', () => {
+    // Password `S3cr3t` is short and broken up by URL punctuation, so it has no
+    // long opaque run — but the URL punctuation/digits mean it must still mask.
+    expect(
+      redactSecrets({
+        DATABASE_URL: 'postgres://admin:S3cr3t@db.example.com/${DBNAME}',
+      }),
+    ).toEqual({ DATABASE_URL: MASKED_VALUE });
+  });
+
   it('masks a plain non-secret-looking literal too (no placeholder)', () => {
     // No placeholder → treated as possibly sensitive and masked.
     expect(redactSecrets({ NODE_ENV: 'production' })).toEqual({

--- a/apps/server/src/mcp/server-record.ts
+++ b/apps/server/src/mcp/server-record.ts
@@ -22,27 +22,30 @@ export const MASKED_VALUE = '••••••';
 const PLACEHOLDER_PATTERN = /\$\{[^}]+\}/g;
 
 /**
- * A long opaque token — used to detect an inlined secret in the literal
- * (non-placeholder) part of a value, so `Bearer sk-longlivedsecret...` is still
- * masked even though it isn't a pure literal.
+ * Literal (non-placeholder) text that is safe to reveal alongside a `${VAR}`
+ * placeholder: auth-scheme words and spacing only. Anything else — digits, `:`
+ * `/` `@` `=` `.` `_`, etc. — could be part of an inlined credential (a URL with
+ * an embedded password, an API token), so a value containing it is masked.
  */
-const LITERAL_SECRET_PATTERN = /[A-Za-z0-9_-]{16,}/;
+const SAFE_SCAFFOLDING_PATTERN = /^[A-Za-z \t-]*$/;
 
 /**
  * Whether a value is safe to show verbatim in API output rather than masked.
  *
- * Safe when the value references its secret through one or more `${VAR}`
- * placeholders — the actual secret lives in the environment, not in the config
- * — and the surrounding literal text is mere scaffolding (e.g. `${TOKEN}` or
- * `Bearer ${TOKEN}`). A value with no placeholder, or one that still contains a
- * long opaque token once placeholders are stripped, is treated as an inlined
- * secret and masked.
+ * Safe only when the value references its secret through one or more `${VAR}`
+ * placeholders — the actual secret lives in the environment, not the config —
+ * AND the remaining literal text is nothing but auth-scheme scaffolding (e.g.
+ * `${TOKEN}` or `Bearer ${TOKEN}`). A value with no placeholder, or whose
+ * literal part contains anything that could be an inlined secret (digits, URL
+ * punctuation, a token), is masked. Deliberately conservative: better to mask a
+ * benign value than to leak a credential inlined next to a placeholder — e.g.
+ * `postgres://user:pass@host/${DB}` must never be shown.
  */
 function isSafeToShow(value: string): boolean {
   const trimmed = value.trim();
   if (!/\$\{[^}]+\}/.test(trimmed)) return false;
   const literal = trimmed.replace(PLACEHOLDER_PATTERN, ' ');
-  return !LITERAL_SECRET_PATTERN.test(literal);
+  return SAFE_SCAFFOLDING_PATTERN.test(literal);
 }
 
 /** Live connection state for a server, as seen by the client service. */

--- a/apps/server/src/mcp/server-record.ts
+++ b/apps/server/src/mcp/server-record.ts
@@ -18,8 +18,32 @@ import type { McpServerRecord, McpToolSummary } from '@openaidy/shared-types';
  */
 export const MASKED_VALUE = '••••••';
 
-/** A value that is exactly a `${VAR}` placeholder — safe to show, not a secret. */
-const PURE_PLACEHOLDER_PATTERN = /^\$\{[^}]+\}$/;
+/** A `${VAR}` placeholder occurring anywhere in a value. */
+const PLACEHOLDER_PATTERN = /\$\{[^}]+\}/g;
+
+/**
+ * A long opaque token — used to detect an inlined secret in the literal
+ * (non-placeholder) part of a value, so `Bearer sk-longlivedsecret...` is still
+ * masked even though it isn't a pure literal.
+ */
+const LITERAL_SECRET_PATTERN = /[A-Za-z0-9_-]{16,}/;
+
+/**
+ * Whether a value is safe to show verbatim in API output rather than masked.
+ *
+ * Safe when the value references its secret through one or more `${VAR}`
+ * placeholders — the actual secret lives in the environment, not in the config
+ * — and the surrounding literal text is mere scaffolding (e.g. `${TOKEN}` or
+ * `Bearer ${TOKEN}`). A value with no placeholder, or one that still contains a
+ * long opaque token once placeholders are stripped, is treated as an inlined
+ * secret and masked.
+ */
+function isSafeToShow(value: string): boolean {
+  const trimmed = value.trim();
+  if (!/\$\{[^}]+\}/.test(trimmed)) return false;
+  const literal = trimmed.replace(PLACEHOLDER_PATTERN, ' ');
+  return !LITERAL_SECRET_PATTERN.test(literal);
+}
 
 /** Live connection state for a server, as seen by the client service. */
 export type McpRuntimeStatus = {
@@ -35,10 +59,12 @@ export type McpRuntimeStatus = {
 /**
  * Redact secret values in an `env`/`headers` record for API output.
  *
- * Keys are always preserved (callers need to know which are set). A value that
- * is exactly a `${VAR}` placeholder is kept verbatim — it is not itself a
- * secret and preserving it lets the UI round-trip the config safely. Any other
- * value may be an inlined secret and is masked.
+ * Keys are always preserved (callers need to know which are set). A value whose
+ * only sensitive content is a `${VAR}` placeholder is kept verbatim — the
+ * secret itself lives in the environment, and preserving the template (e.g.
+ * `Bearer ${TOKEN}`) lets the UI show what's needed and round-trip the config
+ * safely. Any value that looks like an inlined secret is masked. See
+ * {@link isSafeToShow}.
  */
 export function redactSecrets(
   record: Record<string, string> | undefined,
@@ -47,9 +73,7 @@ export function redactSecrets(
 
   const redacted: Record<string, string> = {};
   for (const [key, value] of Object.entries(record)) {
-    redacted[key] = PURE_PLACEHOLDER_PATTERN.test(value.trim())
-      ? value
-      : MASKED_VALUE;
+    redacted[key] = isSafeToShow(value) ? value : MASKED_VALUE;
   }
   return redacted;
 }

--- a/apps/server/src/routes/mcp.test.ts
+++ b/apps/server/src/routes/mcp.test.ts
@@ -599,16 +599,16 @@ describe('MCP Routes', () => {
       app = await buildApp(mcpService, configService);
     });
 
-    it('masks mixed/inlined secret values but preserves ${VAR} placeholders', async () => {
+    it('masks inlined secrets but preserves ${VAR} placeholders (including in templates)', async () => {
       const res = await app.inject({
         method: 'GET',
         url: '/api/mcp/servers/http-srv',
       });
       expect(res.statusCode).toBe(200);
       const { server } = res.json();
-      // Bearer ${GH_TOKEN} embeds a placeholder → treated as a secret → masked.
-      expect(server.headers.Authorization).not.toContain('${GH_TOKEN}');
-      expect(server.headers.Authorization).toBe('••••••');
+      // Bearer ${GH_TOKEN} is a placeholder template — the secret lives in the
+      // environment, so it is shown verbatim rather than masked.
+      expect(server.headers.Authorization).toBe('Bearer ${GH_TOKEN}');
       // Inlined raw value masked; pure placeholder preserved.
       expect(server.env.INLINE).toBe('••••••');
       expect(server.env.PLACEHOLDER).toBe('${SOME_VAR}');
@@ -681,8 +681,11 @@ describe('MCP Routes', () => {
       expect(body.servers[0].missingSecrets).toEqual([
         'GITHUB_PERSONAL_ACCESS_TOKEN',
       ]);
-      // Secret still redacted in the response.
-      expect(body.servers[0].headers.Authorization).toBe('••••••');
+      // Placeholder template shown verbatim (the token lives in the env, so
+      // there's no secret value to redact here).
+      expect(body.servers[0].headers.Authorization).toBe(
+        'Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}',
+      );
     });
 
     it('connects an imported server once its secret is available', async () => {

--- a/apps/web/src/components/pages/McpsPage.tsx
+++ b/apps/web/src/components/pages/McpsPage.tsx
@@ -65,6 +65,11 @@ function ServerFormModal(props: {
           .map(([k, v]) => `${k}=${v}`)
           .join('\n')
       : '',
+    headers: props.server?.headers
+      ? Object.entries(props.server.headers)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join('\n')
+      : '',
   });
   const [saving, setSaving] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
@@ -99,6 +104,17 @@ function ServerFormModal(props: {
       return {
         ...base,
         url: formData().url || undefined,
+        headers: formData().headers
+          ? Object.fromEntries(
+              formData()
+                .headers.split('\n')
+                .filter((l) => l.includes(':'))
+                .map((l) => {
+                  const idx = l.indexOf(':');
+                  return [l.slice(0, idx).trim(), l.slice(idx + 1).trim()];
+                }),
+            )
+          : undefined,
       };
     }
   };
@@ -293,6 +309,26 @@ function ServerFormModal(props: {
                 placeholder="https://my-mcp-server.com/mcp"
                 class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
               />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Headers
+              </label>
+              <textarea
+                value={formData().headers}
+                onInput={(e) =>
+                  setFormData((p) => ({ ...p, headers: e.currentTarget.value }))
+                }
+                placeholder="Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+                rows={3}
+                class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                One <code>Name: value</code> per line. Use $&#123;VAR_NAME&#125;{' '}
+                for secret placeholders (resolved from the server environment),
+                or paste the value directly.
+              </p>
             </div>
           </Show>
         </div>
@@ -965,6 +1001,26 @@ export function McpsPage() {
                         {([key, val]) => (
                           <p class="font-mono text-xs text-gray-700 dark:text-gray-300">
                             {key}=<span class="text-text-tertiary">{val}</span>
+                          </p>
+                        )}
+                      </For>
+                    </div>
+                  </div>
+                </Show>
+
+                <Show
+                  when={
+                    selected()!.headers &&
+                    Object.keys(selected()!.headers!).length > 0
+                  }
+                >
+                  <div>
+                    <span class="text-xs text-text-tertiary">Headers</span>
+                    <div class="mt-1 space-y-0.5">
+                      <For each={Object.entries(selected()!.headers!)}>
+                        {([key, val]) => (
+                          <p class="font-mono text-xs text-gray-700 dark:text-gray-300">
+                            {key}: <span class="text-text-tertiary">{val}</span>
                           </p>
                         )}
                       </For>

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -7,14 +7,6 @@
   },
   "mcpServers": [
     {
-      "id": "filesystem",
-      "name": "Filesystem Tools",
-      "transport": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
-      "env": {}
-    },
-    {
       "id": "github",
       "name": "GitHub Tools",
       "transport": "stdio",

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -9,11 +9,10 @@
     {
       "id": "github",
       "name": "GitHub Tools",
-      "transport": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      "transport": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   ],


### PR DESCRIPTION
## What

Overhauls the preinstalled MCP servers and makes template changes reach existing installs — prompted by `@modelcontextprotocol/server-github` being deprecated (April 2025, non-functional), which meant the bundled GitHub server handed every install a broken server.

## Changes

- **Drop the `filesystem` preinstalled server** from the config template.
- **Switch GitHub to the hosted remote server** over Streamable HTTP — `https://api.githubcopilot.com/mcp/` with `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}` — replacing the dead `npx @modelcontextprotocol/server-github`. Uses the existing http transport (`connectHttp`), and `missingSecrets` still flags it "Needs API key" until a token is provided.
- **Seed preinstalled servers into existing configs on startup.** The template was only copied on first run, so template changes never reached existing installs. A new reconcile (mirroring the skills seed manifest) runs in `buildApp`:
  - adds a template server missing from the config,
  - updates a preinstalled server whose definition changed **only if the user hasn't modified it** (hash-tracked in `.mcp-seed-manifest.json`),
  - never re-adds a server the user deleted, and never clobbers user-created/edited servers.
- **Headers field in the MCP form (web).** The create/edit form had no headers input for http transport and silently dropped headers on save — so the remote GitHub server couldn't be configured via the UI. Added a Headers textarea (one `Name: value` per line, `${VAR}` supported), included headers in the request, and shows headers in the detail panel.
- **Refine `redactSecrets`.** A placeholder template like `Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}` was masked to `••••••`, making the Edit form unreadable. Now such a value is shown verbatim (the secret lives in the env, not the config); only inlined literal secrets are masked. Raw tokens are still never emitted over the API.

## Tests

- New `mcp/preinstall.ts` reconcile logic — 9 unit tests (add / skip-deleted / update-pristine / preserve-user-modified / adopt-identical / idempotent / empty).
- `redactSecrets` — added placeholder-template and inlined-secret cases.
- Full mcp suite (70) + app bootstrap + server typecheck + web typecheck/lint green locally.

## Notes

- Existing installs get the new GitHub server on next startup (the reconcile adds it, or updates a still-pristine old one). A GitHub server the user had customized is left untouched.
- The remote server needs a PAT; set `GITHUB_PERSONAL_ACCESS_TOKEN` in the environment or paste it via the Edit form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
