### PR TITLE
feat(mcp): preinstall additional default MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ coverage
 .cache
 .temp
 .tmp
+# Playwright MCP screenshot/artifact output dir (created wherever the server runs)
+.playwright-mcp/
 .DS_Store
 *.log
 apps/web/.solid

--- a/README.md
+++ b/README.md
@@ -134,6 +134,38 @@ Your skill instructions here.
 
 OpenAidy connects to external MCP servers via stdio or HTTP transport. Configure servers through the UI or the REST API at `POST /api/mcp/servers`.
 
+### Preinstalled servers
+
+The following MCP servers ship preinstalled (reconciled into every install on startup from `config/openaidy.template.json`):
+
+| Server              | Transport | Auth                              | Notes                                                                                                          |
+| ------------------- | --------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| GitHub              | http      | `${GITHUB_PERSONAL_ACCESS_TOKEN}` | [PAT](https://github.com/settings/tokens) with `repo` + `read:user` scopes                                     |
+| Sequential Thinking | stdio     | none                              | step-by-step reasoning                                                                                         |
+| Time                | stdio     | none                              | time + timezone conversion                                                                                     |
+| Playwright Browser  | stdio     | none                              | Microsoft-maintained browser automation                                                                        |
+| Context7 Docs       | http      | optional                          | [free tier](https://context7.com/dashboard) works without a key; higher rate limits with `${CONTEXT7_API_KEY}` |
+| Brave Search        | stdio     | `${BRAVE_API_KEY}`                | [free tier](https://brave.com/search/api/) (~2000 req/month)                                                   |
+| Tavily Search       | stdio     | `${TAVILY_API_KEY}`               | [free tier](https://tavily.com/)                                                                               |
+
+#### Setting API keys
+
+Servers that require a secret reference it as `${VAR_NAME}` in `headers` (http) or `env` (stdio). Two ways to satisfy:
+
+1. **Set the env var before starting the server** — recommended. Secrets stay out of the config file:
+   ```bash
+   export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_…
+   export BRAVE_API_KEY=…
+   openaidy start
+   ```
+2. **Edit the server via the UI** (`MCP` page → Edit) and replace `${VAR}` with the literal key. This persists the key in `~/.openaidy/config.json` — convenient but less secure.
+
+A server whose `${VAR}` is unset sits in "Awaiting configuration" instead of trying (and failing) to connect — set the env var or paste the key to activate it.
+
+#### Adding or removing preinstalled servers
+
+Edit `config/openaidy.template.json` and add/remove entries. On the next server start, `apps/server/src/mcp/preinstall.ts` reconciles: new entries are added, updated entries replace pristine ones, and servers the user has deleted are not resurrected. User-edited entries are never clobbered.
+
 ## Architecture
 
 See the [`docs/`](./docs/) directory for detailed documentation:

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -23,6 +23,66 @@ const fetchServer: McpServerConfig = {
   env: {},
 };
 
+const sequentialThinking: McpServerConfig = {
+  id: 'sequential-thinking',
+  name: 'Sequential Thinking',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-sequential-thinking'],
+};
+
+const time: McpServerConfig = {
+  id: 'time',
+  name: 'Time',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-time'],
+};
+
+const playwright: McpServerConfig = {
+  id: 'playwright',
+  name: 'Playwright Browser',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@playwright/mcp@latest'],
+};
+
+const context7: McpServerConfig = {
+  id: 'context7',
+  name: 'Context7 Docs',
+  transport: 'http',
+  url: 'https://mcp.context7.com/mcp',
+};
+
+const braveSearch: McpServerConfig = {
+  id: 'brave-search',
+  name: 'Brave Search',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@brave/brave-search-mcp-server'],
+  env: { BRAVE_API_KEY: '${BRAVE_API_KEY}' },
+};
+
+const tavily: McpServerConfig = {
+  id: 'tavily',
+  name: 'Tavily Search',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', 'tavily-mcp@latest'],
+  env: { TAVILY_API_KEY: '${TAVILY_API_KEY}' },
+};
+
+/** The full preinstalled set shipped in `config/openaidy.template.json`. */
+const allPreinstalled: McpServerConfig[] = [
+  github,
+  sequentialThinking,
+  time,
+  playwright,
+  context7,
+  braveSearch,
+  tavily,
+];
+
 describe('reconcilePreinstalledMcpServers', () => {
   it('adds a new template server absent from config and manifest', () => {
     const result = reconcilePreinstalledMcpServers([], [github], {});
@@ -154,5 +214,34 @@ describe('reconcilePreinstalledMcpServers', () => {
     expect(result.servers).toEqual([github]); // unchanged
     expect(result.manifest['github']?.hash).toBe(hashMcpServer(github)); // adopted
     expect(result.changed).toBe(true); // manifest gained the entry
+  });
+
+  it('seeds every preinstalled server into a fresh install with no manifest', () => {
+    // Fresh install: empty config, empty manifest, full template set.
+    const result = reconcilePreinstalledMcpServers([], allPreinstalled, {});
+
+    expect(result.added).toEqual(allPreinstalled.map((s) => s.id));
+    expect(result.updated).toEqual([]);
+    expect(result.servers).toEqual(allPreinstalled);
+    // Every preinstalled id is tracked in the manifest after seeding.
+    for (const server of allPreinstalled) {
+      expect(result.manifest[server.id]?.hash).toBe(hashMcpServer(server));
+    }
+    expect(result.changed).toBe(true);
+  });
+
+  it('is idempotent across the full preinstalled set on a second run', () => {
+    // After a successful first run, a second boot must be a no-op.
+    const first = reconcilePreinstalledMcpServers([], allPreinstalled, {});
+    const second = reconcilePreinstalledMcpServers(
+      first.servers,
+      allPreinstalled,
+      first.manifest,
+    );
+
+    expect(second.added).toEqual([]);
+    expect(second.updated).toEqual([]);
+    expect(second.changed).toBe(false);
+    expect(second.servers).toEqual(allPreinstalled);
   });
 });

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -14,6 +14,53 @@
       "headers": {
         "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
+    },
+    {
+      "id": "sequential-thinking",
+      "name": "Sequential Thinking",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-time"]
+    },
+    {
+      "id": "playwright",
+      "name": "Playwright Browser",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    {
+      "id": "context7",
+      "name": "Context7 Docs",
+      "transport": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    {
+      "id": "brave-search",
+      "name": "Brave Search",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server"],
+      "env": {
+        "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+      }
+    },
+    {
+      "id": "tavily",
+      "name": "Tavily Search",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp@latest"],
+      "env": {
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+      }
     }
   ],
   "providers": [


### PR DESCRIPTION
Add Sequential Thinking, Time, Playwright Browser, Context7 Docs, Brave Search, and Tavily Search to the preinstalled server template. Servers requiring a secret reference it as ${VAR} and sit in "Awaiting configuration" until the env var/key is provided.

- config/openaidy.template.json: new preinstalled server entries
- README: preinstalled-servers table, API-key setup, add/remove guidance
- preinstall.test.ts: reconcile coverage for the new entries
- .gitignore: ignore the Playwright MCP artifact dir (.playwright-mcp/)