### PR TITLE
feat(mcp): persist browser screenshots into agent workspace

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -302,6 +302,7 @@ export async function buildApp() {
     logger: log as unknown as FastifyBaseLogger,
     agents: agentRegistry,
     mcp: mcpService,
+    workspace: workspaceService,
     builtinTools: builtinToolRegistry,
     skills: skillRegistry,
     personality: personalityService,

--- a/apps/server/src/mcp/index.ts
+++ b/apps/server/src/mcp/index.ts
@@ -33,3 +33,12 @@ export {
   type RawMcpServerEntry,
   type RawMcpServerMap,
 } from './config-import';
+
+export {
+  SCREENSHOT_WORKSPACE_DIR,
+  isScreenshotTool,
+  stripScreenshotFilename,
+  buildScreenshotFilename,
+  persistScreenshotImages,
+  type PersistScreenshotResult,
+} from './screenshot-capture';

--- a/apps/server/src/mcp/screenshot-capture.test.ts
+++ b/apps/server/src/mcp/screenshot-capture.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isScreenshotTool,
+  stripScreenshotFilename,
+  buildScreenshotFilename,
+  persistScreenshotImages,
+  SCREENSHOT_WORKSPACE_DIR,
+} from './screenshot-capture';
+import type { WorkspaceService } from '../workspace/service';
+import type { McpToolResult } from './client';
+
+/** A minimal WorkspaceService stub that records binary writes. */
+function fakeWorkspace() {
+  const writes: Array<{ agentId: string; path: string; bytes: number }> = [];
+  const workspace = {
+    writeBinaryFile: vi.fn(
+      async (agentId: string, path: string, data: Buffer) => {
+        writes.push({ agentId, path, bytes: data.length });
+        return `/abs/${agentId}/${path}`;
+      },
+    ),
+  } as unknown as WorkspaceService;
+  return { workspace, writes };
+}
+
+const PNG_1PX =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMEAYEuJ8C4AAAAAElFTkSuQmCC';
+
+describe('isScreenshotTool', () => {
+  it('matches playwright and puppeteer screenshot tools', () => {
+    expect(isScreenshotTool('browser_take_screenshot')).toBe(true);
+    expect(isScreenshotTool('puppeteer_screenshot')).toBe(true);
+    expect(isScreenshotTool('Take_Screenshot')).toBe(true);
+  });
+
+  it('ignores the serverId:: prefix', () => {
+    expect(isScreenshotTool('playwright::browser_take_screenshot')).toBe(true);
+  });
+
+  it('does not match unrelated tools', () => {
+    expect(isScreenshotTool('browser_navigate')).toBe(false);
+    expect(isScreenshotTool('playwright::browser_click')).toBe(false);
+  });
+});
+
+describe('stripScreenshotFilename', () => {
+  it('removes filename and returns it, without mutating the original', () => {
+    const args = { filename: 'shot.png', fullPage: true };
+    const { forwardedArgs, requestedFilename } = stripScreenshotFilename(args);
+    expect(requestedFilename).toBe('shot.png');
+    expect(forwardedArgs).toEqual({ fullPage: true });
+    // Original left intact (it is persisted as part of the tool-call record).
+    expect(args).toEqual({ filename: 'shot.png', fullPage: true });
+  });
+
+  it('is a no-op when no filename is present', () => {
+    const args = { fullPage: true };
+    const { forwardedArgs, requestedFilename } = stripScreenshotFilename(args);
+    expect(requestedFilename).toBeUndefined();
+    expect(forwardedArgs).toBe(args);
+  });
+});
+
+describe('buildScreenshotFilename', () => {
+  it('uses a timestamped default when no name is requested', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: undefined,
+        mimeType: 'image/png',
+        index: 0,
+        now: 1234,
+      }),
+    ).toBe('screenshot-1234.png');
+  });
+
+  it('derives extension from the mime type', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: undefined,
+        mimeType: 'image/jpeg',
+        index: 0,
+        now: 1,
+      }),
+    ).toBe('screenshot-1.jpg');
+  });
+
+  it('keeps a requested name with a known extension', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: 'homepage.png',
+        mimeType: 'image/png',
+        index: 0,
+        now: 1,
+      }),
+    ).toBe('homepage.png');
+  });
+
+  it('appends an extension when the requested name lacks one', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: 'homepage',
+        mimeType: 'image/png',
+        index: 0,
+        now: 1,
+      }),
+    ).toBe('homepage.png');
+  });
+
+  it('strips path components and unsafe characters (traversal-safe)', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: '../../etc/pa ss.png',
+        mimeType: 'image/png',
+        index: 0,
+        now: 1,
+      }),
+    ).toBe('pa_ss.png');
+  });
+
+  it('suffixes indexes past the first before the extension', () => {
+    expect(
+      buildScreenshotFilename({
+        requestedFilename: 'shot.png',
+        mimeType: 'image/png',
+        index: 2,
+        now: 1,
+      }),
+    ).toBe('shot-2.png');
+  });
+});
+
+describe('persistScreenshotImages', () => {
+  const baseResult: McpToolResult = {
+    content: [
+      { type: 'text', text: '### Result\n- [Screenshot](page-1.png)' },
+      { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+    ],
+  };
+
+  it('writes the image into the workspace screenshots folder', async () => {
+    const { workspace, writes } = fakeWorkspace();
+    const { savedPaths, absolutePath, result } = await persistScreenshotImages({
+      result: baseResult,
+      workspace,
+      agentId: 'agent-1',
+      requestedFilename: 'homepage.png',
+      now: () => 999,
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.path).toBe(`${SCREENSHOT_WORKSPACE_DIR}/homepage.png`);
+    expect(writes[0]!.agentId).toBe('agent-1');
+    expect(writes[0]!.bytes).toBeGreaterThan(0);
+    expect(savedPaths).toEqual([`${SCREENSHOT_WORKSPACE_DIR}/homepage.png`]);
+    expect(absolutePath).toBe('/abs/agent-1/screenshots/homepage.png');
+
+    // Result is augmented with a note so the model learns the saved path.
+    const note = (result.content as Array<{ type: string; text?: string }>).at(
+      -1,
+    );
+    expect(note?.type).toBe('text');
+    expect(note?.text).toContain('screenshots/homepage.png');
+  });
+
+  it('generates a timestamped name when none is requested', async () => {
+    const { workspace, writes } = fakeWorkspace();
+    await persistScreenshotImages({
+      result: baseResult,
+      workspace,
+      agentId: 'a',
+      now: () => 42,
+    });
+    expect(writes[0]!.path).toBe(
+      `${SCREENSHOT_WORKSPACE_DIR}/screenshot-42.png`,
+    );
+  });
+
+  it('handles multiple images with suffixed names', async () => {
+    const { workspace, writes } = fakeWorkspace();
+    const multi: McpToolResult = {
+      content: [
+        { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+        { type: 'image', data: PNG_1PX, mimeType: 'image/jpeg' },
+      ],
+    };
+    const { savedPaths } = await persistScreenshotImages({
+      result: multi,
+      workspace,
+      agentId: 'a',
+      requestedFilename: 'shot.png',
+      now: () => 1,
+    });
+    expect(savedPaths).toEqual([
+      `${SCREENSHOT_WORKSPACE_DIR}/shot.png`,
+      `${SCREENSHOT_WORKSPACE_DIR}/shot-1.jpg`,
+    ]);
+    expect(writes).toHaveLength(2);
+  });
+
+  it('is a no-op when the result has no image content', async () => {
+    const { workspace, writes } = fakeWorkspace();
+    const textOnly: McpToolResult = {
+      content: [{ type: 'text', text: 'no image here' }],
+    };
+    const out = await persistScreenshotImages({
+      result: textOnly,
+      workspace,
+      agentId: 'a',
+      now: () => 1,
+    });
+    expect(writes).toHaveLength(0);
+    expect(out.savedPaths).toEqual([]);
+    expect(out.result).toBe(textOnly);
+  });
+});

--- a/apps/server/src/mcp/screenshot-capture.ts
+++ b/apps/server/src/mcp/screenshot-capture.ts
@@ -1,0 +1,202 @@
+/**
+ * Screenshot capture → workspace persistence
+ *
+ * MCP browser servers (e.g. `@playwright/mcp`) take screenshots but decide
+ * *where* to save them at server-launch time — the tool call itself has no
+ * lever to pick a directory, and the `filename` parameter is a basename only.
+ * A single shared server therefore cannot know which agent's workspace a
+ * screenshot belongs in.
+ *
+ * This module bridges that gap. It intercepts screenshot-style tool calls and
+ * persists the returned image bytes into the calling agent's workspace under a
+ * dedicated `screenshots/` folder, so screenshots always land somewhere the
+ * agent can read them back.
+ *
+ * Why inline bytes rather than the on-disk file: Playwright returns the image
+ * inline (`{ type: 'image', data: <base64> }`) only when no `filename` is
+ * supplied. So {@link stripScreenshotFilename} removes `filename` from the
+ * forwarded args to guarantee inline bytes, and we save under the requested
+ * name ourselves. This is version-independent and never depends on the
+ * server's (upstream-buggy) `--output-dir` flag or on reaching across
+ * processes for a temp file. Trade-off: Playwright downscales inline images
+ * above ~1568px / ~1.15 MP, so very large screenshots are stored at reduced
+ * resolution.
+ */
+
+import type { WorkspaceService } from '../workspace/service';
+import type { McpToolResult, McpTextContent } from './client';
+
+/** Workspace-relative folder screenshots are saved into. */
+export const SCREENSHOT_WORKSPACE_DIR = 'screenshots';
+
+/** Minimal logger shape — matches the subset of FastifyBaseLogger we use. */
+type Logger = { warn: (obj: unknown, msg?: string) => void };
+
+/**
+ * Whether a tool name looks like a screenshot capture tool. Matches
+ * `@playwright/mcp`'s `browser_take_screenshot` and, generically, any tool
+ * whose (un-prefixed) name contains "screenshot" — e.g. a Puppeteer MCP's
+ * `puppeteer_screenshot`. The `serverId::` prefix, if present, is ignored.
+ */
+export function isScreenshotTool(toolName: string): boolean {
+  const bare = toolName.includes('::')
+    ? toolName.slice(toolName.indexOf('::') + 2)
+    : toolName;
+  return /screenshot/i.test(bare);
+}
+
+/**
+ * Remove `filename` from screenshot tool args so the server returns the image
+ * inline (Playwright omits inline image bytes when a filename is given).
+ * Returns a shallow clone — the original args object (persisted as part of the
+ * tool-call record) is left untouched — plus the requested filename so the
+ * caller can reuse it when naming the workspace file.
+ */
+export function stripScreenshotFilename(args: Record<string, unknown>): {
+  forwardedArgs: Record<string, unknown>;
+  requestedFilename: string | undefined;
+} {
+  const requested =
+    typeof args['filename'] === 'string'
+      ? (args['filename'] as string)
+      : undefined;
+  if (requested === undefined) {
+    return { forwardedArgs: args, requestedFilename: undefined };
+  }
+  const forwardedArgs = { ...args };
+  delete forwardedArgs['filename'];
+  return { forwardedArgs, requestedFilename: requested };
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+const KNOWN_IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif']);
+
+/**
+ * Derive a safe workspace filename for a saved screenshot.
+ *
+ * The stem comes from the model's requested name when given (basename only —
+ * any directory component is stripped and unsafe characters replaced),
+ * otherwise a timestamped default. The extension always reflects the actual
+ * image bytes (from `mimeType`), so a `.jpg` image is never written into a
+ * `.png` file even if the model asked for one. When a single request yields
+ * multiple images, indexes past the first get a `-N` suffix to avoid
+ * collisions.
+ */
+export function buildScreenshotFilename(options: {
+  requestedFilename: string | undefined;
+  mimeType: string | undefined;
+  index: number;
+  now: number;
+}): string {
+  const ext = (options.mimeType && EXT_BY_MIME[options.mimeType]) || 'png';
+
+  let stem: string;
+  if (options.requestedFilename) {
+    // Basename only — strip any path components the model may have included.
+    const raw = options.requestedFilename.split(/[\\/]/).pop() ?? '';
+    const sanitized =
+      raw.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^\.+/, '') || 'screenshot';
+    // Drop a trailing known image extension so we can substitute the real one.
+    const dot = sanitized.lastIndexOf('.');
+    const providedExt = dot > 0 ? sanitized.slice(dot + 1).toLowerCase() : '';
+    stem =
+      dot > 0 && KNOWN_IMAGE_EXTS.has(providedExt)
+        ? sanitized.slice(0, dot)
+        : sanitized;
+  } else {
+    stem = `screenshot-${options.now}`;
+  }
+
+  const suffix = options.index > 0 ? `-${options.index}` : '';
+  return `${stem}${suffix}.${ext}`;
+}
+
+export type PersistScreenshotResult = {
+  /** The tool result, augmented with a text note of where images were saved. */
+  result: McpToolResult;
+  /** Workspace-relative paths of saved screenshots (e.g. `screenshots/x.png`). */
+  savedPaths: string[];
+  /** Absolute path of the first saved screenshot, for tool-result metadata. */
+  absolutePath?: string;
+};
+
+/**
+ * Persist any inline image content in an MCP tool result into the agent's
+ * workspace `screenshots/` folder, and append a text note reporting the saved
+ * path(s) so the model learns where the file went.
+ *
+ * A no-op (returns the result unchanged) when the result carries no inline
+ * image content — e.g. the server was configured with `imageResponses: omit`.
+ */
+export async function persistScreenshotImages(params: {
+  result: McpToolResult;
+  workspace: WorkspaceService;
+  agentId: string;
+  requestedFilename?: string | undefined;
+  logger?: Logger | undefined;
+  /** Injectable clock for deterministic tests. Defaults to `Date.now()`. */
+  now?: () => number;
+}): Promise<PersistScreenshotResult> {
+  const { result, workspace, agentId, requestedFilename, logger } = params;
+  const nowMs = (params.now ?? (() => Date.now()))();
+
+  const content = Array.isArray(result.content) ? result.content : [];
+  const images = content.filter(
+    (c): c is { type: 'image'; data: string; mimeType?: string } =>
+      c?.type === 'image' && typeof (c as { data?: unknown }).data === 'string',
+  );
+
+  if (images.length === 0) {
+    logger?.warn(
+      { agentId },
+      'Screenshot tool returned no inline image content to persist',
+    );
+    return { result, savedPaths: [] };
+  }
+
+  const savedPaths: string[] = [];
+  let firstAbsolutePath: string | undefined;
+
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i]!;
+    const filename = buildScreenshotFilename({
+      requestedFilename,
+      mimeType: image.mimeType,
+      index: i,
+      now: nowMs,
+    });
+    const relativePath = `${SCREENSHOT_WORKSPACE_DIR}/${filename}`;
+    const buffer = Buffer.from(image.data, 'base64');
+    const absolutePath = await workspace.writeBinaryFile(
+      agentId,
+      relativePath,
+      buffer,
+    );
+    savedPaths.push(relativePath);
+    if (i === 0) firstAbsolutePath = absolutePath;
+  }
+
+  const note: McpTextContent = {
+    type: 'text',
+    text: `Screenshot saved to workspace: ${savedPaths.join(', ')}`,
+  };
+
+  const augmented: McpToolResult = {
+    ...result,
+    content: [...content, note],
+    ...(firstAbsolutePath ? { absolutePath: firstAbsolutePath } : {}),
+  } as McpToolResult & { absolutePath?: string };
+
+  return {
+    result: augmented,
+    savedPaths,
+    ...(firstAbsolutePath ? { absolutePath: firstAbsolutePath } : {}),
+  };
+}

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -1,7 +1,13 @@
 import type { FastifyBaseLogger } from 'fastify';
 import type { ProviderServices } from '../providers';
 import type { AgentRegistry } from '../agents';
-import type { McpClientService } from '../mcp/client';
+import type { McpClientService, McpToolResult } from '../mcp/client';
+import type { WorkspaceService } from '../workspace/service';
+import {
+  isScreenshotTool,
+  stripScreenshotFilename,
+  persistScreenshotImages,
+} from '../mcp/screenshot-capture';
 import type { BuiltinToolRegistry } from '../tools';
 import type {
   ToolDefinition,
@@ -71,6 +77,7 @@ export class SessionMessageService {
   private readonly logger: FastifyBaseLogger | undefined;
   private readonly agents: AgentRegistry | undefined;
   private readonly mcp: McpClientService | undefined;
+  private readonly workspace: WorkspaceService | undefined;
   private readonly builtinTools: BuiltinToolRegistry | undefined;
   private readonly getDefaultAgentId: (() => string | undefined) | undefined;
   private readonly sessionsRepo: SessionsStore | undefined;
@@ -89,6 +96,7 @@ export class SessionMessageService {
     this.logger = options.logger;
     this.agents = options.agents;
     this.mcp = options.mcp;
+    this.workspace = options.workspace;
     this.builtinTools = options.builtinTools;
     this.getDefaultAgentId = options.getDefaultAgentId;
     this.skillRegistry = options.skills;
@@ -1169,12 +1177,21 @@ export class SessionMessageService {
               }
             } else {
               // Fall back to MCP tool
-              const mcpResult = await this.mcp
-                ?.callTool(
-                  tc.name.split('::')[0]!,
-                  tc.name.split('::')[1] ?? tc.name,
-                  tc.arguments,
-                )
+              const mcpServerId = tc.name.split('::')[0]!;
+              const mcpToolName = tc.name.split('::')[1] ?? tc.name;
+
+              // Screenshot tools save images to a directory chosen at the
+              // server's launch — not per-agent. Strip `filename` so the
+              // server returns the image inline, then we persist those bytes
+              // into this agent's workspace `screenshots/` folder below.
+              const captureScreenshot =
+                !!this.workspace && isScreenshotTool(mcpToolName);
+              const { forwardedArgs, requestedFilename } = captureScreenshot
+                ? stripScreenshotFilename(tc.arguments)
+                : { forwardedArgs: tc.arguments, requestedFilename: undefined };
+
+              let mcpResult = await this.mcp
+                ?.callTool(mcpServerId, mcpToolName, forwardedArgs)
                 .catch((e: unknown) => {
                   toolIsError = true;
                   return {
@@ -1186,6 +1203,35 @@ export class SessionMessageService {
                     ],
                   };
                 });
+
+              // Persist any inline screenshot image into the agent workspace.
+              // Best-effort: a failure here must not fail the tool call.
+              if (
+                captureScreenshot &&
+                this.workspace &&
+                mcpResult &&
+                !toolIsError
+              ) {
+                try {
+                  const persisted = await persistScreenshotImages({
+                    result: mcpResult as McpToolResult,
+                    workspace: this.workspace,
+                    agentId,
+                    requestedFilename,
+                    logger: this.logger,
+                  });
+                  mcpResult = persisted.result;
+                } catch (e) {
+                  this.logger?.warn(
+                    {
+                      agentId,
+                      tool: mcpToolName,
+                      error: e instanceof Error ? e.message : String(e),
+                    },
+                    'Failed to persist screenshot to workspace',
+                  );
+                }
+              }
               const mcpText = Array.isArray(
                 (mcpResult as { content?: unknown[] } | undefined)?.content,
               )

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -67,6 +67,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { ProviderServices } from '../providers';
 import type { AgentRegistry } from '../agents';
 import type { McpClientService } from '../mcp/client';
+import type { WorkspaceService } from '../workspace/service';
 import type { BuiltinToolRegistry } from '../tools';
 import type { SkillRegistry } from '../skills';
 import type { AgentPersonalityService } from '../agents/personality-service';
@@ -85,6 +86,11 @@ export type SessionMessageServiceOptions = {
   logger?: FastifyBaseLogger;
   agents?: AgentRegistry;
   mcp?: McpClientService;
+  /**
+   * Workspace service — used to persist MCP artifacts (e.g. screenshots)
+   * into the calling agent's workspace.
+   */
+  workspace?: WorkspaceService;
   /** Registry of native (in-process) builtin tools — separate from MCP */
   builtinTools?: BuiltinToolRegistry;
   /** Registry of skills for skill injection into system prompt */

--- a/apps/server/src/workspace/service.test.ts
+++ b/apps/server/src/workspace/service.test.ts
@@ -279,6 +279,45 @@ describe('WorkspaceService', () => {
     });
   });
 
+  describe('writeBinaryFile', () => {
+    it('should write raw bytes and return the absolute path', async () => {
+      const agentId = 'binary-agent';
+      await service.ensureWorkspace(agentId);
+
+      // A tiny PNG header — non-UTF-8 bytes that must round-trip exactly.
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x00]);
+      const absolutePath = await service.writeBinaryFile(
+        agentId,
+        'screenshots/shot.png',
+        bytes,
+      );
+
+      expect(absolutePath).toBe(
+        join(service.getWorkspacePath(agentId), 'screenshots', 'shot.png'),
+      );
+
+      const result = await service.readFileWithType(
+        agentId,
+        'screenshots/shot.png',
+      );
+      expect(result.mimeType).toBe('image/png');
+      expect(result.size).toBe(bytes.length);
+    });
+
+    it('should block path traversal in binary write', async () => {
+      const agentId = 'binary-traversal-agent';
+      await service.ensureWorkspace(agentId);
+
+      await expect(
+        service.writeBinaryFile(
+          agentId,
+          '../../../tmp/evil.png',
+          Buffer.from([0x00]),
+        ),
+      ).rejects.toThrow(WorkspaceError);
+    });
+  });
+
   describe('deleteFile', () => {
     it('should delete existing file', async () => {
       const agentId = 'delete-test-agent';

--- a/apps/server/src/workspace/service.ts
+++ b/apps/server/src/workspace/service.ts
@@ -459,6 +459,49 @@ export class WorkspaceService {
   }
 
   /**
+   * Write binary content (e.g. an image) to a file in the workspace.
+   *
+   * Mirrors {@link writeFile} but takes a Buffer and writes raw bytes rather
+   * than UTF-8 text — used to persist MCP tool artifacts such as screenshots.
+   * Returns the absolute path of the written file.
+   */
+  async writeBinaryFile(
+    agentId: string,
+    filePath: string,
+    data: Buffer,
+  ): Promise<string> {
+    const absolutePath = this.validatePath(agentId, filePath);
+    log.debug('Writing binary file:', {
+      agentId,
+      filePath,
+      absolutePath,
+      bytes: data.length,
+    });
+
+    try {
+      // Ensure parent directory exists
+      const parentDir = dirname(absolutePath);
+      await mkdir(parentDir, { recursive: true });
+
+      await writeFile(absolutePath, data);
+      log.info('Binary file written:', {
+        agentId,
+        filePath,
+        bytes: data.length,
+      });
+      return absolutePath;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.error('Failed to write binary file:', { agentId, filePath }, err);
+      throw new WorkspaceError(
+        `Failed to write file: ${filePath}`,
+        'WRITE_FILE_FAILED',
+        err,
+      );
+    }
+  }
+
+  /**
    * Delete a file from the workspace
    */
   async deleteFile(agentId: string, filePath: string): Promise<void> {


### PR DESCRIPTION
MCP browser servers (e.g. @playwright/mcp) choose their screenshot output directory at server-launch time, and the tool's `filename` parameter is a basename only — so a single shared server had no way to route a screenshot into the calling agent's per-agent workspace, and the returned image bytes were being dropped entirely in the session flow.

Intercept screenshot-style MCP tool calls in the live session path: strip `filename` so the server returns the image inline, then persist those bytes into `<workspace>/<agentId>/screenshots/` and augment the tool result with a note of the saved path. Version-independent — no dependency on the upstream `--output-dir` flag (playwright-mcp#1372) or cross-process temp files.

- add WorkspaceService.writeBinaryFile (raw-byte write, same containment checks)
- add mcp/screenshot-capture.ts helpers (detect, strip filename, safe naming, persist); extension always follows the actual image mimeType
- inject WorkspaceService into SessionMessageService; best-effort persistence never fails the tool call
- unit tests for the helpers and binary write