### PR TITLE
feat(workspace): preview images in the agents workspace tab

### DIFF
--- a/apps/server/src/routes/workspace.test.ts
+++ b/apps/server/src/routes/workspace.test.ts
@@ -228,6 +228,83 @@ describe('workspace routes', () => {
     });
   });
 
+  describe('GET /workspace/:agentId/raw/*', () => {
+    const readableAgent = (id: string): Agent => ({
+      id,
+      name: id,
+      enabled: true,
+      systemPrompt: 'test',
+      model: 'openai/gpt-4o-mini',
+      version: 1,
+      workspace: {
+        enabled: true,
+        workspaces: [{ path: '/project' }],
+      },
+    });
+
+    it('serves raw image bytes with a media type', async () => {
+      addAgent(readableAgent('agent-1'));
+      await workspaceService.ensureWorkspace('agent-1');
+      const wsPath = workspaceService.getWorkspacePath('agent-1');
+      await mkdir(join(wsPath, 'screenshots'), { recursive: true });
+      const png = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0x03,
+      ]);
+      await writeFile(join(wsPath, 'screenshots', 'shot.png'), png);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/workspace/agent-1/raw/screenshots/shot.png',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('image/png');
+      expect(response.rawPayload.equals(png)).toBe(true);
+    });
+
+    it('returns 404 for a missing file', async () => {
+      addAgent(readableAgent('agent-1'));
+      await workspaceService.ensureWorkspace('agent-1');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/workspace/agent-1/raw/missing.png',
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('returns 403 when the agent lacks read permission', async () => {
+      const agent: Agent = {
+        id: 'agent-1',
+        name: 'Agent 1',
+        enabled: true,
+        systemPrompt: 'test',
+        model: 'openai/gpt-4o-mini',
+        version: 1,
+        workspace: {
+          enabled: true,
+          defaultPermissions: {
+            read: false,
+            write: false,
+            delete: false,
+            list: true,
+          },
+          workspaces: [{ path: '/project' }],
+        },
+      };
+      addAgent(agent);
+      await workspaceService.ensureWorkspace('agent-1');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/workspace/agent-1/raw/anything.png',
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
   describe('POST /workspace/:agentId/files/*', () => {
     it('should create a new file', async () => {
       const agent: Agent = {

--- a/apps/server/src/routes/workspace.ts
+++ b/apps/server/src/routes/workspace.ts
@@ -79,6 +79,8 @@ export const workspaceRoutes: FastifyPluginAsync<
   );
 
   const MAX_EDITABLE_FILE_BYTES = 1_000_000;
+  // Raw preview (images etc.) tolerates larger files than the inline editor.
+  const MAX_RAW_FILE_BYTES = 25_000_000;
 
   /**
    * Validate access and return error response if denied.
@@ -213,6 +215,69 @@ export const workspaceRoutes: FastifyPluginAsync<
           reply.code(404);
           return { error: 'Path not found', code: 'NOT_FOUND' };
         }
+      }
+    },
+  );
+
+  /**
+   * GET /workspace/:agentId/raw/*
+   * Serve a file's raw bytes with its media type — used by the UI to preview
+   * images (and other binary files) that the JSON read endpoint returns with
+   * empty content. Fetched by the client through the authenticated fetch
+   * wrapper (Bearer token), so an <img src> points at an object URL, not here.
+   */
+  app.get(
+    '/workspace/:agentId/raw/*',
+    async (
+      request: FastifyRequest<{ Params: { agentId: string; '*': string } }>,
+      reply,
+    ) => {
+      const { agentId: targetAgentId, '*': filePath } = request.params;
+
+      if (!filePath) {
+        reply.code(400);
+        return { error: 'File path is required', code: 'BAD_REQUEST' };
+      }
+
+      const access = validateAccess(targetAgentId, 'read');
+      if (!access.allowed) {
+        reply.code(403);
+        return access.error;
+      }
+
+      try {
+        const file = await workspaceService.readRawFile(
+          targetAgentId,
+          filePath,
+          { maxBytes: MAX_RAW_FILE_BYTES },
+        );
+        reply.header('Content-Type', file.mimeType);
+        reply.header('Content-Length', file.size);
+        reply.header('Cache-Control', 'private, no-cache');
+        return reply.send(file.buffer);
+      } catch (error) {
+        const workspaceError = error as { code?: string };
+        if (workspaceError.code === 'FILE_NOT_FOUND') {
+          reply.code(404);
+          return { error: 'File not found', code: 'NOT_FOUND' };
+        }
+        if (workspaceError.code === 'NOT_A_FILE') {
+          reply.code(400);
+          return { error: 'Path is a directory', code: 'NOT_A_FILE' };
+        }
+        if (workspaceError.code === 'FILE_TOO_LARGE') {
+          reply.code(413);
+          return {
+            error: 'File is too large to preview',
+            code: 'FILE_TOO_LARGE',
+          };
+        }
+        log.error(
+          'Failed to read raw file',
+          error instanceof Error ? error.message : String(error),
+        );
+        reply.code(500);
+        return { error: 'Failed to read file', code: 'INTERNAL_ERROR' };
       }
     },
   );

--- a/apps/server/src/workspace/service.test.ts
+++ b/apps/server/src/workspace/service.test.ts
@@ -233,6 +233,60 @@ describe('WorkspaceService', () => {
     });
   });
 
+  describe('readRawFile', () => {
+    it('returns raw bytes and a media type from the extension', async () => {
+      const agentId = 'raw-agent';
+      await service.ensureWorkspace(agentId);
+      const wsPath = service.getWorkspacePath(agentId);
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+      await fsWriteFile(join(wsPath, 'a.png'), bytes);
+
+      const result = await service.readRawFile(agentId, 'a.png');
+      expect(result.mimeType).toBe('image/png');
+      expect(result.size).toBe(bytes.length);
+      expect(result.buffer.equals(bytes)).toBe(true);
+    });
+
+    it('uses the extension for types that sniff as text (svg)', async () => {
+      const agentId = 'raw-svg-agent';
+      await service.ensureWorkspace(agentId);
+      const wsPath = service.getWorkspacePath(agentId);
+      await fsWriteFile(join(wsPath, 'icon.svg'), '<svg></svg>');
+
+      const result = await service.readRawFile(agentId, 'icon.svg');
+      expect(result.mimeType).toBe('image/svg+xml');
+    });
+
+    it('enforces the maxBytes cap', async () => {
+      const agentId = 'raw-big-agent';
+      await service.ensureWorkspace(agentId);
+      const wsPath = service.getWorkspacePath(agentId);
+      await fsWriteFile(join(wsPath, 'big.png'), Buffer.alloc(2048));
+
+      await expect(
+        service.readRawFile(agentId, 'big.png', { maxBytes: 1024 }),
+      ).rejects.toMatchObject({ code: 'FILE_TOO_LARGE' });
+    });
+
+    it('throws FILE_NOT_FOUND for a missing file', async () => {
+      const agentId = 'raw-missing-agent';
+      await service.ensureWorkspace(agentId);
+
+      await expect(
+        service.readRawFile(agentId, 'nope.png'),
+      ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' });
+    });
+
+    it('blocks path traversal', async () => {
+      const agentId = 'raw-traversal-agent';
+      await service.ensureWorkspace(agentId);
+
+      await expect(
+        service.readRawFile(agentId, '../../../etc/hosts'),
+      ).rejects.toThrow(WorkspaceError);
+    });
+  });
+
   describe('writeFile', () => {
     it('should write file content', async () => {
       const agentId = 'write-test-agent';

--- a/apps/server/src/workspace/service.ts
+++ b/apps/server/src/workspace/service.ts
@@ -245,6 +245,96 @@ export class WorkspaceService {
   }
 
   /**
+   * File extensions whose media type can't be reliably sniffed from content
+   * (SVG is XML text; some formats share/omit magic bytes). Used by
+   * {@link resolveMediaType} to pick a Content-Type for raw serving.
+   */
+  private static readonly MIME_BY_EXTENSION: Record<string, string> = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+    bmp: 'image/bmp',
+    ico: 'image/x-icon',
+    avif: 'image/avif',
+    pdf: 'application/pdf',
+  };
+
+  /**
+   * Best-effort media type for raw serving: prefer the file extension (the
+   * name is authoritative for e.g. SVG, which sniffs as text), then fall back
+   * to content-signature detection.
+   */
+  private resolveMediaType(filePath: string, buffer: Buffer): string {
+    const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+    return (
+      WorkspaceService.MIME_BY_EXTENSION[ext] ??
+      this.detectMimeTypeFromContent(buffer)
+    );
+  }
+
+  /**
+   * Read a file's raw bytes for serving/preview (e.g. images), together with a
+   * best-effort media type. Unlike {@link readFileWithType} — which returns
+   * empty content for binary files — this returns the actual bytes.
+   *
+   * Enforces `maxBytes` (when given) so a huge file can't be pulled into
+   * memory; throws a `FILE_TOO_LARGE` {@link WorkspaceError} in that case.
+   */
+  async readRawFile(
+    agentId: string,
+    filePath: string,
+    options: { maxBytes?: number } = {},
+  ): Promise<{ buffer: Buffer; mimeType: string; size: number }> {
+    const absolutePath = this.validatePath(agentId, filePath);
+    log.debug('Reading raw file:', { agentId, filePath, absolutePath });
+
+    try {
+      const stats = await stat(absolutePath);
+      if (stats.isDirectory()) {
+        throw new WorkspaceError(
+          `Path is a directory: ${filePath}`,
+          'NOT_A_FILE',
+        );
+      }
+
+      if (options.maxBytes !== undefined && stats.size > options.maxBytes) {
+        throw new WorkspaceError(
+          `File is too large to serve (${stats.size} bytes)`,
+          'FILE_TOO_LARGE',
+        );
+      }
+
+      const buffer = await readFile(absolutePath);
+      return {
+        buffer,
+        mimeType: this.resolveMediaType(filePath, buffer),
+        size: buffer.length,
+      };
+    } catch (error) {
+      if (error instanceof WorkspaceError) {
+        throw error;
+      }
+      const err = error instanceof Error ? error : new Error(String(error));
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new WorkspaceError(
+          `File not found: ${filePath}`,
+          'FILE_NOT_FOUND',
+          err,
+        );
+      }
+      log.error('Failed to read raw file:', { agentId, filePath }, err);
+      throw new WorkspaceError(
+        `Failed to read file: ${filePath}`,
+        'READ_FILE_FAILED',
+        err,
+      );
+    }
+  }
+
+  /**
    * Validate that a requested path is within the agent's workspace.
    * Returns the validated absolute path or throws an error.
    */

--- a/apps/web/src/components/workspace/WorkspaceEditor.tsx
+++ b/apps/web/src/components/workspace/WorkspaceEditor.tsx
@@ -19,12 +19,17 @@ import {
 import {
   readWorkspaceFile,
   updateWorkspaceFile,
+  fetchWorkspaceFileBlob,
   type WorkspaceErrorResponse,
   type WorkspaceFileInfo,
   type WorkspaceFileContentResponse,
   type WorkspaceWriteResponse,
 } from '../../lib/api';
 import { CodeMirrorEditor } from './CodeMirrorEditor';
+
+// Largest image we'll pull into the browser for inline preview. Matches the
+// server's raw-serving cap (MAX_RAW_FILE_BYTES).
+const IMAGE_PREVIEW_MAX_BYTES = 25_000_000;
 
 type WorkspaceEditorProps = {
   agentId: string;
@@ -60,6 +65,9 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
   const [isSaving, setIsSaving] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = createSignal<Date | null>(null);
+  const [imageUrl, setImageUrl] = createSignal<string | null>(null);
+  const [imageLoading, setImageLoading] = createSignal(false);
+  const [imageError, setImageError] = createSignal<string | null>(null);
 
   const canWrite = createMemo(() => props.canWrite ?? true);
   const currentPath = createMemo(() => props.selectedFile?.path ?? null);
@@ -87,9 +95,53 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
     return 'other';
   });
 
+  // Images preview regardless of the inline-editor size cap (they're never
+  // editable), up to the larger raw-serving limit.
+  const canPreviewImage = createMemo(
+    () =>
+      previewKind() === 'image' &&
+      (detectedSize() ?? 0) <= IMAGE_PREVIEW_MAX_BYTES,
+  );
+
   createEffect(() => {
     props.onDirtyChange?.(isDirty());
   });
+
+  const revokeImageUrl = () => {
+    const url = imageUrl();
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+    setImageUrl(null);
+  };
+
+  // Free the object URL when the editor unmounts.
+  onCleanup(revokeImageUrl);
+
+  const loadImagePreview = async (filePath: string) => {
+    setImageLoading(true);
+    setImageError(null);
+    try {
+      const blob = await fetchWorkspaceFileBlob(props.agentId, filePath);
+      // Ignore a stale response if the selection changed mid-fetch.
+      if (currentPath() !== filePath) {
+        return;
+      }
+      revokeImageUrl();
+      setImageUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      if (currentPath() !== filePath) {
+        return;
+      }
+      setImageError(
+        err instanceof Error ? err.message : 'Failed to load image',
+      );
+    } finally {
+      if (currentPath() === filePath) {
+        setImageLoading(false);
+      }
+    }
+  };
 
   const resetEditor = () => {
     setContent('');
@@ -102,11 +154,16 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
     setLastKnownModifiedAt(null);
     setError(null);
     setLastSavedAt(null);
+    revokeImageUrl();
+    setImageError(null);
+    setImageLoading(false);
   };
 
   const loadFile = async (filePath: string) => {
     setIsLoading(true);
     setError(null);
+    revokeImageUrl();
+    setImageError(null);
 
     try {
       const response = await readWorkspaceFile(props.agentId, filePath);
@@ -130,6 +187,16 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
       setContent(response.isText ? response.content : '');
       setOriginalContent(response.isText ? response.content : '');
       setLastSavedAt(null);
+
+      // Kick off the image fetch (not awaited — it has its own spinner so the
+      // main loading state can clear immediately).
+      if (
+        !response.isText &&
+        response.mimeType.toLowerCase().startsWith('image/') &&
+        response.size <= IMAGE_PREVIEW_MAX_BYTES
+      ) {
+        void loadImagePreview(filePath);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load file');
       setContent('');
@@ -335,62 +402,90 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
           <Show
             when={canRenderTextFile()}
             fallback={
-              <div class="flex-1 flex items-center justify-center p-6">
-                <div class="w-full max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4 text-sm text-center text-text-tertiary">
-                  <Show
-                    when={isTooLarge()}
-                    fallback={
-                      <>
-                        <Show
-                          when={previewKind() === 'image'}
-                          fallback={
+              <Show
+                when={canPreviewImage()}
+                fallback={
+                  <div class="flex-1 flex items-center justify-center p-6">
+                    <div class="w-full max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4 text-sm text-center text-text-tertiary">
+                      <Show
+                        when={isTooLarge()}
+                        fallback={
+                          <>
                             <Show
-                              when={previewKind() === 'archive'}
+                              when={previewKind() === 'image'}
                               fallback={
                                 <Show
-                                  when={previewKind() === 'pdf'}
+                                  when={previewKind() === 'archive'}
                                   fallback={
-                                    <FileWarning class="w-8 h-8 mx-auto mb-3 text-gray-400" />
+                                    <Show
+                                      when={previewKind() === 'pdf'}
+                                      fallback={
+                                        <FileWarning class="w-8 h-8 mx-auto mb-3 text-gray-400" />
+                                      }
+                                    >
+                                      <FileText class="w-8 h-8 mx-auto mb-3 text-gray-400" />
+                                    </Show>
                                   }
                                 >
-                                  <FileText class="w-8 h-8 mx-auto mb-3 text-gray-400" />
+                                  <FileArchive class="w-8 h-8 mx-auto mb-3 text-gray-400" />
                                 </Show>
                               }
                             >
-                              <FileArchive class="w-8 h-8 mx-auto mb-3 text-gray-400" />
+                              <Image class="w-8 h-8 mx-auto mb-3 text-gray-400" />
                             </Show>
-                          }
-                        >
-                          <Image class="w-8 h-8 mx-auto mb-3 text-gray-400" />
-                        </Show>
 
+                            <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
+                              Preview only
+                            </p>
+                            <p class="mb-2">
+                              This file type is not editable in the workspace
+                              editor.
+                            </p>
+                            <p>Detected type: {mimeType()}</p>
+                          </>
+                        }
+                      >
+                        <AlertTriangle class="w-8 h-8 mx-auto mb-3 text-amber-500" />
                         <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
-                          Preview only
+                          File too large
                         </p>
                         <p class="mb-2">
-                          This file type is not editable in the workspace
-                          editor.
+                          This file exceeds the inline editor limit.
                         </p>
-                        <p>Detected type: {mimeType()}</p>
-                      </>
-                    }
-                  >
-                    <AlertTriangle class="w-8 h-8 mx-auto mb-3 text-amber-500" />
-                    <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
-                      File too large
-                    </p>
-                    <p class="mb-2">
-                      This file exceeds the inline editor limit.
-                    </p>
-                    <p>
-                      Size: {detectedSize() ?? 0} bytes
-                      <Show when={maxEditableBytes()}>
-                        {(limit) => ` (max editable ${limit()} bytes)`}
+                        <p>
+                          Size: {detectedSize() ?? 0} bytes
+                          <Show when={maxEditableBytes()}>
+                            {(limit) => ` (max editable ${limit()} bytes)`}
+                          </Show>
+                        </p>
                       </Show>
-                    </p>
+                    </div>
+                  </div>
+                }
+              >
+                <div class="flex-1 min-h-0 overflow-auto flex items-center justify-center p-4 bg-gray-100 dark:bg-gray-900/40">
+                  <Show when={imageError()}>
+                    <div class="w-full max-w-md rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-center text-red-700 dark:text-red-300">
+                      <AlertTriangle class="w-8 h-8 mx-auto mb-3 text-red-500" />
+                      <p class="font-medium mb-1">Failed to load image</p>
+                      <p>{imageError()}</p>
+                    </div>
+                  </Show>
+                  <Show when={imageLoading() && !imageError()}>
+                    <div class="flex items-center gap-2 text-text-tertiary text-sm">
+                      <Loader2 class="w-4 h-4 animate-spin" />
+                      Loading image...
+                    </div>
+                  </Show>
+                  <Show when={imageUrl() && !imageError()}>
+                    <img
+                      src={imageUrl()!}
+                      alt={props.selectedFile?.name ?? 'Preview'}
+                      class="max-w-full max-h-full object-contain rounded shadow-sm"
+                    />
                   </Show>
                 </div>
-              </div>
+              </Show>
             }
           >
             <CodeMirrorEditor

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -545,6 +545,33 @@ export async function readWorkspaceFile(
 }
 
 /**
+ * Fetch a workspace file's raw bytes as a Blob (e.g. for image preview).
+ *
+ * Goes through the authenticated fetch wrapper, so the caller should turn the
+ * result into an object URL (`URL.createObjectURL`) for an <img> src — a plain
+ * <img src="/api/..."> can't send the Bearer token.
+ */
+export async function fetchWorkspaceFileBlob(
+  agentId: string,
+  filePath: string,
+): Promise<Blob> {
+  const response = await apiFetch(
+    `${API_BASE}/api/workspace/${agentId}/raw/${filePath}`,
+  );
+  if (!response.ok) {
+    let message = `Failed to load file (${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // non-JSON error body — keep the status-based message
+    }
+    throw new Error(message);
+  }
+  return response.blob();
+}
+
+/**
  * Write a file to an agent's workspace
  */
 export async function writeWorkspaceFile(


### PR DESCRIPTION
The workspace file read endpoint returns empty content for binary files, so image files showed only a "Preview only" placeholder. Add a raw-serving endpoint and render images inline in the workspace editor.

- workspace route GET /workspace/:agentId/raw/* streams a file's bytes with a best-effort media type (extension first, then content sniff), gated by the 'read' permission and capped at 25 MB
- WorkspaceService.readRawFile returns raw bytes + media type (reuses the existing path-containment checks)
- web: fetchWorkspaceFileBlob pulls bytes through the authenticated fetch wrapper; WorkspaceEditor renders them via an object URL (a plain <img src> can't send the Bearer token), with loading/error states and URL cleanup
- images preview past the 1 MB inline-editor cap since they're never editable
- tests for the route and readRawFile