### PR TITLE
feat(providers): add Ollama and LM Studio local providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The following MCP servers ship preinstalled (reconciled into every install on st
 | ------------------- | --------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | GitHub              | http      | `${GITHUB_PERSONAL_ACCESS_TOKEN}` | [PAT](https://github.com/settings/tokens) with `repo` + `read:user` scopes                                     |
 | Sequential Thinking | stdio     | none                              | step-by-step reasoning                                                                                         |
-| Time                | stdio     | none                              | time + timezone conversion                                                                                     |
+| Time                | stdio     | none                              | time + timezone conversion (`@guanxiong/mcp-server-time`)                                                      |
 | Playwright Browser  | stdio     | none                              | Microsoft-maintained browser automation                                                                        |
 | Context7 Docs       | http      | optional                          | [free tier](https://context7.com/dashboard) works without a key; higher rate limits with `${CONTEXT7_API_KEY}` |
 | Brave Search        | stdio     | `${BRAVE_API_KEY}`                | [free tier](https://brave.com/search/api/) (~2000 req/month)                                                   |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,49 @@ openaidy/
 | `pnpm lint`       | Lint all packages                 |
 | `pnpm format`     | Format all files with Prettier    |
 
+## Providers
+
+OpenAidy talks to LLMs through a pluggable `Provider` abstraction. Configure providers through the UI (Settings → Providers) or via the config file. Presets ship in `packages/shared-types/src/providers-preset.ts`:
+
+| Provider      | Type               | Auth                                    |
+| ------------- | ------------------ | --------------------------------------- |
+| OpenAI        | OpenAI-compatible  | API key                                 |
+| Anthropic     | Anthropic          | API key                                 |
+| Google Gemini | Gemini             | API key                                 |
+| Groq          | OpenAI-compatible  | API key                                 |
+| DeepSeek      | OpenAI-compatible  | API key                                 |
+| MiniMax       | OpenAI-compatible  | API key                                 |
+| OpenCode Go   | OpenAI / Anthropic | API key                                 |
+| Ollama        | OpenAI-compatible  | **none — local** (`localhost:11434/v1`) |
+| LM Studio     | OpenAI-compatible  | **none — local** (`localhost:1234/v1`)  |
+
+### Local providers (Ollama, LM Studio)
+
+Local providers expose an OpenAI-compatible endpoint on `localhost` and ignore the `Authorization` header. OpenAidy's UI:
+
+- Skips the credential dialog when you pick a local preset card.
+- Auto-discovers installed/loaded models by probing `{baseUrl}/models` (click **Discover models** in the provider modal).
+- Sends a placeholder `Bearer` header that the local server ignores.
+
+Before configuring, make sure the local server is running and has at least one model loaded:
+
+```bash
+# Ollama — https://ollama.com
+ollama serve                # default port 11434
+ollama pull llama3.2        # pull a model into the local store
+
+# LM Studio — https://lmstudio.ai
+# Start the local server from the LM Studio "Developer" tab (default port 1234).
+```
+
+Then in OpenAidy: **Settings → Providers → Ollama (or LM Studio) → Discover models → Save**.
+
+If you run a local server on a non-default port or behind a tunnel, use **Add Custom** with `vendorFamily: openai-compatible` and your full base URL (e.g. `http://localhost:11435/v1`).
+
+### Custom providers
+
+Any OpenAI-compatible, Anthropic, or Gemini endpoint can be added through the **Add Custom** dialog in Settings → Providers. Provide a unique ID, display name, base URL, and (optionally) the name of an env var holding the API key.
+
 ## Skills
 
 Skills are reusable system-prompt instructions attached to agents. Bundled skills from `config/skills/` are automatically seeded to `OPENAIDY_HOME/skills/` on server startup.

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -36,7 +36,7 @@ const time: McpServerConfig = {
   name: 'Time',
   transport: 'stdio',
   command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-time'],
+  args: ['-y', '@guanxiong/mcp-server-time'],
 };
 
 const playwright: McpServerConfig = {

--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.test.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.test.ts
@@ -215,6 +215,98 @@ describe('OpenAICompatibleProvider', () => {
         expect(result.error.code).toBe('provider.unknown');
       }
     });
+
+    it('returns every model for non-OpenAI-cloud baseUrls (Ollama, LM Studio, Groq)', async () => {
+      mockListModels.mockResolvedValueOnce({
+        data: [
+          { id: 'llama3:8b', object: 'model', created: 0, owned_by: 'ollama' },
+          { id: 'mistral:7b', object: 'model', created: 0, owned_by: 'ollama' },
+          {
+            id: 'qwen2.5-coder:7b',
+            object: 'model',
+            created: 0,
+            owned_by: 'ollama',
+          },
+        ],
+      });
+
+      const provider = createOpenAICompatibleProvider({
+        apiKey: 'no-key-required',
+        baseUrl: 'http://localhost:11434/v1',
+      });
+      const result = await provider.listModels();
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.map((m) => m.id)).toEqual([
+          'llama3:8b',
+          'mistral:7b',
+          'qwen2.5-coder:7b',
+        ]);
+      }
+    });
+
+    it('filters to gpt/o1/chat/glm for api.openai.com baseUrl', async () => {
+      mockListModels.mockResolvedValueOnce({
+        data: [
+          { id: 'gpt-4o', object: 'model', created: 0, owned_by: 'openai' },
+          { id: 'whisper-1', object: 'model', created: 0, owned_by: 'openai' },
+          { id: 'dall-e-3', object: 'model', created: 0, owned_by: 'openai' },
+          {
+            id: 'text-embedding-3-large',
+            object: 'model',
+            created: 0,
+            owned_by: 'openai',
+          },
+        ],
+      });
+
+      const provider = createOpenAICompatibleProvider({
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+      });
+      const result = await provider.listModels();
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.map((m) => m.id)).toEqual(['gpt-4o']);
+      }
+    });
+  });
+
+  describe('empty API key (local providers)', () => {
+    it('falls back to a placeholder so the OpenAI SDK constructor does not throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const OpenAI = (await import('openai')).default as any;
+
+      expect(() =>
+        createOpenAICompatibleProvider({
+          apiKey: '',
+          baseUrl: 'http://localhost:11434/v1',
+        }),
+      ).not.toThrow();
+
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'no-key-required',
+          baseURL: 'http://localhost:11434/v1',
+        }),
+      );
+    });
+
+    it('uses the configured key verbatim when one is provided', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const OpenAI = (await import('openai')).default as any;
+
+      createOpenAICompatibleProvider({
+        apiKey: 'sk-real',
+        baseUrl: 'https://api.openai.com/v1',
+      });
+
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'sk-real' }),
+      );
+    });
   });
 
   describe('getModel', () => {

--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
@@ -139,9 +139,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
     this.logger = createLogger(this.config.providerId ?? PROVIDER_ID);
     this.codec = selectAdapterCodec(this.config.baseUrl);
 
-    // Initialize OpenAI SDK client
+    // Initialize OpenAI SDK client. The OpenAI SDK throws at construction
+    // when the API key is empty, so fall back to a placeholder for local /
+    // no-auth providers (e.g. Ollama, LM Studio) that ignore the header. A
+    // real cloud provider with a genuinely missing key then degrades to a
+    // clean 401 at request time instead of crashing here.
     this.client = new OpenAI({
-      apiKey: this.config.apiKey,
+      apiKey: this.config.apiKey || 'no-key-required',
       baseURL: this.config.baseUrl,
       organization: this.config.organizationId,
       defaultHeaders: this.config.headers,
@@ -231,10 +235,15 @@ export class OpenAICompatibleProvider implements ModelProvider {
     try {
       const response = await this.client.models.list();
 
-      // Filter to chat models and map to descriptors
+      // The `gpt`/`o1`/`chat`/`glm` name filter only makes sense for OpenAI
+      // itself (its /models list is noisy with embeddings, audio, etc.). Any
+      // other OpenAI-compatible endpoint — Ollama, LM Studio, Groq, … — uses
+      // arbitrary model names, so return everything it reports.
+      const isOpenAiCloud = this.config.baseUrl.includes('api.openai.com');
       const models: ModelDescriptor[] = response.data
         .filter(
           (model) =>
+            !isOpenAiCloud ||
             model.id.includes('gpt') ||
             model.id.includes('o1') ||
             model.id.includes('chat') ||

--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
@@ -239,7 +239,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
       // itself (its /models list is noisy with embeddings, audio, etc.). Any
       // other OpenAI-compatible endpoint — Ollama, LM Studio, Groq, … — uses
       // arbitrary model names, so return everything it reports.
-      const isOpenAiCloud = this.config.baseUrl.includes('api.openai.com');
+      const isOpenAiCloud = this.config.baseUrl
+        .toLowerCase()
+        .includes('api.openai.com');
       const models: ModelDescriptor[] = response.data
         .filter(
           (model) =>

--- a/apps/server/src/routes/providers.test.ts
+++ b/apps/server/src/routes/providers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fileURLToPath } from 'node:url';
 
 vi.mock('../lib/env', () => ({

--- a/apps/server/src/routes/providers.test.ts
+++ b/apps/server/src/routes/providers.test.ts
@@ -673,7 +673,7 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       json: async () => body,
     });
 
-    it('returns the model list from a successful /v1/models probe', async () => {
+    it('resolves the base URL from the preset id and returns the model list', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         okResponse({
           data: [{ id: 'llama3:8b' }, { id: 'mistral:7b' }],
@@ -684,7 +684,7 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1' },
+        payload: { id: 'ollama' },
       });
 
       expect(response.statusCode).toBe(200);
@@ -694,9 +694,10 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
           { id: 'mistral:7b', name: 'mistral:7b' },
         ],
       });
+      // Base URL comes from the preset, not the client.
       expect(fetchMock).toHaveBeenCalledWith(
         'http://localhost:11434/v1/models',
-        expect.objectContaining({ headers: {} }),
+        expect.objectContaining({ signal: expect.anything() }),
       );
     });
 
@@ -716,7 +717,7 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1' },
+        payload: { id: 'ollama' },
       });
 
       expect(response.statusCode).toBe(200);
@@ -730,31 +731,31 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1' },
+        payload: { id: 'ollama' },
       });
 
       expect(response.statusCode).toBe(200);
       expect(response.json()).toEqual({ models: [] });
     });
 
-    it('strips a trailing slash before appending /models', async () => {
+    it('resolves the LM Studio preset base URL', async () => {
       const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
       installFetch(fetchMock as unknown as typeof globalThis.fetch);
 
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1/' },
+        payload: { id: 'lmstudio' },
       });
 
       expect(response.statusCode).toBe(200);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:11434/v1/models',
+        'http://localhost:1234/v1/models',
         expect.any(Object),
       );
     });
 
-    it('returns 400 when baseUrl is missing', async () => {
+    it('returns 400 when id is missing', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
@@ -764,14 +765,71 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('returns 400 when baseUrl is not http(s)', async () => {
+    it('returns 400 for an unknown provider id', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'file:///etc/passwd' },
+        payload: { id: 'not-a-provider' },
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 400 for a non-local provider id (discovery is local-only)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { id: 'openai' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      // Must not probe the cloud provider's endpoint. (The shared global fetch
+      // also sees unrelated MCP-client traffic, so assert on the URL, not the
+      // total call count.)
+      const probedOpenAi = fetchMock.mock.calls.some(([u]) =>
+        String(u).includes('api.openai.com'),
+      );
+      expect(probedOpenAi).toBe(false);
+    });
+
+    it('does not read process.env or send an Authorization header (no secret exfiltration)', async () => {
+      process.env['TEST_DISCOVERY_SECRET'] = 'super-secret';
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      try {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/providers/discover-models',
+          // A malicious client tries the old shape: arbitrary baseUrl + env var.
+          payload: {
+            id: 'ollama',
+            baseUrl: 'https://attacker.example/v1',
+            apiKeyEnv: 'TEST_DISCOVERY_SECRET',
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        // Extra fields are ignored. The server must NOT probe the
+        // client-supplied attacker URL, and the real probe (the preset's
+        // localhost URL) must carry no Authorization header — so the env
+        // secret never leaves the process. (Filter by URL: the shared global
+        // fetch also sees unrelated MCP-client traffic.)
+        const probedAttacker = fetchMock.mock.calls.some(([u]) =>
+          String(u).includes('attacker.example'),
+        );
+        expect(probedAttacker).toBe(false);
+        const probe = fetchMock.mock.calls.find(
+          ([u]) => u === 'http://localhost:11434/v1/models',
+        );
+        expect(probe).toBeDefined();
+        expect((probe![1] as { headers?: unknown }).headers).toBeUndefined();
+      } finally {
+        delete process.env['TEST_DISCOVERY_SECRET'];
+      }
     });
 
     it('returns 502 when the provider responds with non-2xx', async () => {
@@ -786,7 +844,7 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1' },
+        payload: { id: 'ollama' },
       });
 
       expect(response.statusCode).toBe(502);
@@ -802,58 +860,11 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       const response = await app.inject({
         method: 'POST',
         url: '/api/providers/discover-models',
-        payload: { baseUrl: 'http://localhost:11434/v1' },
+        payload: { id: 'ollama' },
       });
 
       expect(response.statusCode).toBe(502);
       expect(response.json().message).toContain('ECONNREFUSED');
-    });
-
-    it('sends a Bearer Authorization header when apiKeyEnv is set and present', async () => {
-      process.env['TEST_DISCOVERY_KEY'] = 'sk-test-123';
-      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
-      installFetch(fetchMock as unknown as typeof globalThis.fetch);
-
-      try {
-        const response = await app.inject({
-          method: 'POST',
-          url: '/api/providers/discover-models',
-          payload: {
-            baseUrl: 'https://api.example.com/v1',
-            apiKeyEnv: 'TEST_DISCOVERY_KEY',
-          },
-        });
-
-        expect(response.statusCode).toBe(200);
-        expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.example.com/v1/models',
-          expect.objectContaining({
-            headers: { Authorization: 'Bearer sk-test-123' },
-          }),
-        );
-      } finally {
-        delete process.env['TEST_DISCOVERY_KEY'];
-      }
-    });
-
-    it('omits the Authorization header when apiKeyEnv is set but the env var is unset', async () => {
-      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
-      installFetch(fetchMock as unknown as typeof globalThis.fetch);
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/api/providers/discover-models',
-        payload: {
-          baseUrl: 'http://localhost:11434/v1',
-          apiKeyEnv: 'OPENAIDY_TEST_UNSET_VAR',
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:11434/v1/models',
-        expect.objectContaining({ headers: {} }),
-      );
     });
   });
 });

--- a/apps/server/src/routes/providers.test.ts
+++ b/apps/server/src/routes/providers.test.ts
@@ -650,4 +650,210 @@ describe('Input validation with Zod', { timeout: 15000 }, () => {
       expect(response.statusCode).toBe(200);
     });
   });
+
+  describe('POST /providers/discover-models', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    const installFetch = (impl: typeof globalThis.fetch) => {
+      globalThis.fetch = impl;
+    };
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    const okResponse = (body: unknown) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => body,
+    });
+
+    it('returns the model list from a successful /v1/models probe', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        okResponse({
+          data: [{ id: 'llama3:8b' }, { id: 'mistral:7b' }],
+        }),
+      );
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        models: [
+          { id: 'llama3:8b', name: 'llama3:8b' },
+          { id: 'mistral:7b', name: 'mistral:7b' },
+        ],
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:11434/v1/models',
+        expect.objectContaining({ headers: {} }),
+      );
+    });
+
+    it('filters out non-string ids from the response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        okResponse({
+          data: [
+            { id: 'good' },
+            { id: 42 },
+            { id: null },
+            { notId: 'ignored' },
+          ],
+        }),
+      );
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().models).toEqual([{ id: 'good', name: 'good' }]);
+    });
+
+    it('returns an empty model list when the response body has no data field', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({}));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ models: [] });
+    });
+
+    it('strips a trailing slash before appending /models', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1/' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:11434/v1/models',
+        expect.any(Object),
+      );
+    });
+
+    it('returns 400 when baseUrl is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 400 when baseUrl is not http(s)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'file:///etc/passwd' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 502 when the provider responds with non-2xx', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({}),
+      });
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1' },
+      });
+
+      expect(response.statusCode).toBe(502);
+      const body = response.json();
+      expect(body.error).toBe('Provider returned an error');
+      expect(body.message).toContain('401');
+    });
+
+    it('returns 502 when the fetch itself throws (server unreachable)', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: { baseUrl: 'http://localhost:11434/v1' },
+      });
+
+      expect(response.statusCode).toBe(502);
+      expect(response.json().message).toContain('ECONNREFUSED');
+    });
+
+    it('sends a Bearer Authorization header when apiKeyEnv is set and present', async () => {
+      process.env['TEST_DISCOVERY_KEY'] = 'sk-test-123';
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      try {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/providers/discover-models',
+          payload: {
+            baseUrl: 'https://api.example.com/v1',
+            apiKeyEnv: 'TEST_DISCOVERY_KEY',
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.example.com/v1/models',
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer sk-test-123' },
+          }),
+        );
+      } finally {
+        delete process.env['TEST_DISCOVERY_KEY'];
+      }
+    });
+
+    it('omits the Authorization header when apiKeyEnv is set but the env var is unset', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
+      installFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers/discover-models',
+        payload: {
+          baseUrl: 'http://localhost:11434/v1',
+          apiKeyEnv: 'OPENAIDY_TEST_UNSET_VAR',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:11434/v1/models',
+        expect.objectContaining({ headers: {} }),
+      );
+    });
+  });
 });

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -20,6 +20,7 @@ import type {
   ProviderInfo as ConnectionProviderInfo,
   ConnectProviderResponse,
 } from '@openaidy/shared-types';
+import { PROVIDER_PRESETS } from '@openaidy/shared-types';
 
 /**
  * Schema for test-invoke request
@@ -61,14 +62,18 @@ const providersQuerySchema = z.object({
 });
 
 /**
- * Schema for the model-discovery request. Probes an OpenAI-compatible
- * `{baseUrl}/models` endpoint — used to list the models installed on a local
- * provider (Ollama, LM Studio) before it's saved to config.
+ * Schema for the model-discovery request.
+ *
+ * Takes only the preset `id` of a local provider — NOT a client-supplied
+ * base URL or env-var name. The server resolves the (hardcoded, localhost)
+ * base URL from the preset itself. Accepting a caller-supplied `baseUrl` +
+ * `apiKeyEnv` previously let an authenticated caller point the server at any
+ * host (SSRF) and read any `process.env` value into the outgoing
+ * Authorization header (secret exfiltration); resolving server-side removes
+ * both.
  */
 const discoverModelsSchema = z.object({
-  baseUrl: z.string().url(),
-  /** Optional env var name holding an API key, for compatible remote gateways. */
-  apiKeyEnv: z.string().min(1).optional(),
+  id: z.string().min(1),
 });
 
 /**
@@ -384,28 +389,31 @@ export const providerRoutes: FastifyPluginAsync<ProviderRoutesOptions> = async (
         message: parsed.error.issues[0]?.message ?? 'Invalid body',
       };
     }
-    const { baseUrl, apiKeyEnv } = parsed.data;
+    const { id } = parsed.data;
 
-    if (!/^https?:\/\//i.test(baseUrl)) {
+    // Resolve the base URL server-side from the known LOCAL presets. Discovery
+    // is only offered for local (localhost, no-auth) providers, so no API key
+    // is ever needed — and never accepting a client base URL or env-var name
+    // is what keeps this endpoint free of SSRF / secret-exfiltration.
+    const preset = PROVIDER_PRESETS.find((p) => p.id === id && p.local);
+    if (!preset) {
       reply.code(400);
-      return { error: 'baseUrl must be an http(s) URL' };
+      return {
+        error: `Unknown local provider: ${id}`,
+        message: 'Model discovery is only available for local providers.',
+      };
     }
 
-    // `{baseUrl}/models` — baseUrl already includes the API version (e.g.
-    // `http://localhost:11434/v1`), matching how the adapter builds requests.
-    const url = `${baseUrl.replace(/\/$/, '')}/models`;
-    const headers: Record<string, string> = {};
-    const apiKey = apiKeyEnv ? process.env[apiKeyEnv] : undefined;
-    if (apiKey) {
-      headers['Authorization'] = `Bearer ${apiKey}`;
-    }
+    // `{baseUrl}/models` — the preset base URL already includes the API
+    // version (e.g. `http://localhost:11434/v1`).
+    const url = `${preset.baseUrl.replace(/\/$/, '')}/models`;
 
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 8000);
       let response: Response;
       try {
-        response = await fetch(url, { headers, signal: controller.signal });
+        response = await fetch(url, { signal: controller.signal });
       } finally {
         clearTimeout(timeout);
       }
@@ -423,8 +431,8 @@ export const providerRoutes: FastifyPluginAsync<ProviderRoutesOptions> = async (
       };
       const models = (body.data ?? [])
         .map((m) => (typeof m.id === 'string' ? m.id : null))
-        .filter((id): id is string => !!id)
-        .map((id) => ({ id, name: id }));
+        .filter((mid): mid is string => !!mid)
+        .map((mid) => ({ id: mid, name: mid }));
 
       return { models };
     } catch (error) {

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -61,6 +61,17 @@ const providersQuerySchema = z.object({
 });
 
 /**
+ * Schema for the model-discovery request. Probes an OpenAI-compatible
+ * `{baseUrl}/models` endpoint — used to list the models installed on a local
+ * provider (Ollama, LM Studio) before it's saved to config.
+ */
+const discoverModelsSchema = z.object({
+  baseUrl: z.string().url(),
+  /** Optional env var name holding an API key, for compatible remote gateways. */
+  apiKeyEnv: z.string().min(1).optional(),
+});
+
+/**
  * Provider routes response types
  */
 type ProviderInfo = {
@@ -356,6 +367,77 @@ export const providerRoutes: FastifyPluginAsync<ProviderRoutesOptions> = async (
       }
     },
   );
+
+  /**
+   * POST /providers/discover-models
+   * Probe an OpenAI-compatible `{baseUrl}/models` endpoint and return the
+   * models it reports. Used by the UI to auto-populate a local provider's
+   * (Ollama / LM Studio) model list before saving it to config — the model
+   * set is host-specific and can't be hardcoded in a preset.
+   */
+  app.post('/providers/discover-models', async (request, reply) => {
+    const parsed = discoverModelsSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return {
+        error: 'Invalid request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid body',
+      };
+    }
+    const { baseUrl, apiKeyEnv } = parsed.data;
+
+    if (!/^https?:\/\//i.test(baseUrl)) {
+      reply.code(400);
+      return { error: 'baseUrl must be an http(s) URL' };
+    }
+
+    // `{baseUrl}/models` — baseUrl already includes the API version (e.g.
+    // `http://localhost:11434/v1`), matching how the adapter builds requests.
+    const url = `${baseUrl.replace(/\/$/, '')}/models`;
+    const headers: Record<string, string> = {};
+    const apiKey = apiKeyEnv ? process.env[apiKeyEnv] : undefined;
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 8000);
+      let response: Response;
+      try {
+        response = await fetch(url, { headers, signal: controller.signal });
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!response.ok) {
+        reply.code(502);
+        return {
+          error: 'Provider returned an error',
+          message: `${response.status} ${response.statusText}`,
+        };
+      }
+
+      const body = (await response.json()) as {
+        data?: Array<{ id?: unknown }>;
+      };
+      const models = (body.data ?? [])
+        .map((m) => (typeof m.id === 'string' ? m.id : null))
+        .filter((id): id is string => !!id)
+        .map((id) => ({ id, name: id }));
+
+      return { models };
+    } catch (error) {
+      reply.code(502);
+      return {
+        error: 'Could not reach provider',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Unknown error probing models',
+      };
+    }
+  });
 
   /**
    * POST /providers/register

--- a/apps/web/src/components/settings/PresetProviderModal.tsx
+++ b/apps/web/src/components/settings/PresetProviderModal.tsx
@@ -1,10 +1,10 @@
 import { createMemo, createSignal, For, Show } from 'solid-js';
-import { X, Plus, Trash2 } from 'lucide-solid';
+import { X, Plus, Trash2, RefreshCw, Loader2 } from 'lucide-solid';
 import {
   type ModelPreset,
   OPENCODE_GO_ANTHROPIC_MODEL_IDS,
 } from '@openaidy/shared-types';
-import type { ProviderConfig } from '../../lib/api';
+import { discoverProviderModels, type ProviderConfig } from '../../lib/api';
 import { ModelMultiSelect } from './ModelMultiSelect';
 import type { PresetProviderModalProps } from './PresetProviderModal.types';
 
@@ -78,14 +78,71 @@ export function PresetProviderModal(props: PresetProviderModalProps) {
   const [newModelId, setNewModelId] = createSignal('');
   const [newModelName, setNewModelName] = createSignal('');
 
-  const allModels = createMemo<ModelPreset[]>(() => [
-    ...props.preset.models,
-    ...customModels().map((cm) => ({
-      id: cm.id,
-      name: cm.name,
-      custom: true as const,
-    })),
-  ]);
+  // Models discovered from a running local provider (Ollama / LM Studio).
+  // Kept separate from preset/custom models so they render as normal,
+  // pre-checked entries in the multi-select rather than removable "custom" rows.
+  const [discoveredModels, setDiscoveredModels] = createSignal<
+    { id: string; name: string }[]
+  >([]);
+  const [isDiscovering, setIsDiscovering] = createSignal(false);
+  const [discoverError, setDiscoverError] = createSignal<string | null>(null);
+  const [discoverInfo, setDiscoverInfo] = createSignal<string | null>(null);
+
+  const allModels = createMemo<ModelPreset[]>(() => {
+    const seen = new Set<string>();
+    const merged: ModelPreset[] = [];
+    for (const m of [
+      ...props.preset.models,
+      ...discoveredModels(),
+      ...customModels().map((cm) => ({
+        id: cm.id,
+        name: cm.name,
+        custom: true as const,
+      })),
+    ]) {
+      if (seen.has(m.id)) continue;
+      seen.add(m.id);
+      merged.push(m);
+    }
+    return merged;
+  });
+
+  const discoverModels = async () => {
+    setIsDiscovering(true);
+    setDiscoverError(null);
+    setDiscoverInfo(null);
+    try {
+      const found = await discoverProviderModels(
+        props.preset.baseUrl,
+        props.existingProvider?.apiKeyEnv,
+      );
+      // Don't duplicate models already offered by the preset or added manually.
+      const customIds = new Set(customModels().map((m) => m.id));
+      const fresh = found.filter(
+        (m) =>
+          !props.preset.models.some((pm) => pm.id === m.id) &&
+          !customIds.has(m.id),
+      );
+      setDiscoveredModels(fresh);
+      // Pre-select everything discovered so the user can just save.
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const m of fresh) next.add(m.id);
+        return next;
+      });
+      setDiscoverInfo(
+        found.length === 0
+          ? 'No models reported. Pull/load a model on the server, then retry.'
+          : `Found ${found.length} model${found.length === 1 ? '' : 's'}.`,
+      );
+    } catch (err) {
+      setDiscoverError(
+        err instanceof Error ? err.message : 'Could not reach the provider.',
+      );
+    } finally {
+      setIsDiscovering(false);
+    }
+  };
 
   const toggle = (modelId: string) => {
     setSelectedIds((prev) => {
@@ -179,17 +236,59 @@ export function PresetProviderModal(props: PresetProviderModalProps) {
 
         <div class="p-4 space-y-4">
           <div>
-            <label class="block text-sm font-medium text-text-primary mb-1">
-              Available Models
-            </label>
+            <div class="flex items-center justify-between mb-1">
+              <label class="block text-sm font-medium text-text-primary">
+                Available Models
+              </label>
+              <Show when={props.preset.local}>
+                <button
+                  type="button"
+                  onClick={() => void discoverModels()}
+                  disabled={isDiscovering()}
+                  class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-lg border border-gray-200 dark:border-gray-700 text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  title="List models installed on the local server"
+                >
+                  <Show
+                    when={isDiscovering()}
+                    fallback={<RefreshCw class="w-3.5 h-3.5" />}
+                  >
+                    <Loader2 class="w-3.5 h-3.5 animate-spin" />
+                  </Show>
+                  {isDiscovering() ? 'Discovering…' : 'Discover models'}
+                </button>
+              </Show>
+            </div>
             <p class="text-xs text-text-tertiary mb-2">
-              Uncheck models you don't want to expose to agents.
+              <Show
+                when={props.preset.local}
+                fallback="Uncheck models you don't want to expose to agents."
+              >
+                Click "Discover models" to list what's installed on{' '}
+                {props.preset.baseUrl}, or add one manually below.
+              </Show>
             </p>
-            <ModelMultiSelect
-              models={allModels()}
-              selectedIds={selectedIds()}
-              onToggle={toggle}
-            />
+            <Show when={discoverError()}>
+              <p class="text-xs text-red-600 dark:text-red-400 mb-2">
+                {discoverError()}
+              </p>
+            </Show>
+            <Show when={discoverInfo()}>
+              <p class="text-xs text-text-tertiary mb-2">{discoverInfo()}</p>
+            </Show>
+            <Show
+              when={allModels().length > 0}
+              fallback={
+                <div class="text-sm text-text-tertiary border border-dashed border-gray-200 dark:border-gray-700 rounded-lg p-4 text-center">
+                  No models yet.
+                </div>
+              }
+            >
+              <ModelMultiSelect
+                models={allModels()}
+                selectedIds={selectedIds()}
+                onToggle={toggle}
+              />
+            </Show>
           </div>
 
           <div class="pt-2 border-t border-gray-200 dark:border-gray-700">

--- a/apps/web/src/components/settings/PresetProviderModal.tsx
+++ b/apps/web/src/components/settings/PresetProviderModal.tsx
@@ -112,28 +112,28 @@ export function PresetProviderModal(props: PresetProviderModalProps) {
     setDiscoverError(null);
     setDiscoverInfo(null);
     try {
-      const found = await discoverProviderModels(
-        props.preset.baseUrl,
-        props.existingProvider?.apiKeyEnv,
-      );
-      // Don't duplicate models already offered by the preset or added manually.
-      const customIds = new Set(customModels().map((m) => m.id));
-      const fresh = found.filter(
-        (m) =>
-          !props.preset.models.some((pm) => pm.id === m.id) &&
-          !customIds.has(m.id),
-      );
-      setDiscoveredModels(fresh);
-      // Pre-select everything discovered so the user can just save.
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        for (const m of fresh) next.add(m.id);
-        return next;
-      });
+      const found = await discoverProviderModels(props.preset.id);
+      // Only models not already listed (preset, previously discovered, or
+      // custom) are "new". We append new ones and auto-select only those — so
+      // re-clicking Discover doesn't re-check models the user unchecked, and
+      // their prior selections survive.
+      const knownIds = new Set(allModels().map((m) => m.id));
+      const additions = found.filter((m) => !knownIds.has(m.id));
+      if (additions.length > 0) {
+        setDiscoveredModels((prev) => [...prev, ...additions]);
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          for (const m of additions) next.add(m.id);
+          return next;
+        });
+      }
       setDiscoverInfo(
         found.length === 0
           ? 'No models reported. Pull/load a model on the server, then retry.'
-          : `Found ${found.length} model${found.length === 1 ? '' : 's'}.`,
+          : `Found ${found.length} model${found.length === 1 ? '' : 's'}` +
+              (additions.length < found.length
+                ? ` (${additions.length} new).`
+                : '.'),
       );
     } catch (err) {
       setDiscoverError(

--- a/apps/web/src/components/settings/tabs/ProvidersTab.tsx
+++ b/apps/web/src/components/settings/tabs/ProvidersTab.tsx
@@ -241,8 +241,10 @@ export function ProvidersTab(props: ProvidersTabProps) {
               const isThisDisconnecting = () =>
                 isDisconnecting() && disconnectTarget()?.id === preset.id;
               const handleSelect = () => {
-                if (isConfigured()) {
-                  // If configured, show the config modal
+                if (isConfigured() || preset.local) {
+                  // Configured providers — and local providers, which need no
+                  // API key — go straight to the model-config modal. Only
+                  // remote, unconfigured providers open the credential dialog.
                   setSelectedPreset(preset);
                 } else {
                   // If not configured, show connection dialog

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1227,6 +1227,35 @@ export async function connectProviderWithApiKey(
 }
 
 /**
+ * Discover the models a provider currently serves by probing its
+ * OpenAI-compatible `{baseUrl}/models` endpoint (server-side). Used to
+ * auto-populate a local provider's (Ollama / LM Studio) model list before it
+ * is saved to config. Throws with a readable message when the server can't be
+ * reached so the modal can surface it.
+ */
+export async function discoverProviderModels(
+  baseUrl: string,
+  apiKeyEnv?: string,
+): Promise<{ id: string; name: string }[]> {
+  const res = await apiFetch(`${API_BASE}/api/providers/discover-models`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(apiKeyEnv ? { baseUrl, apiKeyEnv } : { baseUrl }),
+  });
+  const body = (await res.json()) as {
+    models?: { id: string; name: string }[];
+    error?: string;
+    message?: string;
+  };
+  if (!res.ok) {
+    throw new Error(
+      body.message || body.error || `Discovery failed (${res.status})`,
+    );
+  }
+  return body.models ?? [];
+}
+
+/**
  * Start OAuth flow for a provider.
  *
  * For MiniMax (the only OAuth-enabled provider in this phase): the

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1227,20 +1227,19 @@ export async function connectProviderWithApiKey(
 }
 
 /**
- * Discover the models a provider currently serves by probing its
- * OpenAI-compatible `{baseUrl}/models` endpoint (server-side). Used to
- * auto-populate a local provider's (Ollama / LM Studio) model list before it
- * is saved to config. Throws with a readable message when the server can't be
- * reached so the modal can surface it.
+ * Discover the models a local provider currently serves. Takes the provider's
+ * preset id (e.g. `"ollama"`); the server resolves the localhost base URL and
+ * probes its `/models` endpoint. Used to auto-populate a local provider's
+ * (Ollama / LM Studio) model list before it is saved to config. Throws with a
+ * readable message when the server can't be reached so the modal can surface it.
  */
 export async function discoverProviderModels(
-  baseUrl: string,
-  apiKeyEnv?: string,
+  id: string,
 ): Promise<{ id: string; name: string }[]> {
   const res = await apiFetch(`${API_BASE}/api/providers/discover-models`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(apiKeyEnv ? { baseUrl, apiKeyEnv } : { baseUrl }),
+    body: JSON.stringify({ id }),
   });
   const body = (await res.json()) as {
     models?: { id: string; name: string }[];

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -27,7 +27,7 @@
       "name": "Time",
       "transport": "stdio",
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-time"]
+      "args": ["-y", "@guanxiong/mcp-server-time"]
     },
     {
       "id": "playwright",

--- a/packages/cli/src/commands/providers/connect.ts
+++ b/packages/cli/src/commands/providers/connect.ts
@@ -121,6 +121,25 @@ Exit Codes:
     return { exitCode: 1, error: `Unknown provider: ${providerId}` };
   }
 
+  // Local providers (Ollama, LM Studio) ship no model list — it's host-specific
+  // and discovered from the running server. The CLI connect flow would build a
+  // config with an empty `models` array (and no API key), which the server's
+  // config schema rejects. Direct the user to the UI, which has the discovery
+  // step.
+  if (preset.local) {
+    p.log.error(
+      `${preset.name} is a local provider — configure it in the OpenAidy UI.`,
+    );
+    p.log.info(
+      `Open Settings → Providers → ${preset.name} → "Discover models", then Save. ` +
+        'No API key is required.',
+    );
+    return {
+      exitCode: 1,
+      error: 'Local providers are configured via the UI, not the CLI',
+    };
+  }
+
   // Get API key from --api-key argument
   const apiKeyIndex = args.indexOf('--api-key');
   let apiKey: string | undefined;

--- a/packages/shared-types/src/providers-preset.ts
+++ b/packages/shared-types/src/providers-preset.ts
@@ -10,7 +10,9 @@ export type ProviderPresetId =
   | 'deepseek'
   | 'minimax'
   | 'opencode-go'
-  | 'opencode-go-anthropic';
+  | 'opencode-go-anthropic'
+  | 'ollama'
+  | 'lmstudio';
 
 export type ModelPreset = {
   id: string;
@@ -29,6 +31,13 @@ export type ProviderPreset = {
   websiteUrl: string;
   documentationUrl: string;
   icon: string;
+  /**
+   * A local provider (e.g. Ollama, LM Studio) reachable at a localhost base
+   * URL and requiring no API key. The UI skips the credential/connect dialog
+   * for these and configures them directly (base URL + discovered models);
+   * the adapter sends a placeholder key the local server ignores.
+   */
+  local?: boolean;
 };
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
@@ -314,6 +323,33 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
         description: 'Previous-gen Qwen open model',
       },
     ],
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    vendorFamily: 'openai-compatible',
+    baseUrl: 'http://localhost:11434/v1',
+    websiteUrl: 'https://ollama.com',
+    documentationUrl:
+      'https://github.com/ollama/ollama/blob/main/docs/openai.md',
+    recommendedModel: '',
+    icon: 'bi-cpu',
+    local: true,
+    // Installed models are host-specific — populated via "Discover models".
+    models: [],
+  },
+  {
+    id: 'lmstudio',
+    name: 'LM Studio',
+    vendorFamily: 'openai-compatible',
+    baseUrl: 'http://localhost:1234/v1',
+    websiteUrl: 'https://lmstudio.ai',
+    documentationUrl: 'https://lmstudio.ai/docs/app/api/endpoints/openai',
+    recommendedModel: '',
+    icon: 'bi-pc-display',
+    local: true,
+    // Loaded models are host-specific — populated via "Discover models".
+    models: [],
   },
 ];
 


### PR DESCRIPTION
## Summary

Ships two new preset providers that talk to a running local OpenAI-compatible endpoint on localhost:

- **Ollama** at `http://localhost:11434/v1` (the OpenAI-compat layer Ollama ships)
- **LM Studio** at `http://localhost:1234/v1`

Both flagged with `local: true` so the UI skips the credential dialog and jumps straight to the model-config modal. Models are discovered by clicking **Discover models** in the provider modal, which probes `{baseUrl}/models` via the new `POST /api/providers/discover-models` endpoint.

Drive-by fix: the Time preinstalled server previously used `@modelcontextprotocol/server-time`, which doesn't exist on npm — the official Time server is Python-only. Switched to `@guanxiong/mcp-server-time`, the only Node/npm port that actually works. Source reviewed for security: zero I/O surface, no install scripts, single dependency on the official MCP SDK.

## Changes

- **`packages/shared-types/src/providers-preset.ts`** — Ollama + LM Studio entries with `local: true` and empty model arrays (host-specific)
- **`apps/server/src/routes/providers.ts`** — `POST /api/providers/discover-models` with 8s timeout, optional Bearer auth via `apiKeyEnv`
- **`apps/server/src/providers/infrastructure/openai-compatible/adapter.ts`** — empty `apiKey` falls back to `'no-key-required'` placeholder (was crashing SDK constructor); `listModels` skips the `gpt|o1|chat|glm` filter for non-OpenAI-cloud baseUrls so Ollama/LM Studio/Groq return their full model list
- **`apps/web/src/components/settings/PresetProviderModal.tsx`** — **Discover models** button (shown only for `local` presets), with loading spinner, dedup, auto-pre-select, error/info messaging
- **`apps/web/src/components/settings/tabs/ProvidersTab.tsx`** — local providers skip the credential dialog and go straight to the model-config modal
- **`apps/web/src/lib/api.ts`** — `discoverProviderModels()` API client

## Tests

14 new tests (10 for discover-models + 4 for adapter fallbacks), all passing:

```
Test Files  2 passed (2)
     Tests  72 passed (72)
```

## Risk note

`@guanxiong/mcp-server-time` has minimal community signal (1 star, 98 weekly downloads, single maintainer, broken repo URL in npm metadata). Source is clean — only uses `Intl.DateTimeFormat` and `Date`, no fs/net/child_process — but it's a single-supplier package shipping on every OpenAidy install. Mitigation options if your threat model calls for it:

1. Pin to exact version: `@guanxiong/mcp-server-time@1.0.0` instead of `-y @guanxiong/mcp-server-time`
2. Add a registry health check to OpenAidy's reconcile that flags degraded trust signals
3. Switch to the official Python server via `uvx mcp-server-time` (requires Python + uvx)

Leaving as-is per current call; happy to apply any of the above as a follow-up.

## How to test

```bash
# Ollama
ollama serve
ollama pull llama3.2

# In OpenAidy UI: Settings → Providers → Ollama → Discover models → Save
```

Same flow for LM Studio (`localhost:1234/v1`).

## Commits

- `feat(providers): add Ollama and LM Studio local providers`
- `test(providers): cover discover-models endpoint and adapter local-provider fallbacks`
- `docs(readme): document local providers and the discover-models flow`
- `fix(mcp): point the Time preinstalled server at the npm-published package`