### PR TITLE
fix(installer): reliably start the server and serve the UI on one port

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -615,10 +615,16 @@ $env:OPENAIDY_REPO = $InstallDir
 $env:WS_TOKEN_SECRET = $script:JwtSecret
 $BootstrapToken = Invoke-Init
 
-# PR2: start the server and open the browser
+# PR2: start the server and open the browser.
+#
+# --server-only: the server serves the already-built web bundle itself
+# (apps/web/dist, resolved via the OPENAIDY_REPO fallback), so the whole UI is
+# available on the server's port. We deliberately do NOT spawn the Vite dev
+# server — it's a development tool, redundant for an installed instance, and a
+# flaky Vite start shouldn't fail the install.
 Write-Host ""
 Log-Info "Starting the server (this may take up to 30 seconds)..."
-$StartOutput = & "$env:LOCALAPPDATA\openaidy\bin\openaidy.cmd" start 2>&1
+$StartOutput = & "$env:LOCALAPPDATA\openaidy\bin\openaidy.cmd" start --server-only 2>&1
 $StartExit = $LASTEXITCODE
 $StartUrl = ""
 if ($StartExit -eq 0) {
@@ -646,10 +652,10 @@ if ($StartUrl) {
     Write-Host ""
     Write-Host "Use 'openaidy stop' to stop the server."
 } else {
-    Write-Host "Run 'openaidy start' to bring the server online."
+    Write-Host "Run 'openaidy start --server-only' to bring the server online,"
+    Write-Host "then open http://localhost:3001 in your browser."
     Write-Host ""
-    Write-Host "Next steps:"
-    Write-Host "  cd $InstallDir"
-    Write-Host "  pnpm --filter @openaidy/server dev"
+    Write-Host "If it still doesn't start, check the log at:"
+    Write-Host "  $env:USERPROFILE\.openaidy\logs\server.log"
 }
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -461,7 +461,7 @@ check_ripgrep() {
 clone_or_update_repo() {
     log_info "Preparing repository (branch: $BRANCH)..."
 
-    if [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-verify --quiet HEAD 2>/dev/null; then
+    if [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse --quiet HEAD 2>/dev/null; then
         log_info "Repository already exists — updating..."
         cd "$INSTALL_DIR"
         git fetch origin "$BRANCH" 2>/dev/null || true
@@ -656,9 +656,15 @@ run_init() {
 }
 
 run_start() {
-    # Run `openaidy start` and capture the output.
+    # Run `openaidy start --server-only` and capture the output.
+    #
+    # --server-only: the server serves the already-built web bundle itself
+    # (apps/web/dist, resolved via the OPENAIDY_REPO fallback), so the whole
+    # UI is available on the server's port. We deliberately do NOT spawn the
+    # Vite dev server here — that's a development tool, redundant for an
+    # installed instance, and a flaky Vite start shouldn't fail the install.
     log_info "Starting the server (this may take up to 30 seconds)..."
-    "$link_dir_global/openaidy" start 2>&1
+    "$link_dir_global/openaidy" start --server-only 2>&1
 }
 
 # Capture the wrapper path now so run_init can invoke it (create_cli_wrapper
@@ -695,13 +701,14 @@ main() {
 
     # PR2: start the server and open the browser.
     echo ""
-    log "Starting the server..."
+    log_info "Starting the server..."
     START_URL=""
     if START_OUTPUT=$(run_start 2>&1); then
-        START_URL=$(echo "$START_OUTPUT" | grep -oP 'http://localhost:\d+' | head -1)
-        log "Server is ready."
+        # -oE (POSIX ERE), not -oP — BSD/macOS grep has no -P.
+        START_URL=$(echo "$START_OUTPUT" | grep -oE 'http://localhost:[0-9]+' | head -1)
+        log_success "Server is ready."
     else
-        log "Warning: server did not start (will be available after re-login)."
+        log_warn "Server did not start automatically."
     fi
 
     echo ""
@@ -733,10 +740,11 @@ main() {
         echo ""
         echo "Use 'openaidy stop' to stop the server."
     else
-        echo "Run 'openaidy start' to bring the server online."
+        echo "Run 'openaidy start --server-only' to bring the server online,"
+        echo "then open http://localhost:3001 in your browser."
         echo ""
-        echo "Next steps:"
-        echo "  cd $INSTALL_DIR && pnpm --filter @openaidy/server dev"
+        echo "If it still doesn't start, check the log at:"
+        echo "  $OPENAIDY_HOME/logs/server.log"
     fi
     echo ""
 }


### PR DESCRIPTION
After install, the server should come up on its own port serving the already-built web bundle. Two defects broke that:

- install.sh aborted at the start step: it called `log ...`, but only `log_info`/`log_success`/etc. exist. Under `set -e`, `log: command not found` exited the script before `openaidy start` ever ran, so the server was never started on Linux/macOS/WSL. Use the real log_* helpers.
- install.sh used `git rev-verify` (not a real subcommand) to detect an existing checkout, so the update path never ran and every install `rm -rf`'d and re-cloned — wiping state/install.json and rotating the JWT secret. Fix to `git rev-parse`.

Both installers now run `openaidy start --server-only` instead of the default two-process mode. The server serves apps/web/dist itself (via the OPENAIDY_REPO fallback) on its port — SPA routes fall back to index.html while /api and /ws stay same-origin — so no redundant Vite dev server is spawned and a flaky Vite start can't make the installer misreport failure. The build the installer already ran is reused; nothing is rebuilt.

Also make the URL extraction portable (grep -oE, not the GNU-only -oP that fails on BSD/macOS grep) and point the failure-path hint at `openaidy start --server-only` + the server log instead of a dev command.

Verified live: `openaidy start --server-only` boots, /health=200, `/` serves the built SPA, /api/* stays JSON (401 unauth), and stop confirms no web process was spawned.