### PR TITLE
feat(release): tag-based releases + install the latest release by def…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Cut a release by pushing a semver tag:
+#   git tag v0.1.0 && git push origin v0.1.0
+# This gates on the same checks as CI (lint + typecheck/build + test), then
+# publishes a GitHub Release with auto-generated notes. The installer's
+# default channel resolves to the newest release tag, so a green release here
+# is what `curl -fsSL https://openaidy.com/install.sh | bash` installs.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  # Manual re-run for an existing tag (e.g. if the first run failed after the
+  # gates but before publishing). Requires the tag to already exist.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g. v0.1.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CI: 'true'
+
+jobs:
+  gate:
+    name: Gate (lint, build, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: ESLint
+        run: pnpm -r lint
+      - name: Build (includes typecheck)
+        run: pnpm -r build
+      - name: Test
+        run: pnpm -r test
+
+  release:
+    name: Publish GitHub Release
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so release-note generation can diff against the
+          # previous tag.
+          fetch-depth: 0
+      - name: Resolve tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          # Idempotent: if a run already created the release, don't fail.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing OpenAidy
+
+OpenAidy ships as a source install: the installer clones a git ref, builds it,
+and runs it. A "release" is therefore a **git tag** plus a **GitHub Release**,
+not an npm publish. The one-liner installer resolves the newest release tag by
+default, so cutting a release is what end users get from:
+
+```
+curl -fsSL https://openaidy.com/install.sh | bash
+```
+
+## Versioning
+
+The product version lives in the root `package.json` `version` field and is the
+single source of truth. Tags are `vMAJOR.MINOR.PATCH` (e.g. `v0.1.0`) and must
+match that version. Pre-1.0, treat minor as "features" and patch as "fixes".
+
+## Cut a release
+
+1. Make sure `main` is green (CI passes) and is the commit you want to ship.
+2. Bump the version in the root `package.json` (e.g. `0.1.0` → `0.1.1`) and
+   commit it to `main`:
+   ```
+   git commit -am "chore(release): v0.1.1"
+   ```
+3. Tag that commit and push the tag:
+   ```
+   git tag v0.1.1
+   git push origin main --tags
+   ```
+
+Pushing the `v*.*.*` tag triggers `.github/workflows/release.yml`, which:
+
+- re-runs the full gate (ESLint, typecheck/build, tests), then
+- creates a GitHub Release for the tag with **auto-generated notes**
+  (`gh release create --generate-notes`), diffing against the previous tag.
+
+If the workflow fails _after_ the gate but before publishing, re-run it from the
+Actions tab (**Run workflow** → enter the existing tag) — it's idempotent and
+skips an already-created release.
+
+## What users get
+
+- **Default:** `install.sh` / `install.ps1` query the GitHub "latest release"
+  API and install that tag. No release yet → they fall back to `main`.
+- **Dev edge:** `--branch main` (or `-Branch main` on Windows) installs the tip
+  of `main`.
+- **Pin a version:** `--tag v0.1.0` (or `--branch v0.1.0`).
+
+## Notes
+
+- The release workflow needs no secrets — it uses the built-in `GITHUB_TOKEN`
+  (`contents: write`).
+- `git clone --branch <ref>` accepts both branches and tags, so the installer
+  needs no special-casing to install a tag.

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,10 @@
 # ============================================================================
 
 param(
-    [string]$Branch = "main",
+    # Empty = auto: resolve the latest published release tag (falling back to
+    # 'main' when no release exists yet). Pass -Branch main for the dev edge,
+    # or -Branch v0.1.0 for a specific release.
+    [string]$Branch = "",
     [string]$InstallDir = "$env:LOCALAPPDATA\openaidy",
     [switch]$SkipBuild
 )
@@ -35,6 +38,18 @@ function Log-Error   { param([string]$Message) Write-Host "[openaidy] ✗ $Messa
 function New-TempFile {
     $tmp = [System.IO.Path]::GetTempPath()
     return Join-Path $tmp "openaidy-install-$(Get-Random).tmp"
+}
+
+# Query the newest published release tag via the GitHub API. Returns the tag
+# (e.g. "v0.1.0"), or "main" when there's no release yet / the API is
+# unreachable — so a fresh repo with no releases still installs.
+function Resolve-DefaultRef {
+    try {
+        $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/imzodev/openaidy/releases/latest" `
+            -Headers @{ "User-Agent" = "OpenAidy-Installer" } -TimeoutSec 15
+        if ($rel.tag_name) { return $rel.tag_name }
+    } catch { }
+    return "main"
 }
 
 # ============================================================================
@@ -565,7 +580,17 @@ Write-Host "OpenAidy Installer" -ForegroundColor White
 Write-Host ""
 
 Log-Info "Install directory: $InstallDir"
-Log-Info "Branch: $Branch"
+if ([string]::IsNullOrWhiteSpace($Branch)) {
+    Log-Info "Resolving latest release..."
+    $Branch = Resolve-DefaultRef
+    if ($Branch -eq "main") {
+        Log-Warn "No published release found — installing from 'main' (development edge)."
+    } else {
+        Log-Success "Latest release: $Branch"
+    }
+} else {
+    Log-Info "Installing ref: $Branch (explicit)"
+}
 Write-Host ""
 
 # Git

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,10 @@ NODE_VERSION="22.12.0"
 # Options
 RUN_SETUP=true
 SKIP_BUILD=false
-BRANCH="main"
+# Empty = auto: resolve the latest published release tag (falling back to
+# `main` when no release exists yet). An explicit --branch/--tag overrides.
+BRANCH=""
+BRANCH_EXPLICIT=false
 NON_INTERACTIVE=false
 
 # State
@@ -65,8 +68,9 @@ while [[ $# -gt 0 ]]; do
             RUN_SETUP=false
             shift
             ;;
-        --branch|-Branch)
+        --branch|-Branch|--tag)
             BRANCH="$2"
+            BRANCH_EXPLICIT=true
             shift 2
             ;;
         --dir)
@@ -83,7 +87,9 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --dir <path>       Install to custom directory (default: ~/.openaidy)"
-            echo "  --branch <name>    Branch to install (default: main)"
+            echo "  --branch <ref>     Branch or tag to install"
+            echo "                     (default: latest release; use 'main' for the dev edge)"
+            echo "  --tag <ref>        Alias for --branch (install a specific release tag)"
             echo "  --skip-build       Skip build step"
             echo "  --skip-setup       Skip initial setup"
             echo "  --non-interactive  Run without interactive prompts"
@@ -458,8 +464,39 @@ check_ripgrep() {
 # Repository
 # ============================================================================
 
+# Query the newest published release tag via the GitHub API. Prints the tag
+# (e.g. "v0.1.0") on success, or "main" when there's no release yet / the API
+# is unreachable — so a fresh repo with no releases still installs.
+resolve_default_ref() {
+    local api="https://api.github.com/repos/imzodev/openaidy/releases/latest"
+    local tag=""
+    tag=$(curl -fsSL "$api" 2>/dev/null | grep -m1 '"tag_name"' \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/') || true
+    if [ -n "$tag" ]; then
+        printf '%s' "$tag"
+    else
+        printf 'main'
+    fi
+}
+
+# Decide which ref to install: an explicit --branch/--tag wins; otherwise the
+# latest release tag (falling back to main).
+resolve_install_ref() {
+    if [ "$BRANCH_EXPLICIT" = true ]; then
+        log_info "Installing ref: $BRANCH (explicit)"
+        return 0
+    fi
+    log_info "Resolving latest release..."
+    BRANCH="$(resolve_default_ref)"
+    if [ "$BRANCH" = "main" ]; then
+        log_warn "No published release found — installing from 'main' (development edge)."
+    else
+        log_success "Latest release: $BRANCH"
+    fi
+}
+
 clone_or_update_repo() {
-    log_info "Preparing repository (branch: $BRANCH)..."
+    log_info "Preparing repository (ref: $BRANCH)..."
 
     if [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-verify --quiet HEAD 2>/dev/null; then
         log_info "Repository already exists — updating..."
@@ -683,6 +720,7 @@ main() {
     check_node
     check_pnpm
     check_ripgrep
+    resolve_install_ref
     clone_or_update_repo
     build_project
     create_cli_wrapper

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "openaidy",
+  "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
…ault

OpenAidy had no release process: zero tags, no release workflow, and both installers cloned `main` — so every `curl | bash` pulled bleeding-edge HEAD with no stable, reproducible install point or rollback.

Add lightweight, source-install-appropriate releases (git tag + GitHub Release, not npm publish):

- .github/workflows/release.yml: on a `v*.*.*` tag push, re-run the full gate (lint + typecheck/build + test), then `gh release create --generate-notes`. Idempotent; also runnable via workflow_dispatch for an existing tag. Uses the built-in GITHUB_TOKEN (contents: write) — no secrets.
- Installers now default to the newest published release tag: install.sh and install.ps1 query the GitHub "latest release" API and clone that tag, falling back to `main` when no release exists yet (fresh repo still installs). `--branch main` / `-Branch main` selects the dev edge; `--tag vX.Y.Z` pins a release. `git clone --branch` already accepts tags, so no clone-path changes.
- Root package.json gets a product version (0.1.0) as the single source of truth for the tag.
- RELEASING.md documents the bump → tag → workflow flow and the install channels.

Verified: both installers parse (bash -n, PowerShell parser); the ref resolvers fall back to `main` for a release-less repo (live) and extract the tag from a GitHub-shaped payload (bash sed + PS ConvertFrom-Json). The release workflow fires only on a tag push, so it's first exercised when v0.1.0 is cut.