### PR TITLE
fix(installer): polish start phase (PR 355 review follow-ups)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -649,8 +649,22 @@ $BootstrapToken = Invoke-Init
 # flaky Vite start shouldn't fail the install.
 Write-Host ""
 Log-Info "Starting the server (this may take up to 30 seconds)..."
-$StartOutput = & "$env:LOCALAPPDATA\openaidy\bin\openaidy.cmd" start --server-only 2>&1
-$StartExit = $LASTEXITCODE
+# Capture stdout only (the "Server running on http://..." line lives there).
+# We must NOT use `2>&1`: under $ErrorActionPreference='Stop', PowerShell 5.1
+# turns any stderr line from the native command (e.g. a Node
+# `ExperimentalWarning` from `node --import tsx`) into a terminating
+# NativeCommandError and aborts the installer before we can read the exit
+# code. Let stderr flow to the console, and wrap defensively so a flaky start
+# still falls through to the "did not start" guidance instead of crashing.
+$StartOutput = ""
+$StartExit = 1
+try {
+    $StartOutput = & "$env:LOCALAPPDATA\openaidy\bin\openaidy.cmd" start --server-only
+    $StartExit = $LASTEXITCODE
+} catch {
+    $StartExit = 1
+    $StartOutput = "$_"
+}
 $StartUrl = ""
 if ($StartExit -eq 0) {
     $StartUrl = [regex]::Match($StartOutput, 'http://localhost:\d+').Value

--- a/install.sh
+++ b/install.sh
@@ -498,7 +498,7 @@ resolve_install_ref() {
 clone_or_update_repo() {
     log_info "Preparing repository (ref: $BRANCH)..."
 
-    if [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse --quiet HEAD 2>/dev/null; then
+    if [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
         log_info "Repository already exists — updating..."
         cd "$INSTALL_DIR"
         git fetch origin "$BRANCH" 2>/dev/null || true


### PR DESCRIPTION
Two one-liners from the [PR 355 review](https://github.com/imzodev/openaidy/pull/355#issuecomment-4929240098), landing ahead of `v0.1.0` since this installer is what every fresh install pulls.

### 1. `install.ps1` — Windows auto-start could abort the installer
Capturing the start output with `2>&1` under `$ErrorActionPreference='Stop'` let PowerShell 5.1 turn any stderr line from the native CLI (e.g. a Node `ExperimentalWarning` from `node --import tsx`) into a terminating `NativeCommandError` — aborting the installer *before* it read `$LASTEXITCODE` and fell through to the graceful "did not start" guidance.

Fix: capture **stdout only** (the `Server running on http://…` line lives there) and wrap the call in `try/catch` so a flaky start can't crash the install.

### 2. `install.sh` — `rev-parse` leaked the HEAD SHA
`git rev-parse --quiet HEAD 2>/dev/null` printed the 40-char SHA to stdout on every re-install (`--quiet` is a no-op without `--verify`, and only stderr was redirected).

Fix: `git rev-parse --verify --quiet HEAD >/dev/null 2>&1`.

### Verification
Both scripts parse (`bash -n` / PowerShell `Parser::ParseFile`).

Deferred (not blocking `v0.1.0`): the exit-code-vs-`$START_URL` messaging inconsistency, the hardcoded `:3001` failure hint, and the swallowed progress line — all from the same 355 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)