### PR TITLE
feat(dist): prebuilt openaidy npm package + npm-based release (v0.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,18 @@
 name: Release
 
 # Cut a release by pushing a semver tag:
-#   git tag v0.1.0 && git push origin v0.1.0
-# This gates on the same checks as CI (lint + typecheck/build + test), then
-# publishes a GitHub Release with auto-generated notes. The installer's
-# default channel resolves to the newest release tag, so a green release here
-# is what `curl -fsSL https://openaidy.com/install.sh | bash` installs.
+#   git tag v0.2.0 && git push origin v0.2.0
+# Gates on the same checks as CI, publishes the prebuilt `openaidy` package to
+# npm, then publishes a GitHub Release. The installer runs `npm i -g openaidy`,
+# so a green publish here is what users install.
 on:
   push:
     tags:
       - 'v*.*.*'
-  # Manual re-run for an existing tag (e.g. if the first run failed after the
-  # gates but before publishing). Requires the tag to already exist.
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to release (e.g. v0.1.0)'
+        description: 'Existing tag to release (e.g. v0.2.0)'
         required: true
         type: string
 
@@ -48,9 +45,41 @@ jobs:
       - name: Test
         run: pnpm -r test
 
+  publish-npm:
+    name: Publish openaidy to npm
+    needs: gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          # Writes an .npmrc that authenticates `npm publish` via NODE_AUTH_TOKEN.
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm install --frozen-lockfile
+      - name: Build web bundle
+        run: pnpm --filter web build
+      - name: Build npm package
+        run: pnpm build:npm
+      - name: Publish (skip if this version is already on npm)
+        working-directory: build/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          if npm view "openaidy@$VER" version >/dev/null 2>&1; then
+            echo "openaidy@$VER already published — skipping."
+          else
+            npm publish --access public
+          fi
+
   release:
     name: Publish GitHub Release
-    needs: gate
+    needs: [gate, publish-npm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +97,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
-          # Idempotent: if a run already created the release, don't fail.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — skipping."
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules
 .env
 .env.*
 dist
+build
+*.tgz
 coverage
 .vite
 .cache

--- a/apps/server/src/routes/addons.ts
+++ b/apps/server/src/routes/addons.ts
@@ -388,7 +388,11 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
     // SDK is shared across addons, so the token need not be addon-bound.
     if (!requireAssetToken(request, reply)) return reply;
 
-    const sdkPath = path.join(__dirname, '../sdk/openaidy-sdk.js');
+    // OPENAIDY_SDK_PATH lets a packaged (bundled) install point at the SDK
+    // shipped in the package; dev/source falls back to the co-located file.
+    const sdkPath =
+      process.env['OPENAIDY_SDK_PATH'] ??
+      path.join(__dirname, '../sdk/openaidy-sdk.js');
     if (!fs.existsSync(sdkPath)) {
       return reply.code(404).send({ error: 'SDK not found' });
     }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "openaidy",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "esbuild": "0.18.20",
     "@types/node": "^24.12.0",
     "@types/pg": "^8.18.0",
     "eslint": "^9.39.4",
@@ -24,6 +25,7 @@
     "dev:server": "pnpm --filter ./apps/server dev",
     "dev:web": "pnpm --filter ./apps/web dev",
     "build": "pnpm -r build",
+    "build:npm": "node scripts/build-npm-package.mjs",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
     "format": "prettier --write .",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -23,8 +23,10 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { resolve, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { request } from 'node:http';
 import type { CommandResult } from '../types.js';
 import { writePidFile, writeWebPidFile } from '../lib/process-manager.js';
@@ -202,23 +204,38 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
     };
   }
 
-  // Resolve server entry point (source .ts — tsx handles ESM resolution).
-  // OPENAIDY_REPO points at the cloned repo (code root). When unset — e.g. an
-  // older Windows wrapper that only exported OPENAIDY_HOME — fall back to
-  // OPENAIDY_HOME so existing installs keep working.
+  // Packaged-install detection: the npm build ships the bundled server next to
+  // this CLI (both in <pkg>/dist). In that mode we run the bundled server with
+  // plain node — no repo, no tsx — and point it at assets shipped in the
+  // package. Otherwise (dev / from-source install) run the TS entry via tsx.
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const packagedServerEntry = resolve(cliDir, 'server.mjs');
+  const packaged = existsSync(packagedServerEntry);
+  const pkgRoot = resolve(cliDir, '..');
+  // OPENAIDY_REPO points at the cloned repo (code root) for from-source
+  // installs. When unset, fall back to OPENAIDY_HOME so older installs keep
+  // working. Unused in packaged mode.
   const repoRoot = process.env.OPENAIDY_REPO ?? openaidyHome;
-  const serverEntry = resolve(repoRoot, 'apps/server/src/server.ts');
-  try {
-    await import('node:fs/promises').then((fs) => fs.access(serverEntry));
-  } catch {
-    return {
-      exitCode: 1,
-      output: `Error: Server entry not found at ${serverEntry}. Has the repo been cloned and built?`,
-    };
+
+  let serverEntry: string;
+  let runtimeArgs: string[];
+  if (packaged) {
+    serverEntry = packagedServerEntry;
+    runtimeArgs = [serverEntry];
+  } else {
+    serverEntry = resolve(repoRoot, 'apps/server/src/server.ts');
+    try {
+      await import('node:fs/promises').then((fs) => fs.access(serverEntry));
+    } catch {
+      return {
+        exitCode: 1,
+        output: `Error: Server entry not found at ${serverEntry}. Has the repo been cloned and built?`,
+      };
+    }
+    // node --import tsx enables ESM + extensionless resolution for the TS entry.
+    runtimeArgs = ['--import', 'tsx', serverEntry];
   }
 
-  // Use node --import tsx to enable ESM extensionless resolution
-  // This is more reliable cross-platform than spawning tsx directly
   const nodeBin = process.execPath;
 
   // Resolve the listen port. CLI flag wins, then env, then default. We
@@ -250,7 +267,10 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
   // Build synchronously so a failure aborts startup with a clear error
   // before we leave a half-running server behind.
   let webDistPath: string | undefined;
-  if (integrated) {
+  if (packaged) {
+    // The packaged server serves the SPA shipped alongside it in the package.
+    webDistPath = resolve(pkgRoot, 'web');
+  } else if (integrated) {
     webDistPath = resolve(repoRoot, 'apps', 'web', 'dist');
     const buildResult = spawnSync('pnpm', ['--filter', 'web', 'build'], {
       cwd: repoRoot,
@@ -297,7 +317,17 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
   if (webDistPath) {
     childEnv['OPENAIDY_WEB_DIST'] = webDistPath;
   }
-  const child = spawn(nodeBin, ['--import', 'tsx', serverEntry], {
+  if (packaged) {
+    // Point the bundled server at the assets shipped in the package (the
+    // import.meta.url-relative defaults don't apply once bundled).
+    childEnv['APP_CONFIG_TEMPLATE_PATH'] = resolve(
+      pkgRoot,
+      'assets/openaidy.template.json',
+    );
+    childEnv['OPENAIDY_SDK_PATH'] = resolve(pkgRoot, 'assets/openaidy-sdk.js');
+    childEnv['OPENAIDY_DRIZZLE_DIR'] = resolve(pkgRoot, 'assets/drizzle');
+  }
+  const child = spawn(nodeBin, runtimeArgs, {
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: process.platform === 'win32',
@@ -354,7 +384,9 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
   // there's no separate Vite process to start. Otherwise (the default),
   // spawn a Vite dev server unless --server-only was passed.
 
-  if (integrated) {
+  // Packaged and --integrated both serve the SPA from the server itself on one
+  // port, so there's no Vite process to spawn.
+  if (integrated || packaged) {
     return {
       exitCode: 0,
       output: [

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -650,18 +650,18 @@ export async function createDatabaseClient(
 
   const pool = new Pool({ connectionString: config.connectionString });
 
+  // OPENAIDY_DRIZZLE_DIR lets a packaged (bundled) install point at the SQL
+  // migrations shipped in the package; dev/source falls back to the sibling
+  // `drizzle/` dir resolved from this module's location.
+  const drizzleDir = process.env['OPENAIDY_DRIZZLE_DIR']
+    ? resolve(process.env['OPENAIDY_DRIZZLE_DIR'])
+    : resolve(fileURLToPath(import.meta.url), '../../drizzle');
   const migrationSql = readFileSync(
-    resolve(
-      fileURLToPath(import.meta.url),
-      '../../drizzle/0001_initial_schema.sql',
-    ),
+    resolve(drizzleDir, '0001_initial_schema.sql'),
     'utf-8',
   );
   const runningStatusMigrationSql = readFileSync(
-    resolve(
-      fileURLToPath(import.meta.url),
-      '../../drizzle/0010_add_running_status.sql',
-    ),
+    resolve(drizzleDir, '0010_add_running_status.sql'),
     'utf-8',
   );
   const client = await pool.connect();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/pg':
         specifier: ^8.18.0
         version: 8.18.0
+      esbuild:
+        specifier: 0.18.20
+        version: 0.18.20
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Builds the publishable `openaidy` npm package into build/npm/.
+ *
+ * Distribution model: instead of cloning + building from source on the user's
+ * machine (fragile — pnpm/corepack/native-toolchain issues), we ship a
+ * prebuilt package. `npm install -g openaidy` then `openaidy start` runs with
+ * zero build step.
+ *
+ * Layout produced:
+ *   build/npm/
+ *     package.json        name "openaidy", bin, deps (third-party + native)
+ *     dist/server.mjs     esbuild bundle of apps/server (@openaidy/* inlined)
+ *     dist/cli.mjs        esbuild bundle of the CLI (bin, shebang)
+ *     web/                apps/web/dist (the built SPA)
+ *     assets/openaidy.template.json
+ *     assets/openaidy-sdk.js
+ *     assets/drizzle/*.sql
+ *
+ * First-party @openaidy/* code is bundled in; third-party deps (incl. the
+ * native better-sqlite3) stay external and are declared as `dependencies` so
+ * npm installs them (better-sqlite3 pulls its prebuilt binary — no compiler).
+ */
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const out = resolve(root, 'build/npm');
+const require = createRequire(resolve(root, 'package.json'));
+const esbuild = require('esbuild');
+
+const readPkg = (p) => JSON.parse(readFileSync(resolve(root, p), 'utf-8'));
+const rootPkg = readPkg('package.json');
+
+// ── Dependency set: union of third-party deps across the packages we bundle,
+// minus first-party @openaidy/* (those are inlined by esbuild).
+const depSources = [
+  'apps/server/package.json',
+  'packages/db/package.json',
+  'packages/cli/package.json',
+];
+const deps = {};
+for (const src of depSources) {
+  const d = readPkg(src).dependencies ?? {};
+  for (const [name, range] of Object.entries(d)) {
+    if (!name.startsWith('@openaidy/')) deps[name] = range;
+  }
+}
+const external = Object.keys(deps);
+
+console.log(`[build-npm] cleaning ${out}`);
+rmSync(out, { recursive: true, force: true });
+mkdirSync(resolve(out, 'dist'), { recursive: true });
+
+// ── Bundle the server.
+console.log('[build-npm] bundling server…');
+await esbuild.build({
+  entryPoints: [resolve(root, 'apps/server/src/server.ts')],
+  outfile: resolve(out, 'dist/server.mjs'),
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  external,
+  logLevel: 'error',
+  // Fastify/pino etc. reference `require` in an ESM bundle; shim it.
+  banner: {
+    js: "import { createRequire as __cjsRequire } from 'node:module'; const require = __cjsRequire(import.meta.url);",
+  },
+});
+
+// ── Bundle the CLI (bin). It detects packaged mode by finding server.mjs next
+// to itself, so keep both in dist/.
+console.log('[build-npm] bundling CLI…');
+await esbuild.build({
+  entryPoints: [resolve(root, 'packages/cli/bin/openaidy.ts')],
+  outfile: resolve(out, 'dist/cli.mjs'),
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  external,
+  logLevel: 'error',
+  // esbuild preserves the entry's own `#!/usr/bin/env node` shebang (it must be
+  // line 1 for Node to strip it), so the banner only adds the require shim.
+  banner: {
+    js: "import { createRequire as __cjsRequire } from 'node:module'; const require = __cjsRequire(import.meta.url);",
+  },
+});
+
+// ── Assets.
+console.log('[build-npm] copying assets…');
+mkdirSync(resolve(out, 'assets'), { recursive: true });
+cpSync(
+  resolve(root, 'config/openaidy.template.json'),
+  resolve(out, 'assets/openaidy.template.json'),
+);
+cpSync(
+  resolve(root, 'apps/server/src/sdk/openaidy-sdk.js'),
+  resolve(out, 'assets/openaidy-sdk.js'),
+);
+cpSync(resolve(root, 'packages/db/drizzle'), resolve(out, 'assets/drizzle'), {
+  recursive: true,
+});
+
+// ── Web bundle (must be built first: pnpm --filter web build).
+const webDist = resolve(root, 'apps/web/dist');
+try {
+  cpSync(webDist, resolve(out, 'web'), { recursive: true });
+} catch {
+  throw new Error(
+    `apps/web/dist not found at ${webDist}. Run \`pnpm --filter web build\` before this script.`,
+  );
+}
+
+// ── package.json for the published package.
+const pkg = {
+  name: 'openaidy',
+  version: rootPkg.version,
+  description: 'OpenAidy — self-hosted AI agent platform (prebuilt).',
+  type: 'module',
+  bin: { openaidy: './dist/cli.mjs' },
+  files: ['dist', 'web', 'assets', 'README.md'],
+  engines: { node: '>=22.12.0' },
+  dependencies: deps,
+  license: rootPkg.license ?? 'UNLICENSED',
+};
+writeFileSync(resolve(out, 'package.json'), JSON.stringify(pkg, null, 2));
+writeFileSync(
+  resolve(out, 'README.md'),
+  `# openaidy\n\nPrebuilt OpenAidy. Install and run:\n\n\`\`\`\nnpm install -g openaidy\nopenaidy start\n\`\`\`\n`,
+);
+
+console.log(
+  `[build-npm] done → ${out}\n  version ${pkg.version}, ${external.length} runtime deps`,
+);


### PR DESCRIPTION
Pivots distribution from **clone + build-from-source** (the source of the pnpm/corepack/libatomic/clone/toolchain-wipe bug pile-up) to a **prebuilt npm package**: `npm install -g openaidy && openaidy start`, no build step on the user's machine.

## What's here (Phase A–C)
- **`scripts/build-npm-package.mjs`** (`pnpm build:npm`) — esbuild-bundles the server + CLI (first-party `@openaidy/*` inlined; third-party incl. native `better-sqlite3` kept external + declared as deps so npm pulls prebuilt binaries), ships `apps/web/dist` + config template + addon SDK + drizzle SQL as assets, and generates the publishable `openaidy` `package.json`.
- **CLI packaged mode** (`start.ts`) — detects a bundled `server.mjs` next to the CLI and runs it with plain `node` (no repo, no tsx), pointing the server at the package's `web/` + assets via env. Dev/from-source path unchanged.
- **Asset overrides** so the bundled server finds shipped assets: `OPENAIDY_SDK_PATH`, `OPENAIDY_DRIZZLE_DIR` (config template already had `APP_CONFIG_TEMPLATE_PATH`). Backward-compatible.
- **`release.yml`** — after the gate, builds the package and `npm publish --access public` (idempotent on version) via `NPM_TOKEN`, then cuts the GitHub Release.
- esbuild root devDep; **version → 0.2.0**.

## Verified end-to-end (Windows)
`npm pack` → clean `npm install` of the tarball → `openaidy start`:
- `/health` 200, `/` serves the built SPA, `/agents` SPA fallback works, `/api/config` 401 (JSON intact), `openaidy stop` clean — **no pnpm, no source, no build**.

## Not in this PR
The **installer rewrite** (`install.sh`/`install.ps1` → `npm i -g openaidy`) lands *after* `0.2.0` is published to npm, so it references a package that exists. Merge this → tag `v0.2.0` → the workflow publishes `openaidy` → then the installer PR.

`NPM_TOKEN` is already set in repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)