### PR TITLE
feat(dist): scoped @openaidy/app + OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,15 @@ jobs:
         run: pnpm -r test
 
   publish-npm:
-    name: Publish openaidy to npm
+    name: Publish @openaidy/app to npm
     needs: gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # OIDC trusted publishing: npm exchanges this short-lived GitHub identity
+      # for publish rights (no long-lived NPM_TOKEN). Requires a Trusted
+      # Publisher configured on the package pointing at this repo + workflow.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -58,8 +62,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          # Writes an .npmrc that authenticates `npm publish` via NODE_AUTH_TOKEN.
-          registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing needs npm >= 11.5.1; Node 22 ships an older npm.
+      - name: Upgrade npm (OIDC trusted publishing)
+        run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - name: Build web bundle
         run: pnpm --filter web build
@@ -67,14 +72,13 @@ jobs:
         run: pnpm build:npm
       - name: Publish (skip if this version is already on npm)
         working-directory: build/npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          NAME=$(node -p "require('./package.json').name")
           VER=$(node -p "require('./package.json').version")
-          if npm view "openaidy@$VER" version >/dev/null 2>&1; then
-            echo "openaidy@$VER already published — skipping."
+          if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+            echo "$NAME@$VER already published — skipping."
           else
-            npm publish --access public
+            npm publish
           fi
 
   release:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -124,7 +124,10 @@ try {
 
 // ── package.json for the published package.
 const pkg = {
-  name: 'openaidy',
+  // Scoped under the @openaidy org: npm's typosquat filter blocks the unscoped
+  // `openaidy` (too close to `openai`). The `bin` name stays `openaidy`, so
+  // users still run `openaidy` regardless of the (scoped) install name.
+  name: '@openaidy/app',
   version: rootPkg.version,
   description: 'OpenAidy — self-hosted AI agent platform (prebuilt).',
   type: 'module',
@@ -132,12 +135,14 @@ const pkg = {
   files: ['dist', 'web', 'assets', 'README.md'],
   engines: { node: '>=22.12.0' },
   dependencies: deps,
+  // Scoped packages default to restricted; make it public.
+  publishConfig: { access: 'public' },
   license: rootPkg.license ?? 'UNLICENSED',
 };
 writeFileSync(resolve(out, 'package.json'), JSON.stringify(pkg, null, 2));
 writeFileSync(
   resolve(out, 'README.md'),
-  `# openaidy\n\nPrebuilt OpenAidy. Install and run:\n\n\`\`\`\nnpm install -g openaidy\nopenaidy start\n\`\`\`\n`,
+  `# @openaidy/app\n\nPrebuilt OpenAidy. Install and run:\n\n\`\`\`\nnpm install -g @openaidy/app\nopenaidy start\n\`\`\`\n`,
 );
 
 console.log(


### PR DESCRIPTION
`@openaidy/app@0.2.0` is now published to npm (the unscoped `openaidy` name is blocked by npm's typosquat filter for being too close to `openai`). The **run command stays `openaidy`** — only the install name is scoped.

This PR switches CI publishing off the long-lived `NPM_TOKEN` to **OIDC trusted publishing** — npm's recommended path, ahead of the 2FA-bypass token deprecation (account ops ~Aug 2026, direct publish ~Jan 2027).

## Changes
- **`@openaidy/app`** as the package name (build script) + `publishConfig.access: public`.
- **`release.yml` publish job → OIDC:** `id-token: write`, upgrade npm to ≥ 11.5.1, drop `NODE_AUTH_TOKEN`/`registry-url`; `npm publish` authenticates via OIDC. Skip-check/publish read the scoped name from `package.json`.
- **Version → 0.2.1** so the next tag actually exercises the OIDC path (0.2.0 was published manually to claim the name).

## Required before this can publish (your action, on npm)
Configure a **Trusted Publisher** on the package:
`npmjs.com → @openaidy/app → Settings → Trusted Publisher → GitHub Actions` →
- Organization/owner: `imzodev`
- Repository: `openaidy`
- Workflow filename: `release.yml`
- Environment: (leave blank)

Once that's set and this is merged, tag **`v0.2.1`** → CI publishes `@openaidy/app@0.2.1` with no token. Then you can delete the `NPM_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)