### PR TITLE
fix(release): OIDC provenance publish (sigstore + repository field)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+      # Node 24 ships a modern npm (>= 11.5.1, with sigstore) that supports OIDC
+      # trusted publishing + provenance. We do NOT `npm install -g npm@latest`:
+      # upgrading npm in-place corrupts its bundled deps, which is what caused
+      # provenance to fail with "Cannot find module 'sigstore'".
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
-      # Trusted publishing needs npm >= 11.5.1; Node 22 ships an older npm.
-      - name: Upgrade npm (OIDC trusted publishing)
-        run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - name: Build web bundle
         run: pnpm --filter web build

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -134,6 +134,12 @@ const pkg = {
   bin: { openaidy: './dist/cli.mjs' },
   files: ['dist', 'web', 'assets', 'README.md'],
   engines: { node: '>=22.12.0' },
+  // Required for npm provenance (OIDC trusted publishing): must match the repo
+  // that builds/publishes the package.
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/imzodev/openaidy.git',
+  },
   dependencies: deps,
   // Scoped packages default to restricted; make it public.
   publishConfig: { access: 'public' },


### PR DESCRIPTION
The `v0.2.1` OIDC publish failed in npm's **provenance** step: `Cannot find module 'sigstore'`.

## Causes & fixes
1. **`npm install -g npm@latest` corrupts npm in-place** (drops bundled deps like `sigstore`). Removed it; the publish job now uses **Node 24**, which ships a modern npm (≥ 11.5.1, sigstore intact) that supports OIDC trusted publishing + provenance.
2. **Provenance requires a `repository` field** matching the building repo — the generated `package.json` lacked one. Added `repository: git+https://github.com/imzodev/openaidy.git`.

Still token-free (OIDC). No version bump.

## After merge — re-run the release for 0.2.1
`0.2.1` never published (only the tag exists), so once this is in `main` I'll trigger the release via **workflow_dispatch (tag `v0.2.1`)**, which runs main's fixed workflow and publishes `@openaidy/app@0.2.1` via OIDC + provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)