### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Bumps the root version to `0.2.2` so tagging `v0.2.2` publishes `@openaidy/app@0.2.2` (the release workflow skips publish if the version already exists on npm, and `0.2.1` is already up).

Ships to npm:
- npm-based installer (`install.sh` / `install.ps1`) — #364
- CLI `OPENAIDY_HOME` defaults (`~/.openaidy`) so a globally-installed `openaidy` works with no env setup — #364

After merge: `git tag v0.2.2 && git push origin v0.2.2` triggers Gate → Publish (OIDC) → GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)