### PR TITLE
fix(installer): clean bootstrap token output (logs to stderr)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,10 +99,12 @@ detect_os() {
     fi
 }
 
-log_info()    { echo -e "${BLUE}[openaidy]${NC} $*"; }
-log_success() { echo -e "${GREEN}[openaidy]${NC} ✓ $*"; }
-log_warn()    { echo -e "${YELLOW}[openaidy]${NC} ⚠ $*"; }
-log_error()   { echo -e "${RED}[openaidy]${NC} ✗ $*"; }
+# Logs go to stderr so they never pollute a `$(...)` capture of a function's
+# stdout (e.g. run_init returns the token, load_jwt_secret returns the secret).
+log_info()    { echo -e "${BLUE}[openaidy]${NC} $*" >&2; }
+log_success() { echo -e "${GREEN}[openaidy]${NC} ✓ $*" >&2; }
+log_warn()    { echo -e "${YELLOW}[openaidy]${NC} ⚠ $*" >&2; }
+log_error()   { echo -e "${RED}[openaidy]${NC} ✗ $*" >&2; }
 
 # ============================================================================
 # Node.js Provisioning


### PR DESCRIPTION
## Problem

On a real VPS install the bootstrap token printed with a log line glued to it:

```
Bootstrap admin token: [openaidy] Generating bootstrap admin token...
eyJhbGci...
```

`run_init` (and `load_jwt_secret`) return their value on **stdout**, captured with `$(...)`. But `log_info` also wrote to stdout, so the "Generating bootstrap admin token..." line got captured into `$BOOTSTRAP_TOKEN`.

## Fix

Route all `log_*` output to **stderr** (logs → stderr, data → stdout). The token now prints cleanly on one line, and no log message can pollute any `$(...)` capture (also protects `load_jwt_secret`'s secret).

`install.ps1` is unaffected — its logs use `Write-Host` (bypasses stdout) and `init`/`start` use isolated `ProcessStartInfo` capture.

## Note
This is installer-script only — no npm package change, so **no re-tag/republish needed**. Lands on `main`; `openaidy.com/install.sh` picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)