### PR TITLE
feat(db): replace better-sqlite3 with Node's built-in node:sqlite (#362)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -31,6 +31,10 @@ try {
 # the same home.
 $script:DataHome = "$env:USERPROFILE\.openaidy"
 
+# Node version to provision. Must be >= 22.13 so Node's built-in `node:sqlite`
+# (OpenAidy's SQLite driver) is available without the --experimental-sqlite flag.
+$script:NodeVersion = "22.23.1"
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -50,13 +54,14 @@ function New-TempFile {
 # ============================================================================
 
 function Install-Node {
-    Log-Info "Installing Node.js 22 LTS..."
+    Log-Info "Installing Node.js $($script:NodeVersion) LTS..."
 
     $arch = $env:PROCESSOR_ARCHITECTURE
     $nodeArch = "x64"
     if ($arch -eq "ARM64") { $nodeArch = "arm64" }
 
-    $url = "https://nodejs.org/dist/latest-v22.x/node-v22.12.0-win-$nodeArch.zip"
+    $v = $script:NodeVersion
+    $url = "https://nodejs.org/dist/v$v/node-v$v-win-$nodeArch.zip"
     $zipPath = New-TempFile
     $nodePath = Join-Path $InstallDir "node"
 
@@ -101,14 +106,25 @@ function Install-Node {
     return $false
 }
 
+# OpenAidy's SQLite layer uses Node's built-in `node:sqlite`, available without
+# a flag only on Node >= 22.13. A too-old system Node returns $false here so a
+# managed copy is provisioned instead.
 function Test-Node {
-    try {
-        $v = node --version 2>$null
-        if ($v) {
-            Log-Success "Node.js $v found"
-            return $true
-        }
-    } catch { }
+    $v = $null
+    try { $v = node --version 2>$null } catch { }
+    if (-not $v) { return $false }
+
+    $m = [regex]::Match([string]$v, 'v(\d+)\.(\d+)\.')
+    if (-not $m.Success) { return $false }
+    $major = [int]$m.Groups[1].Value
+    $minor = [int]$m.Groups[2].Value
+    $adequate = ($major -ge 24) -or ($major -eq 22 -and $minor -ge 13)
+
+    if ($adequate) {
+        Log-Success "Node.js $v found"
+        return $true
+    }
+    Log-Warn "Node.js $v is too old (need >= 22.13 for node:sqlite) — installing a managed copy..."
     return $false
 }
 

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ BOLD='\033[1m'
 # installed. Honors an existing OPENAIDY_HOME; matches the CLI's default so a
 # later `openaidy` invocation without env finds the same home.
 OPENAIDY_HOME="${OPENAIDY_HOME:-$HOME/.openaidy}"
-NODE_VERSION="22.12.0"
+NODE_VERSION="22.23.1"
 NPM_PKG="@openaidy/app"
 
 # Options
@@ -187,22 +187,44 @@ install_node() {
     NODE_PROVISIONED=true
 }
 
+# OpenAidy's SQLite layer uses Node's built-in `node:sqlite`, available without
+# a flag only on Node >= 22.13 (older Node lacks it or hides it behind
+# --experimental-sqlite). A too-old system Node is bypassed for a managed copy.
+node_is_adequate() {
+    command -v node >/dev/null 2>&1 || return 1
+    local v major minor
+    v="$(node --version 2>/dev/null | sed 's/^v//')"
+    major="${v%%.*}"
+    minor="$(echo "$v" | cut -d. -f2)"
+    [ -n "$major" ] || return 1
+    [ "$major" -ge 24 ] && return 0
+    [ "$major" -eq 22 ] && [ "$minor" -ge 13 ] && return 0
+    return 1
+}
+
 check_node() {
     log_info "Checking Node.js..."
 
-    if command -v node >/dev/null 2>&1; then
+    if node_is_adequate; then
         log_success "Node.js $(node --version) found"
         return 0
     fi
 
-    if [ -x "$INSTALL_DIR/node/bin/node" ]; then
-        export PATH="$INSTALL_DIR/node/bin:$PATH"
-        log_success "Node.js $(node --version) found (OpenAidy-managed)"
-        return 0
+    if command -v node >/dev/null 2>&1; then
+        log_warn "Node.js $(node --version) is too old (need >= 22.13 for node:sqlite) — installing a managed copy..."
     fi
 
-    log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
+    if [ -x "$INSTALL_DIR/node/bin/node" ]; then
+        export PATH="$INSTALL_DIR/node/bin:$PATH"
+        if node_is_adequate; then
+            log_success "Node.js $(node --version) found (OpenAidy-managed)"
+            return 0
+        fi
+    fi
+
+    log_info "Installing Node.js $NODE_VERSION LTS..."
     install_node
+    export PATH="$INSTALL_DIR/node/bin:$PATH"
 }
 
 # ============================================================================

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -217,7 +217,10 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
   let runtimeArgs: string[];
   if (packaged) {
     serverEntry = packagedServerEntry;
-    runtimeArgs = [serverEntry];
+    // The bundled server uses Node's built-in node:sqlite, which prints an
+    // ExperimentalWarning on every start. Silence it so server.log stays clean
+    // (safe: we require Node >= 22.13, where node:sqlite is available).
+    runtimeArgs = ['--disable-warning=ExperimentalWarning', serverEntry];
   } else {
     serverEntry = resolve(repoRoot, 'apps/server/src/server.ts');
     try {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,12 +10,8 @@
     "test": "vitest run --passWithNoTests",
     "lint": "eslint ."
   },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13"
-  },
   "dependencies": {
     "@openaidy/shared-types": "workspace:*",
-    "better-sqlite3": "^12.8.0",
     "drizzle-orm": "^0.41.0",
     "nanoid": "^5.0.9",
     "pg": "^8.20.0",

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -36,7 +36,7 @@ describe('createDatabaseClient (sqlite)', () => {
       sqlitePath: dbPath,
     });
 
-    // Access the underlying better-sqlite3 instance via drizzle's session
+    // Access the underlying sqlite instance via drizzle's session
     const db = conn.db as unknown as {
       session?: { client: unknown };
       driver: unknown;

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import Database from 'better-sqlite3';
-import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
+import Database from './node-sqlite';
+import { drizzleNodeSqlite } from './drizzle-node-sqlite';
 import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import * as accessTokenSchema from './schema/access-tokens';
@@ -631,7 +631,9 @@ export async function createDatabaseClient(
     initializeSqliteSchema(sqlite);
     runSqliteMigrations(sqlite);
 
-    const db = drizzleSqlite(sqlite, { schema }) as DatabaseClient;
+    const db = drizzleNodeSqlite(sqlite, {
+      schema,
+    }) as unknown as DatabaseClient;
     return {
       db,
       kind: 'sqlite',

--- a/packages/db/src/drizzle-node-sqlite.ts
+++ b/packages/db/src/drizzle-node-sqlite.ts
@@ -1,0 +1,61 @@
+/**
+ * Build a drizzle SQLite client over the node:sqlite shim.
+ *
+ * We deliberately do NOT use `drizzle-orm/better-sqlite3`'s `drizzle()`: that
+ * entry point statically imports the native `better-sqlite3` module at load
+ * time (even when you pass your own client), and we no longer ship it. By
+ * contrast `drizzle-orm/better-sqlite3/session` imports better-sqlite3 as types
+ * only, so constructing the session directly needs no native module — in dev,
+ * CI, and the bundled package alike.
+ *
+ * This mirrors the driver's internal `construct()` for drizzle-orm 0.41, using
+ * the synchronous session so transaction/insert/select semantics are identical
+ * to the previous better-sqlite3 setup.
+ */
+import {
+  createTableRelationsHelpers,
+  extractTablesRelationalConfig,
+} from 'drizzle-orm';
+import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core';
+import { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core/db';
+import { BetterSQLiteSession } from 'drizzle-orm/better-sqlite3/session';
+import type Database from './node-sqlite';
+
+export function drizzleNodeSqlite<TSchema extends Record<string, unknown>>(
+  client: Database,
+  config: { schema: TSchema },
+) {
+  const dialect = new SQLiteSyncDialect({});
+  const tablesConfig = extractTablesRelationalConfig(
+    config.schema,
+    createTableRelationsHelpers,
+  );
+  const schema = {
+    fullSchema: config.schema,
+    schema: tablesConfig.tables,
+    tableNamesMap: tablesConfig.tableNamesMap,
+  };
+  const session = new BetterSQLiteSession(
+    // The shim is better-sqlite3-compatible for everything the session calls,
+    // but not structurally identical to better-sqlite3's Database type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client as any,
+    dialect,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    schema as any,
+    {},
+  );
+  const db = new BaseSQLiteDatabase(
+    'sync',
+    dialect,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    session as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    schema as any,
+  );
+  // Expose the raw client the way drizzle's driver does; repositories reach it
+  // via `db.session.client` (see getRawSqlite).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (db as any).$client = client;
+  return db;
+}

--- a/packages/db/src/node-sqlite.ts
+++ b/packages/db/src/node-sqlite.ts
@@ -1,0 +1,141 @@
+/**
+ * node:sqlite shim — a minimal better-sqlite3-compatible wrapper over Node's
+ * built-in `node:sqlite` (`DatabaseSync`).
+ *
+ * Why: `better-sqlite3` is a native addon whose prebuilt binary is fetched by a
+ * postinstall script. npm v12 disables dependency lifecycle scripts by default,
+ * so `npm install -g @openaidy/app` would skip that script and leave the server
+ * with no SQLite binary. Node's built-in `node:sqlite` needs no native install
+ * step, so shipping this shim removes the failure class entirely.
+ *
+ * This exposes just the surface that `client.ts`, the repositories, and
+ * `drizzle-orm/better-sqlite3` actually use (`prepare`, `exec`, `pragma`,
+ * `transaction`, `close`, and statement `run/get/all/raw`). drizzle's SQLite
+ * session maps columns by position via `.raw()`, which maps onto node:sqlite's
+ * `setReturnArrays()`.
+ *
+ * Requires Node >= 22.13 (node:sqlite available without the
+ * `--experimental-sqlite` flag).
+ */
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+
+export interface RunResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+/**
+ * better-sqlite3-compatible prepared statement.
+ */
+export class Statement {
+  constructor(private readonly stmt: StatementSync) {}
+
+  /**
+   * Toggle positional-array output — better-sqlite3's `.raw()`. drizzle's
+   * SQLite session calls this to read rows as arrays and map columns by index.
+   * Returns `this` so `.raw().all()` chains like better-sqlite3.
+   */
+  raw(toggled = true): this {
+    this.stmt.setReturnArrays(toggled);
+    return this;
+  }
+
+  run(...params: unknown[]): RunResult {
+    const r = this.stmt.run(...(params as never[]));
+    return { changes: Number(r.changes), lastInsertRowid: r.lastInsertRowid };
+  }
+
+  get(...params: unknown[]): unknown {
+    return this.stmt.get(...(params as never[]));
+  }
+
+  all(...params: unknown[]): unknown[] {
+    return this.stmt.all(...(params as never[]));
+  }
+}
+
+type TransactionFn = (...args: unknown[]) => unknown;
+
+/**
+ * A better-sqlite3 transaction runner: callable (defaults to DEFERRED) and also
+ * exposing `.deferred/.immediate/.exclusive`. drizzle calls
+ * `client.transaction(fn)[behavior](tx)`; client.ts calls the returned runner
+ * directly.
+ */
+export interface TransactionRunner {
+  (...args: unknown[]): unknown;
+  deferred: (...args: unknown[]) => unknown;
+  immediate: (...args: unknown[]) => unknown;
+  exclusive: (...args: unknown[]) => unknown;
+}
+
+/**
+ * better-sqlite3-compatible Database over node:sqlite.
+ */
+export default class Database {
+  private readonly db: DatabaseSync;
+  private depth = 0;
+
+  constructor(path: string) {
+    this.db = new DatabaseSync(path);
+  }
+
+  /** True while a transaction is open (used to pick SAVEPOINT vs BEGIN). */
+  get inTransaction(): boolean {
+    return this.depth > 0;
+  }
+
+  prepare(sql: string): Statement {
+    return new Statement(this.db.prepare(sql));
+  }
+
+  exec(sql: string): this {
+    this.db.exec(sql);
+    return this;
+  }
+
+  /**
+   * better-sqlite3-style pragma. Runs `PRAGMA <source>` and returns the rows
+   * (e.g. `table_info(...)` / `index_list(...)` return arrays of objects;
+   * assignment pragmas like `foreign_keys = ON` return `[]`). node:sqlite has
+   * no `.pragma()` helper of its own.
+   */
+  pragma(source: string): unknown[] {
+    return this.db.prepare(`PRAGMA ${source}`).all();
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /**
+   * better-sqlite3-style transaction wrapper. Nested calls use SAVEPOINTs so
+   * both drizzle's top-level `.transaction()` and the app's own wrapper compose
+   * safely.
+   */
+  transaction(fn: TransactionFn): TransactionRunner {
+    const make =
+      (behavior: 'DEFERRED' | 'IMMEDIATE' | 'EXCLUSIVE') =>
+      (...args: unknown[]): unknown => {
+        const nested = this.depth > 0;
+        const savepoint = `_oa_sp_${this.depth}`;
+        this.db.exec(nested ? `SAVEPOINT ${savepoint}` : `BEGIN ${behavior}`);
+        this.depth++;
+        try {
+          const result = fn(...args);
+          this.db.exec(nested ? `RELEASE ${savepoint}` : 'COMMIT');
+          this.depth--;
+          return result;
+        } catch (err) {
+          this.db.exec(nested ? `ROLLBACK TO ${savepoint}` : 'ROLLBACK');
+          this.depth--;
+          throw err;
+        }
+      };
+    const runner = make('DEFERRED') as TransactionRunner;
+    runner.deferred = make('DEFERRED');
+    runner.immediate = make('IMMEDIATE');
+    runner.exclusive = make('EXCLUSIVE');
+    return runner;
+  }
+}

--- a/packages/db/src/repositories/memories.ts
+++ b/packages/db/src/repositories/memories.ts
@@ -7,7 +7,7 @@ import type {
 } from '@openaidy/shared-types';
 
 /**
- * Helper to access raw better-sqlite3 instance from a Drizzle client.
+ * Helper to access the raw sqlite instance from a Drizzle client.
  */
 function getRawSqlite(db: DatabaseClient) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/db/src/repositories/sessions.ts
+++ b/packages/db/src/repositories/sessions.ts
@@ -7,7 +7,7 @@ import type { SessionSearchResult } from '../types/index.js';
 type Database = DatabaseClient;
 
 /**
- * Helper to access raw better-sqlite3 instance from a Drizzle client.
+ * Helper to access the raw sqlite instance from a Drizzle client.
  */
 function getRawSqlite(db: DatabaseClient) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/db/src/repositories/task-execution-history.ts
+++ b/packages/db/src/repositories/task-execution-history.ts
@@ -32,14 +32,14 @@ export class TaskExecutionHistoryRepository {
   }): Promise<schema.TaskExecutionHistoryRow> {
     // We bypass the typed Drizzle insert because the table is declared
     // with `pgTable` (Postgres-style types), but the actual driver in
-    // the dev SQLite DB is better-sqlite3. Two mismatches:
+    // the dev SQLite DB is node:sqlite. Two mismatches:
     //   1. `defaultNow()` would compile to `now()` in SQL, which
     //      SQLite doesn't have. `task_execution_history` is created
     //      via raw CREATE TABLE in client.ts with `TEXT NOT NULL
     //      DEFAULT CURRENT_TIMESTAMP` (so the SQL default works) but
     //      Drizzle still emits `now()` from the typed schema.
     //   2. `timestamp({ withTimezone: true })` columns try to bind
-    //      JS `Date` objects, but better-sqlite3 only accepts
+    //      JS `Date` objects, but node:sqlite only accepts
     //      numbers/strings/bigints/buffers/null. Other repos work
     //      around this by passing the value through a different path,
     //      but `create` here is the only place that does an INSERT

--- a/packages/db/src/types/better-sqlite3.d.ts
+++ b/packages/db/src/types/better-sqlite3.d.ts
@@ -1,1 +1,0 @@
-declare module 'better-sqlite3';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,9 +384,6 @@ importers:
       '@openaidy/shared-types':
         specifier: workspace:*
         version: link:../shared-types
-      better-sqlite3:
-        specifier: ^12.8.0
-        version: 12.8.0
       drizzle-orm:
         specifier: ^0.41.0
         version: 0.41.0(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.8.0)(gel@2.2.0)(pg@8.20.0)
@@ -399,10 +396,6 @@ importers:
       zod:
         specifier: ^3.25.76
         version: 3.25.76
-    devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
 
   packages/plugin-sdk: {}
 
@@ -6881,6 +6874,7 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 24.13.1
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -7434,7 +7428,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
+  base64-js@1.5.1:
+    optional: true
 
   baseline-browser-mapping@2.10.8: {}
 
@@ -7442,6 +7437,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bidi-js@1.0.3:
     dependencies:
@@ -7452,6 +7448,7 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
 
   birpc@2.9.0: {}
 
@@ -7460,6 +7457,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -7506,6 +7504,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bun-plugin-dts@0.4.0:
     dependencies:
@@ -7576,7 +7575,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   cli-cursor@5.0.0:
     dependencies:
@@ -7702,10 +7702,12 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -8095,7 +8097,8 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -8223,7 +8226,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  file-uri-to-path@1.0.0: {}
+  file-uri-to-path@1.0.0:
+    optional: true
 
   fill-range@7.1.1:
     dependencies:
@@ -8287,7 +8291,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8333,7 +8338,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -8476,7 +8482,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   invariant@2.2.4:
     dependencies:
@@ -8798,7 +8805,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   min-indent@1.0.1: {}
 
@@ -8810,7 +8818,8 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimist@1.2.8: {}
+  minimist@1.2.8:
+    optional: true
 
   minipass@7.1.3: {}
 
@@ -8818,7 +8827,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mmx-cli@1.0.16:
     dependencies:
@@ -8862,7 +8872,8 @@ snapshots:
 
   nanoid@5.1.6: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   natural-compare@1.4.0: {}
 
@@ -8871,6 +8882,7 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+    optional: true
 
   node-releases@2.0.36: {}
 
@@ -9134,6 +9146,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -9175,6 +9188,7 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -9211,6 +9225,7 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -9538,13 +9553,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -9640,7 +9657,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-json-comments@3.1.1: {}
 
@@ -9712,6 +9730,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -9720,6 +9739,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   thenify-all@1.6.0:
     dependencies:
@@ -9807,6 +9827,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -9,7 +9,7 @@
  *
  * Layout produced:
  *   build/npm/
- *     package.json        name "openaidy", bin, deps (third-party + native)
+ *     package.json        name "openaidy", bin, deps (third-party)
  *     dist/server.mjs     esbuild bundle of apps/server (@openaidy/* inlined)
  *     dist/cli.mjs        esbuild bundle of the CLI (bin, shebang)
  *     web/                apps/web/dist (the built SPA)
@@ -17,9 +17,11 @@
  *     assets/openaidy-sdk.js
  *     assets/drizzle/*.sql
  *
- * First-party @openaidy/* code is bundled in; third-party deps (incl. the
- * native better-sqlite3) stay external and are declared as `dependencies` so
- * npm installs them (better-sqlite3 pulls its prebuilt binary — no compiler).
+ * First-party @openaidy/* code is bundled in; third-party deps stay external
+ * and are declared as `dependencies` so npm installs them. There are no native
+ * addons — the SQLite layer uses Node's built-in `node:sqlite` — so nothing
+ * needs a compiler or a postinstall script (safe under npm v12's script
+ * defaults). Requires Node >= 22.13 (node:sqlite without a flag).
  */
 
 import { createRequire } from 'node:module';
@@ -133,7 +135,7 @@ const pkg = {
   type: 'module',
   bin: { openaidy: './dist/cli.mjs' },
   files: ['dist', 'web', 'assets', 'README.md'],
-  engines: { node: '>=22.12.0' },
+  engines: { node: '>=22.13.0' },
   // Required for npm provenance (OIDC trusted publishing): must match the repo
   // that builds/publishes the package.
   repository: {


### PR DESCRIPTION
Closes #362.

## Why

`better-sqlite3` is a native addon whose prebuilt binary is fetched by a **postinstall** script. **npm v12 disables dependency lifecycle scripts by default**, so `npm install -g @openaidy/app` on an npm-12 machine would skip that script and leave the server with no SQLite binary → DB init crash. (It only hasn't bitten yet because the installer provisions Node 22.12 with npm 10, where scripts still run.)

Node's built-in **`node:sqlite`** needs no native install step, so switching to it removes the failure class entirely — no compiler, no postinstall, nothing for npm v12 to block.

## How

- **`packages/db/src/node-sqlite.ts`** — a small better-sqlite3-compatible shim over `node:sqlite`'s `DatabaseSync` (`prepare/exec/pragma/transaction/close` + statement `run/get/all/raw`; `raw()` → `setReturnArrays`).
- **`packages/db/src/drizzle-node-sqlite.ts`** — builds the drizzle client from drizzle's **sync session** directly. We can't use `drizzle-orm/better-sqlite3`'s `drizzle()` because that entry **statically imports the native `better-sqlite3` module at load time** even when you pass your own client. `drizzle-orm/better-sqlite3/session` imports better-sqlite3 as *types only*, so constructing the session directly needs no native module — in dev, CI, and the bundled package alike — while keeping the exact synchronous semantics.
- **Drop `better-sqlite3` + `@types/better-sqlite3`** from `@openaidy/db`. The published `@openaidy/app` now depends on **no native addon**.
- **Node floor**: `node:sqlite` is unflagged on Node ≥ 22.13. Bump the provisioned Node to **22.23.1** and gate on `>= 22.13` in `install.sh` / `install.ps1` (provision a managed copy when the system Node is too old). Package `engines` → `>=22.13.0`.
- Suppress the `node:sqlite` ExperimentalWarning in the packaged server spawn so `server.log` stays clean.

The Postgres path is unchanged.

## Verification
- `@openaidy/db` typecheck + lint clean; db tests: 45 passed, same **6 Windows-only `EBUSY`** failures as before (green on CI).
- **Full server suite: 3013 passed / 0 failed** — exercises `node:sqlite` throughout (incl. FTS5).
- Built `@openaidy/app`, installed its runtime deps (confirmed **no better-sqlite3**), and booted the bundled server: **health 200, SPA 200, API 401**. DB init works when bundled with no native module present.
- `pnpm-lock.yaml`: removes better-sqlite3 as a direct dep; the remaining references are drizzle-orm's inherent optional-peer metadata (same as the unused `gel`), not a real dependency (`pnpm why better-sqlite3` → nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)