### PR TITLE
fix(cli): server dies immediately after `openaidy start`

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -323,19 +323,22 @@ export async function startHandler(args: string[]): Promise<CommandResult> {
     childEnv['OPENAIDY_SDK_PATH'] = resolve(pkgRoot, 'assets/openaidy-sdk.js');
     childEnv['OPENAIDY_DRIZZLE_DIR'] = resolve(pkgRoot, 'assets/drizzle');
   }
+  // Hand the log file's descriptor directly to the detached child so it writes
+  // its own stdout/stderr to the file. We must NOT pipe the child's output
+  // through this CLI process: the CLI exits right after the health check, which
+  // would close the read end of those pipes and kill the (now parentless)
+  // server with EPIPE on its next log write. Owning the fd makes the server
+  // fully independent of the CLI's lifetime.
+  const fs = await import('node:fs');
+  const logFd = fs.openSync(logFile, 'a');
   const child = spawn(nodeBin, runtimeArgs, {
     detached: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', logFd, logFd],
     shell: process.platform === 'win32',
     env: childEnv,
   });
-
-  // Capture stdout/stderr to log file
-  const logStream = await import('node:fs').then((fs) =>
-    fs.createWriteStream(logFile, { flags: 'a' }),
-  );
-  if (child.stdout) child.stdout.pipe(logStream);
-  if (child.stderr) child.stderr.pipe(logStream);
+  // The child inherited its own reference to the fd; release ours.
+  fs.closeSync(logFd);
 
   // Write PID file
   const rec = {


### PR DESCRIPTION
## Problem

On a fresh VPS, `openaidy start` reports **"Server running on http://localhost:3001"** but `openaidy status` immediately shows **stopped** and nothing listens on the port. The server log ends mid-run with **no error** right after full startup.

## Cause

`start` spawns the server detached but pipes its stdout/stderr **through the CLI process**:

```ts
stdio: ['ignore', 'pipe', 'pipe']
child.stdout.pipe(logStream); child.stderr.pipe(logStream);
```

The CLI exits right after the health check prints "Server running", which closes the read ends of those pipes. The now-parentless server dies with **EPIPE** on its next log write — and because the crash message goes to the same broken pipe, nothing is logged. So the server that just answered `/health` with 200 is dead seconds later.

## Fix

Open the log file and hand its **file descriptor** directly to the child as stdout/stderr:

```ts
const logFd = fs.openSync(logFile, 'a');
spawn(nodeBin, runtimeArgs, { detached: true, stdio: ['ignore', logFd, logFd], ... });
fs.closeSync(logFd);
```

The server now owns its output and is fully independent of the CLI — it survives the CLI exiting and SSH logout (`detached` already calls `setsid` on POSIX). This is the standard daemonization pattern.

## Verification
- CLI `tsc --noEmit` clean.
- `start.test.ts` passes, including the integration test that spawns a **real detached server**, polls `/health` (200), and exits 0 — on both Windows and Linux.

Note: this makes `openaidy start` (and the installer) produce a server that stays up on its own. Boot-persistence across reboots is a separate enhancement (installer-managed systemd service) — discussing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)