### PR TITLE
chore(release): bump version to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Bumps the root version to `0.2.3` so tagging `v0.2.3` publishes `@openaidy/app@0.2.3`.

Ships:
- **#366** — clean bootstrap token output (installer logs → stderr)
- **#368** — fix the detached server dying immediately after `openaidy start` (server now survives the CLI exiting + SSH logout)

(node:sqlite / #367 deferred to a later release.)

After merge: `git tag v0.2.3 && git push origin v0.2.3` → Gate → Publish (OIDC) → GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)