### PR TITLE
chore(release): bump version to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Bumps the root version to `0.2.4` so tagging `v0.2.4` publishes `@openaidy/app@0.2.4`.

Ships **#367** — SQLite layer moved from native `better-sqlite3` to Node's built-in `node:sqlite`. No native addon, no postinstall → install works under npm v12's script-disabling defaults (closes #362). Requires Node ≥ 22.13; the installer provisions 22.23.1 and gates the system Node.

After merge: `git tag v0.2.4 && git push origin v0.2.4` → Gate → Publish (OIDC) → GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)