### PR TITLE
feat(addons): per-addon SQLite storage — Phase 1 (#374)

### DIFF
--- a/apps/server/src/addons/permission.ts
+++ b/apps/server/src/addons/permission.ts
@@ -23,6 +23,7 @@ export const PERMISSION_RESOURCES = [
   'mcp',
   'workspace',
   'logs',
+  'storage',
 ] as const;
 
 /**

--- a/apps/server/src/addons/proxy-routes-storage.test.ts
+++ b/apps/server/src/addons/proxy-routes-storage.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Addon proxy routes — storage endpoints
+ *
+ * Exercises the full request → auth → permission → engine path for
+ * /api/addon-proxy/storage/* against a real per-addon SQLite engine backed by
+ * a temp directory.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { addonProxyRoutes } from './proxy-routes';
+import { AddonService } from './service';
+import { AddonStorageEngine, DEFAULT_QUOTAS } from './storage/engine';
+import type { Addon } from '@openaidy/db';
+
+const JWT_SECRET = 'test-secret-at-least-32-chars-long!!';
+const MIGRATIONS = [
+  'CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT);',
+  'CREATE VIRTUAL TABLE notes_fts USING fts5(title);',
+];
+
+function makeAddon(addonId: string, permissions: string[]): Addon {
+  return {
+    id: 'db-row-id',
+    addonId,
+    name: 'Storage Addon',
+    version: '1.0.0',
+    status: 'enabled',
+    permissions,
+    manifest: { permissions, storage: { migrations: MIGRATIONS } },
+    config: {},
+    installedAt: new Date(),
+    updatedAt: new Date(),
+    installedBy: 'admin',
+  } as unknown as Addon;
+}
+
+async function buildApp(opts: {
+  addon: Addon;
+  engine?: AddonStorageEngine;
+}): Promise<{ app: FastifyInstance; token: string }> {
+  const addonSvc = new AddonService({
+    repository: null as never,
+    validator: null as never,
+    jwtSecret: JWT_SECRET,
+    openAidyVersion: '0.0.0',
+  });
+  const token = (
+    addonSvc as unknown as {
+      generateAccessToken: (id: string, perms: string[]) => string;
+    }
+  ).generateAccessToken(opts.addon.addonId, opts.addon.permissions as string[]);
+
+  vi.spyOn(addonSvc as never, 'getAddon' as never).mockResolvedValue(
+    opts.addon as never,
+  );
+  vi.spyOn(addonSvc as never, 'recordUsage' as never).mockResolvedValue(
+    undefined as never,
+  );
+
+  const app = Fastify({ logger: false });
+  await app.register(
+    async (api: FastifyInstance) => {
+      await api.register(addonProxyRoutes, {
+        addonService: addonSvc,
+        authMiddleware: null as never,
+        internalApiBaseUrl: '',
+        ...(opts.engine ? { storageEngine: opts.engine } : {}),
+      });
+    },
+    { prefix: '/api' },
+  );
+  return { app, token };
+}
+
+describe('addon-proxy storage routes', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+  const auth = (token: string) => ({ authorization: `Bearer ${token}` });
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'addon-storage-routes-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+  });
+
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('KV: set then get round-trips a JSON value', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('kv-addon', ['storage.read', 'storage.write']),
+      engine,
+    });
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/addon-proxy/storage/kv/theme',
+      headers: auth(token),
+      payload: { value: { mode: 'dark' } },
+    });
+    expect(put.statusCode).toBe(200);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/storage/kv/theme',
+      headers: auth(token),
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toEqual({ value: { mode: 'dark' } });
+  });
+
+  it('query + exec: migrations applied, params bound, rows returned', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('sql-addon', ['storage.read', 'storage.write']),
+      engine,
+    });
+    const exec = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/exec',
+      headers: auth(token),
+      payload: { sql: 'INSERT INTO notes (title) VALUES (?)', params: ['hi'] },
+    });
+    expect(exec.statusCode).toBe(200);
+    expect(exec.json().changes).toBe(1);
+
+    const query = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/query',
+      headers: auth(token),
+      payload: {
+        sql: 'SELECT title FROM notes WHERE title = ?',
+        params: ['hi'],
+      },
+    });
+    expect(query.statusCode).toBe(200);
+    expect(query.json()).toEqual({ rows: [{ title: 'hi' }] });
+  });
+
+  it('search: full-text search over a declared FTS table', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('fts-addon', ['storage.read', 'storage.write']),
+      engine,
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/exec',
+      headers: auth(token),
+      payload: {
+        sql: 'INSERT INTO notes_fts (title) VALUES (?)',
+        params: ['React and Vite'],
+      },
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/search',
+      headers: auth(token),
+      payload: { table: 'notes_fts', match: 'Vite' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().rows).toHaveLength(1);
+  });
+
+  it('permission: a read-only addon cannot write (exec → 403)', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('ro-addon', ['storage.read']),
+      engine,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/exec',
+      headers: auth(token),
+      payload: { sql: 'INSERT INTO notes (title) VALUES (?)', params: ['x'] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('permission: no storage permission at all → 403', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('none-addon', ['sessions.list']),
+      engine,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/storage/kv/x',
+      headers: auth(token),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('guardrail: ATTACH is rejected with 400', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('guard-addon', ['storage.read']),
+      engine,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/storage/query',
+      headers: auth(token),
+      payload: { sql: "ATTACH DATABASE 'x' AS y" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('FORBIDDEN_SQL');
+  });
+
+  it('returns 503 when no storage engine is configured', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('no-engine', ['storage.read']),
+      // engine omitted
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/storage/kv/x',
+      headers: auth(token),
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/apps/server/src/addons/proxy-routes.ts
+++ b/apps/server/src/addons/proxy-routes.ts
@@ -2,6 +2,8 @@ import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import type { AddonProxyRoutesOptions, InvokeAgentBody } from './types';
 import { createAddonProxyService } from '../addons/proxy';
 import { AddonProxyAgentService } from './proxy-agent-service';
+import { AddonStorageError } from './storage/engine';
+import type { StorageParams } from './storage/engine';
 
 // Extend FastifyRequest to include addon context
 declare module 'fastify' {
@@ -288,6 +290,210 @@ export const addonProxyRoutes: FastifyPluginAsync<
         config: {},
         message: 'Config retrieval placeholder',
       });
+    },
+  );
+
+  // ==========================================================================
+  // Storage (per-addon SQLite) — /addon-proxy/storage/*
+  // ==========================================================================
+  //
+  // The addon's own iframe reaches its private SQLite file through these
+  // routes. Reads require `storage.read`, writes require `storage.write`. The
+  // schema (manifest.storage.migrations) is applied lazily by the engine on
+  // first open, so tables exist even if the UI has never run.
+
+  const getMigrations = (manifest: unknown): string[] => {
+    const m = manifest as { storage?: { migrations?: string[] } } | null;
+    return m?.storage?.migrations ?? [];
+  };
+
+  /**
+   * Resolve the addon + authorize a storage permission. Returns the addon's
+   * migrations on success, or null after having sent the error response.
+   */
+  const forStorage = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    permission: 'storage.read' | 'storage.write',
+  ): Promise<{ migrations: string[] } | null> => {
+    if (!opts.storageEngine) {
+      reply
+        .code(503)
+        .send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Storage not available',
+        });
+      return null;
+    }
+    const addon = await opts.addonService.getAddon(request.addonId!);
+    if (!addon) {
+      reply
+        .code(404)
+        .send({ error: 'ADDON_NOT_FOUND', message: 'Addon not found' });
+      return null;
+    }
+    const auth = proxyService.authorize(addon, permission);
+    if (!auth.authorized) {
+      reply.code(403).send({ error: 'PERMISSION_DENIED', message: auth.error });
+      return null;
+    }
+    return { migrations: getMigrations(addon.manifest) };
+  };
+
+  /** Run a (synchronous) storage operation, mapping engine errors to HTTP. */
+  const runStorage = (reply: FastifyReply, fn: () => unknown) => {
+    try {
+      return reply.send(fn());
+    } catch (err) {
+      if (err instanceof AddonStorageError) {
+        return reply.code(400).send({ error: err.code, message: err.message });
+      }
+      return reply.code(500).send({
+        error: 'STORAGE_ERROR',
+        message: err instanceof Error ? err.message : 'Storage error',
+      });
+    }
+  };
+
+  // KV — list / get / set / delete
+  app.get<{ Querystring: { prefix?: string } }>(
+    '/addon-proxy/storage/kv',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.read');
+      if (!ctx) return;
+      await proxyService.recordUsage(request.addonId!, '/storage/kv');
+      return runStorage(reply, () => ({
+        items: opts.storageEngine!.kvList(
+          request.addonId!,
+          ctx.migrations,
+          request.query.prefix,
+        ),
+      }));
+    },
+  );
+
+  app.get<{ Params: { key: string } }>(
+    '/addon-proxy/storage/kv/:key',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.read');
+      if (!ctx) return;
+      await proxyService.recordUsage(request.addonId!, '/storage/kv/:key');
+      return runStorage(reply, () => ({
+        value: opts.storageEngine!.kvGet(
+          request.addonId!,
+          ctx.migrations,
+          request.params.key,
+        ),
+      }));
+    },
+  );
+
+  app.put<{ Params: { key: string }; Body: { value: unknown } }>(
+    '/addon-proxy/storage/kv/:key',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.write');
+      if (!ctx) return;
+      await proxyService.recordUsage(request.addonId!, '/storage/kv/:key');
+      return runStorage(reply, () => {
+        opts.storageEngine!.kvSet(
+          request.addonId!,
+          ctx.migrations,
+          request.params.key,
+          request.body?.value,
+        );
+        return { ok: true };
+      });
+    },
+  );
+
+  app.delete<{ Params: { key: string } }>(
+    '/addon-proxy/storage/kv/:key',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.write');
+      if (!ctx) return;
+      await proxyService.recordUsage(request.addonId!, '/storage/kv/:key');
+      return runStorage(reply, () => ({
+        deleted: opts.storageEngine!.kvDelete(
+          request.addonId!,
+          ctx.migrations,
+          request.params.key,
+        ),
+      }));
+    },
+  );
+
+  // Raw SQL — query (read) / exec (write)
+  app.post<{ Body: { sql: string; params?: StorageParams } }>(
+    '/addon-proxy/storage/query',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.read');
+      if (!ctx) return;
+      const { sql, params } = request.body ?? {};
+      if (typeof sql !== 'string') {
+        return reply
+          .code(400)
+          .send({ error: 'INVALID_REQUEST', message: 'sql is required' });
+      }
+      await proxyService.recordUsage(request.addonId!, '/storage/query');
+      return runStorage(reply, () => ({
+        rows: opts.storageEngine!.query(
+          request.addonId!,
+          ctx.migrations,
+          sql,
+          params,
+        ),
+      }));
+    },
+  );
+
+  app.post<{ Body: { sql: string; params?: StorageParams } }>(
+    '/addon-proxy/storage/exec',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.write');
+      if (!ctx) return;
+      const { sql, params } = request.body ?? {};
+      if (typeof sql !== 'string') {
+        return reply
+          .code(400)
+          .send({ error: 'INVALID_REQUEST', message: 'sql is required' });
+      }
+      await proxyService.recordUsage(request.addonId!, '/storage/exec');
+      return runStorage(reply, () =>
+        opts.storageEngine!.exec(request.addonId!, ctx.migrations, sql, params),
+      );
+    },
+  );
+
+  // Full-text search over a declared FTS5 table
+  app.post<{ Body: { table: string; match: string; limit?: number } }>(
+    '/addon-proxy/storage/search',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const ctx = await forStorage(request, reply, 'storage.read');
+      if (!ctx) return;
+      const { table, match, limit } = request.body ?? {};
+      if (typeof table !== 'string' || typeof match !== 'string') {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message: 'table and match are required',
+        });
+      }
+      await proxyService.recordUsage(request.addonId!, '/storage/search');
+      return runStorage(reply, () => ({
+        rows: opts.storageEngine!.search(
+          request.addonId!,
+          ctx.migrations,
+          table,
+          match,
+          limit,
+        ),
+      }));
     },
   );
 

--- a/apps/server/src/addons/storage/engine.test.ts
+++ b/apps/server/src/addons/storage/engine.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AddonStorageEngine,
+  AddonStorageError,
+  DEFAULT_QUOTAS,
+} from './engine.js';
+
+const ADDON = 'test-addon';
+
+describe('AddonStorageEngine', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'addon-storage-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+  });
+
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── KV ──────────────────────────────────────────────────────────────────
+  it('kv: set/get round-trips JSON values', () => {
+    engine.kvSet(ADDON, [], 'a', { n: 1, s: 'x' });
+    engine.kvSet(ADDON, [], 'b', [1, 2, 3]);
+    expect(engine.kvGet(ADDON, [], 'a')).toEqual({ n: 1, s: 'x' });
+    expect(engine.kvGet(ADDON, [], 'b')).toEqual([1, 2, 3]);
+    expect(engine.kvGet(ADDON, [], 'missing')).toBeUndefined();
+  });
+
+  it('kv: set overwrites, delete removes, list filters by prefix', () => {
+    engine.kvSet(ADDON, [], 'ui:theme', 'dark');
+    engine.kvSet(ADDON, [], 'ui:lang', 'en');
+    engine.kvSet(ADDON, [], 'other', 1);
+    engine.kvSet(ADDON, [], 'ui:theme', 'light'); // overwrite
+
+    expect(engine.kvGet(ADDON, [], 'ui:theme')).toBe('light');
+    const ui = engine.kvList(ADDON, [], 'ui:');
+    expect(ui.map((r) => r.key).sort()).toEqual(['ui:lang', 'ui:theme']);
+
+    expect(engine.kvDelete(ADDON, [], 'ui:lang')).toBe(true);
+    expect(engine.kvDelete(ADDON, [], 'ui:lang')).toBe(false);
+    expect(engine.kvList(ADDON, [], 'ui:').map((r) => r.key)).toEqual([
+      'ui:theme',
+    ]);
+  });
+
+  it('kv: list prefix escapes LIKE metacharacters', () => {
+    engine.kvSet(ADDON, [], 'a%b', 1);
+    engine.kvSet(ADDON, [], 'axb', 2);
+    // '%' must be treated literally, not as a wildcard
+    expect(engine.kvList(ADDON, [], 'a%').map((r) => r.key)).toEqual(['a%b']);
+  });
+
+  // ── Migrations ──────────────────────────────────────────────────────────
+  const MIGRATIONS = [
+    `CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT, body TEXT);`,
+    `CREATE VIRTUAL TABLE notes_fts USING fts5(title, body);`,
+  ];
+
+  it('migrations: applied once and idempotent across reopen', () => {
+    engine.exec(
+      ADDON,
+      MIGRATIONS,
+      'INSERT INTO notes (title, body) VALUES (?, ?)',
+      ['hello', 'world'],
+    );
+    // Reopen (new engine, same dir) — migrations must not re-run/throw
+    engine.close(ADDON);
+    const engine2 = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+    const rows = engine2.query(ADDON, MIGRATIONS, 'SELECT title FROM notes');
+    expect(rows).toEqual([{ title: 'hello' }]);
+    // Adding a new migration appends without redoing old ones
+    const more = [...MIGRATIONS, `ALTER TABLE notes ADD COLUMN tag TEXT;`];
+    engine2.close(ADDON);
+    const engine3 = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+    engine3.exec(ADDON, more, 'UPDATE notes SET tag = ? WHERE title = ?', [
+      't',
+      'hello',
+    ]);
+    expect(
+      engine3.query(ADDON, more, 'SELECT tag FROM notes WHERE title = ?', [
+        'hello',
+      ]),
+    ).toEqual([{ tag: 't' }]);
+    engine3.closeAll();
+  });
+
+  it('migrations: a failing migration rolls back and surfaces an error', () => {
+    expect(() =>
+      engine.kvGet(ADDON, ['CREATE TABLE x (a);', 'THIS IS NOT SQL;'], 'k'),
+    ).toThrow(AddonStorageError);
+  });
+
+  // ── query / exec ────────────────────────────────────────────────────────
+  it('exec: returns changes and lastInsertRowid; query binds params', () => {
+    const r = engine.exec(
+      ADDON,
+      MIGRATIONS,
+      'INSERT INTO notes (title, body) VALUES (?, ?)',
+      ['t1', 'b1'],
+    );
+    expect(r.changes).toBe(1);
+    expect(Number(r.lastInsertRowid)).toBeGreaterThan(0);
+
+    engine.exec(ADDON, MIGRATIONS, 'INSERT INTO notes (title) VALUES (?)', [
+      't2',
+    ]);
+    const found = engine.query(
+      ADDON,
+      MIGRATIONS,
+      'SELECT title FROM notes WHERE title = ?',
+      ['t2'],
+    );
+    expect(found).toEqual([{ title: 't2' }]);
+  });
+
+  it('query: supports named parameters', () => {
+    engine.exec(ADDON, MIGRATIONS, 'INSERT INTO notes (title) VALUES (?)', [
+      'named',
+    ]);
+    const rows = engine.query(
+      ADDON,
+      MIGRATIONS,
+      'SELECT title FROM notes WHERE title = :t',
+      { t: 'named' },
+    );
+    expect(rows).toEqual([{ title: 'named' }]);
+  });
+
+  it('query: caps rows at the quota', () => {
+    const smallEngine = new AddonStorageEngine(dir, {
+      ...DEFAULT_QUOTAS,
+      maxRows: 3,
+    });
+    for (let i = 0; i < 10; i++) {
+      smallEngine.exec(
+        ADDON,
+        MIGRATIONS,
+        'INSERT INTO notes (title) VALUES (?)',
+        [`n${i}`],
+      );
+    }
+    expect(
+      smallEngine.query(ADDON, MIGRATIONS, 'SELECT * FROM notes'),
+    ).toHaveLength(3);
+    smallEngine.closeAll();
+  });
+
+  // ── FTS ─────────────────────────────────────────────────────────────────
+  it('search: full-text search over a declared FTS5 table', () => {
+    engine.exec(
+      ADDON,
+      MIGRATIONS,
+      'INSERT INTO notes_fts (title, body) VALUES (?, ?)',
+      ['React setup', 'remember to use Vite'],
+    );
+    engine.exec(
+      ADDON,
+      MIGRATIONS,
+      'INSERT INTO notes_fts (title, body) VALUES (?, ?)',
+      ['Cooking', 'pasta recipe'],
+    );
+    const hits = engine.search(ADDON, MIGRATIONS, 'notes_fts', 'Vite');
+    expect(hits).toHaveLength(1);
+    expect((hits[0] as { title: string }).title).toBe('React setup');
+  });
+
+  it('search: rejects an invalid table name', () => {
+    expect(() =>
+      engine.search(ADDON, MIGRATIONS, 'notes; DROP TABLE notes', 'x'),
+    ).toThrow(AddonStorageError);
+  });
+
+  // ── Guardrails ──────────────────────────────────────────────────────────
+  it('guardrail: ATTACH/DETACH are rejected in query, exec, and migrations', () => {
+    expect(() =>
+      engine.query(ADDON, [], "ATTACH DATABASE 'other.db' AS x"),
+    ).toThrow(/ATTACH/i);
+    expect(() => engine.exec(ADDON, [], 'DETACH DATABASE x')).toThrow(
+      /DETACH/i,
+    );
+    expect(() =>
+      engine.kvGet(ADDON, ["ATTACH DATABASE 'x' AS y"], 'k'),
+    ).toThrow(/ATTACH/i);
+  });
+
+  it('guardrail: the word "attach" inside string data is allowed', () => {
+    // Not SQL ATTACH — just a value that contains the word.
+    engine.exec(ADDON, MIGRATIONS, 'INSERT INTO notes (body) VALUES (?)', [
+      'please attach the file',
+    ]);
+    const rows = engine.query(
+      ADDON,
+      MIGRATIONS,
+      "SELECT body FROM notes WHERE body = 'please attach the file'",
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────
+  it('destroyData: closes and removes the data directory', () => {
+    engine.kvSet(ADDON, [], 'k', 'v');
+    const dataDir = join(dir, ADDON, 'data');
+    expect(existsSync(dataDir)).toBe(true);
+    engine.destroyData(ADDON);
+    expect(existsSync(dataDir)).toBe(false);
+  });
+});

--- a/apps/server/src/addons/storage/engine.ts
+++ b/apps/server/src/addons/storage/engine.ts
@@ -1,0 +1,380 @@
+/**
+ * Addon storage engine — per-addon SQLite storage.
+ *
+ * Each addon gets its own SQLite file at `<addonsDir>/<addonId>/data/store.db`,
+ * opened lazily via Node's built-in `node:sqlite`. Because the file is the
+ * addon's own, the addon's UI can run raw SQL against it safely — the blast
+ * radius is that single file. Two guardrails keep it that way:
+ *
+ *   - Extension loading is never enabled (node:sqlite has it off by default),
+ *     so `load_extension()` is rejected as "not authorized".
+ *   - `ATTACH`/`DETACH` are denied at the SQL layer (node:sqlite exposes no
+ *     authorizer / limit API), so an addon cannot reach the main DB or any
+ *     other file.
+ *
+ * This is defense-in-depth for a self-hosted, single-user tool where the
+ * realistic hazard is a buggy or AI-generated addon, not a cross-tenant
+ * attacker. Quotas are soft (warn/log), not hard failures.
+ *
+ * Schema is declared by the addon as `manifest.storage.migrations` (an ordered
+ * list of DDL strings) and applied lazily the first time the DB is opened, so
+ * tables exist even when no addon UI has run (e.g. an agent writing headless).
+ */
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import { mkdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export interface StorageQuotas {
+  /** Soft cap on the addon DB file size; exceeding it logs a warning. */
+  maxBytes: number;
+  /** Maximum rows returned by a single query/search. */
+  maxRows: number;
+}
+
+export const DEFAULT_QUOTAS: StorageQuotas = {
+  maxBytes: 100 * 1024 * 1024, // 100 MB (soft)
+  maxRows: 10_000,
+};
+
+export type StorageParams =
+  | readonly unknown[]
+  | Record<string, unknown>
+  | undefined;
+
+export interface ExecResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+export interface StorageLogger {
+  warn: (message: string, meta?: unknown) => void;
+}
+
+export type StorageErrorCode =
+  | 'FORBIDDEN_SQL'
+  | 'MIGRATION_FAILED'
+  | 'INVALID_ARG'
+  | 'QUERY_FAILED';
+
+export class AddonStorageError extends Error {
+  constructor(
+    message: string,
+    readonly code: StorageErrorCode,
+  ) {
+    super(message);
+    this.name = 'AddonStorageError';
+  }
+}
+
+interface Handle {
+  db: DatabaseSync;
+  lastUsed: number;
+}
+
+/** Safe SQL identifier (used to validate a caller-supplied FTS table name). */
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export class AddonStorageEngine {
+  private readonly handles = new Map<string, Handle>();
+
+  constructor(
+    private readonly addonsDir: string,
+    private readonly quotas: StorageQuotas = DEFAULT_QUOTAS,
+    private readonly logger: StorageLogger = { warn: () => {} },
+  ) {}
+
+  private dbPath(addonId: string): string {
+    return join(this.addonsDir, addonId, 'data', 'store.db');
+  }
+
+  // ── Guardrails ────────────────────────────────────────────────────────────
+
+  /**
+   * Reject SQL that could escape the addon's own file. node:sqlite exposes no
+   * authorizer, so we deny `ATTACH`/`DETACH` textually (comments and string /
+   * quoted-identifier literals are stripped first so keywords inside them don't
+   * trip the check). Extension loading is already off at the driver level.
+   */
+  private assertSafe(sql: string): void {
+    const stripped = sql
+      .replace(/--[^\n]*/g, ' ') // line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+      .replace(/'(?:''|[^'])*'/g, "''") // string literals
+      .replace(/"(?:""|[^"])*"/g, '""'); // quoted identifiers
+    if (/\b(?:attach|detach)\b/i.test(stripped)) {
+      throw new AddonStorageError(
+        'ATTACH/DETACH are not permitted in addon storage',
+        'FORBIDDEN_SQL',
+      );
+    }
+  }
+
+  // ── Connection + migrations ────────────────────────────────────────────────
+
+  private connect(
+    addonId: string,
+    migrations: readonly string[],
+  ): DatabaseSync {
+    const cached = this.handles.get(addonId);
+    if (cached) {
+      cached.lastUsed = Date.now();
+      return cached.db;
+    }
+
+    const path = this.dbPath(addonId);
+    mkdirSync(dirname(path), { recursive: true });
+    // Extensions stay off (never call enableLoadExtension) → load_extension is
+    // rejected as "not authorized".
+    const db = new DatabaseSync(path);
+    try {
+      db.exec(
+        'PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000;',
+      );
+      this.initMeta(db);
+      this.applyMigrations(db, migrations);
+    } catch (err) {
+      // Don't leak the open handle (and the file lock) if setup/migration fails.
+      try {
+        db.close();
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    }
+
+    this.handles.set(addonId, { db, lastUsed: Date.now() });
+    return db;
+  }
+
+  private initMeta(db: DatabaseSync): void {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS _kv (
+        key        TEXT PRIMARY KEY,
+        value      TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE IF NOT EXISTS _openaidy_migrations (
+        idx        INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+  }
+
+  /**
+   * Apply any manifest migrations not yet recorded, by index, each in its own
+   * transaction. Migrations must be plain DDL/DML (no BEGIN/COMMIT of their
+   * own). Already-applied indices are skipped, so this is idempotent and safe
+   * to call on every open.
+   */
+  private applyMigrations(
+    db: DatabaseSync,
+    migrations: readonly string[],
+  ): void {
+    const { max } = db
+      .prepare('SELECT COALESCE(MAX(idx), -1) AS max FROM _openaidy_migrations')
+      .get() as { max: number };
+
+    for (let i = 0; i < migrations.length; i++) {
+      if (i <= max) continue;
+      const sql = migrations[i]!;
+      this.assertSafe(sql);
+      db.exec('BEGIN');
+      try {
+        db.exec(sql);
+        db.prepare('INSERT INTO _openaidy_migrations (idx) VALUES (?)').run(i);
+        db.exec('COMMIT');
+      } catch (err) {
+        db.exec('ROLLBACK');
+        throw new AddonStorageError(
+          `Migration ${i} failed: ${(err as Error).message}`,
+          'MIGRATION_FAILED',
+        );
+      }
+    }
+  }
+
+  // ── Parameter binding ──────────────────────────────────────────────────────
+
+  private allRows(stmt: StatementSync, params: StorageParams): unknown[] {
+    if (params === undefined) return stmt.all();
+    if (Array.isArray(params)) return stmt.all(...(params as never[]));
+    stmt.setAllowBareNamedParameters(true);
+    return stmt.all(params as never);
+  }
+
+  private runStmt(stmt: StatementSync, params: StorageParams): ExecResult {
+    let r: { changes: number | bigint; lastInsertRowid: number | bigint };
+    if (params === undefined) r = stmt.run();
+    else if (Array.isArray(params)) r = stmt.run(...(params as never[]));
+    else {
+      stmt.setAllowBareNamedParameters(true);
+      r = stmt.run(params as never);
+    }
+    return { changes: Number(r.changes), lastInsertRowid: r.lastInsertRowid };
+  }
+
+  // ── Raw SQL (iframe SDK) ────────────────────────────────────────────────────
+
+  /** Run a read query and return rows (capped at the row quota). */
+  query(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): unknown[] {
+    this.assertSafe(sql);
+    const db = this.connect(addonId, migrations);
+    const stmt = db.prepare(sql);
+    const out: unknown[] = [];
+    const iter =
+      params === undefined
+        ? stmt.iterate()
+        : Array.isArray(params)
+          ? stmt.iterate(...(params as never[]))
+          : (stmt.setAllowBareNamedParameters(true),
+            stmt.iterate(params as never));
+    for (const row of iter) {
+      out.push(row);
+      if (out.length >= this.quotas.maxRows) break;
+    }
+    return out;
+  }
+
+  /** Run a write statement and return {changes, lastInsertRowid}. */
+  exec(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): ExecResult {
+    this.assertSafe(sql);
+    const db = this.connect(addonId, migrations);
+    const res = this.runStmt(db.prepare(sql), params);
+    this.checkQuota(addonId);
+    return res;
+  }
+
+  /**
+   * Full-text search convenience over an FTS5 table the addon declared. The
+   * table name is caller-supplied, so it's validated as a bare identifier
+   * (no injection) rather than parameterized (SQLite can't bind identifiers).
+   */
+  search(
+    addonId: string,
+    migrations: readonly string[],
+    table: string,
+    match: string,
+    limit = 50,
+  ): unknown[] {
+    if (!IDENTIFIER.test(table)) {
+      throw new AddonStorageError(
+        `Invalid FTS table name: ${table}`,
+        'INVALID_ARG',
+      );
+    }
+    const db = this.connect(addonId, migrations);
+    const cap = Math.max(1, Math.min(limit, this.quotas.maxRows));
+    return db
+      .prepare(`SELECT * FROM ${table} WHERE ${table} MATCH ? LIMIT ?`)
+      .all(match, cap);
+  }
+
+  // ── Key/value store (iframe SDK sugar) ──────────────────────────────────────
+
+  kvGet(addonId: string, migrations: readonly string[], key: string): unknown {
+    const db = this.connect(addonId, migrations);
+    const row = db.prepare('SELECT value FROM _kv WHERE key = ?').get(key) as
+      | { value: string }
+      | undefined;
+    return row ? JSON.parse(row.value) : undefined;
+  }
+
+  kvSet(
+    addonId: string,
+    migrations: readonly string[],
+    key: string,
+    value: unknown,
+  ): void {
+    const db = this.connect(addonId, migrations);
+    db.prepare(
+      `INSERT INTO _kv (key, value, updated_at)
+       VALUES (?, ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    ).run(key, JSON.stringify(value ?? null));
+    this.checkQuota(addonId);
+  }
+
+  kvList(
+    addonId: string,
+    migrations: readonly string[],
+    prefix?: string,
+  ): Array<{ key: string; value: unknown }> {
+    const db = this.connect(addonId, migrations);
+    const rows = (
+      prefix
+        ? db
+            .prepare(
+              `SELECT key, value FROM _kv WHERE key LIKE ? ESCAPE '\\' ORDER BY key`,
+            )
+            .all(`${prefix.replace(/[\\%_]/g, '\\$&')}%`)
+        : db.prepare('SELECT key, value FROM _kv ORDER BY key').all()
+    ) as Array<{ key: string; value: string }>;
+    return rows.map((r) => ({ key: r.key, value: JSON.parse(r.value) }));
+  }
+
+  kvDelete(
+    addonId: string,
+    migrations: readonly string[],
+    key: string,
+  ): boolean {
+    const db = this.connect(addonId, migrations);
+    const { changes } = db.prepare('DELETE FROM _kv WHERE key = ?').run(key);
+    return Number(changes) > 0;
+  }
+
+  // ── Quotas + lifecycle ──────────────────────────────────────────────────────
+
+  private checkQuota(addonId: string): void {
+    try {
+      const { size } = statSync(this.dbPath(addonId));
+      if (size > this.quotas.maxBytes) {
+        this.logger.warn('Addon storage exceeds its soft size quota', {
+          addonId,
+          size,
+          maxBytes: this.quotas.maxBytes,
+        });
+      }
+    } catch {
+      /* file may not exist yet — ignore */
+    }
+  }
+
+  /** Close and forget an addon's connection (e.g. on disable or upgrade). */
+  close(addonId: string): void {
+    const h = this.handles.get(addonId);
+    if (!h) return;
+    try {
+      h.db.close();
+    } catch {
+      /* ignore */
+    }
+    this.handles.delete(addonId);
+  }
+
+  /** Close every open connection (e.g. on server shutdown). */
+  closeAll(): void {
+    for (const id of [...this.handles.keys()]) this.close(id);
+  }
+
+  /**
+   * Close the connection and delete the addon's on-disk data directory
+   * (store.db + WAL/SHM sidecars). Called on uninstall.
+   */
+  destroyData(addonId: string): void {
+    this.close(addonId);
+    rmSync(join(this.addonsDir, addonId, 'data'), {
+      recursive: true,
+      force: true,
+    });
+  }
+}

--- a/apps/server/src/addons/storage/engine.ts
+++ b/apps/server/src/addons/storage/engine.ts
@@ -195,13 +195,6 @@ export class AddonStorageEngine {
 
   // ── Parameter binding ──────────────────────────────────────────────────────
 
-  private allRows(stmt: StatementSync, params: StorageParams): unknown[] {
-    if (params === undefined) return stmt.all();
-    if (Array.isArray(params)) return stmt.all(...(params as never[]));
-    stmt.setAllowBareNamedParameters(true);
-    return stmt.all(params as never);
-  }
-
   private runStmt(stmt: StatementSync, params: StorageParams): ExecResult {
     let r: { changes: number | bigint; lastInsertRowid: number | bigint };
     if (params === undefined) r = stmt.run();
@@ -367,8 +360,8 @@ export class AddonStorageEngine {
   }
 
   /**
-   * Close the connection and delete the addon's on-disk data directory
-   * (store.db + WAL/SHM sidecars). Called on uninstall.
+   * Close the connection and delete only the addon's data directory
+   * (store.db + WAL/SHM sidecars), leaving its source files in place.
    */
   destroyData(addonId: string): void {
     this.close(addonId);
@@ -376,5 +369,15 @@ export class AddonStorageEngine {
       recursive: true,
       force: true,
     });
+  }
+
+  /**
+   * Close the connection and delete the addon's entire on-disk directory
+   * (source files + data). Called on uninstall — previously addon files were
+   * left behind entirely.
+   */
+  destroyAddon(addonId: string): void {
+    this.close(addonId);
+    rmSync(join(this.addonsDir, addonId), { recursive: true, force: true });
   }
 }

--- a/apps/server/src/addons/types.ts
+++ b/apps/server/src/addons/types.ts
@@ -22,6 +22,7 @@ export interface AddonProxyRoutesOptions {
   internalApiBaseUrl: string;
   sessionService?: SessionMessageService;
   agentRegistry?: AgentRegistry;
+  storageEngine?: import('./storage/engine').AddonStorageEngine;
 }
 
 /**

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -36,6 +36,7 @@ import { logRoutes } from './routes/logs';
 import { createMcpRoutesPlugin } from './routes/mcp';
 import { addonRoutes } from './routes/addons';
 import { addonProxyRoutes } from './addons/proxy-routes';
+import { AddonStorageEngine, DEFAULT_QUOTAS } from './addons/storage/engine';
 import { ManifestValidator } from './addons/manifest-validator';
 import { createAddonService } from './addons/service';
 import { taskRoutes } from './routes/tasks';
@@ -236,6 +237,14 @@ export async function buildApp() {
         openAidyVersion,
       })
     : undefined;
+
+  // Per-addon SQLite storage engine (lazy connections; shared by the addon
+  // proxy routes and the uninstall cleanup path).
+  const addonStorageEngine = new AddonStorageEngine(
+    path.join(env.OPENAIDY_HOME, 'addons'),
+    DEFAULT_QUOTAS,
+    { warn: (message, meta) => log.warn(message, meta) },
+  );
 
   // Create builtin tool registry (native, in-process tools — separate from MCP)
   // Session tools and Tasks tools use lazy getters to break circular dependencies:
@@ -729,6 +738,7 @@ export async function buildApp() {
           internalApiBaseUrl: `http://${env.HOST}:${env.PORT}`,
           sessionService,
           agentRegistry,
+          storageEngine: addonStorageEngine,
         });
       }
     },
@@ -758,6 +768,7 @@ export async function buildApp() {
       jwtSecret: env.WS_TOKEN_SECRET,
       openAidyVersion,
       manifestValidator: addonManifestValidator,
+      storageEngine: addonStorageEngine,
     });
   }
 

--- a/apps/server/src/routes/addons.ts
+++ b/apps/server/src/routes/addons.ts
@@ -67,6 +67,7 @@ export type AddonRoutesOptions = {
   jwtSecret: string;
   openAidyVersion: string;
   manifestValidator: ManifestValidator;
+  storageEngine?: import('../addons/storage/engine').AddonStorageEngine;
 };
 
 /**
@@ -253,6 +254,9 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
     async (request, reply) => {
       try {
         await addonService.uninstallAddon(request.params.addonId, 'admin');
+        // Close the storage connection and delete the addon's on-disk
+        // directory (source + data) — previously left behind entirely.
+        opts.storageEngine?.destroyAddon(request.params.addonId);
         return reply.code(204).send();
       } catch (error: unknown) {
         const err = error as { code?: string; message?: string };

--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -166,6 +166,76 @@
       );
     },
 
+    // ── Storage (per-addon SQLite) ────────────────────────────────────────
+    // Requires the `storage.read` / `storage.write` permissions. Schema is
+    // declared in the manifest under `storage.migrations`.
+    storage: {
+      kv: {
+        /** Read a JSON value by key (resolves undefined if absent). */
+        get: function (key) {
+          return request(
+            'GET',
+            '/api/addon-proxy/storage/kv/' + encodeURIComponent(key),
+          ).then(function (r) {
+            return r.value;
+          });
+        },
+        /** Write a JSON value by key. */
+        set: function (key, value) {
+          return request(
+            'PUT',
+            '/api/addon-proxy/storage/kv/' + encodeURIComponent(key),
+            { value: value },
+          );
+        },
+        /** List {key, value} entries, optionally filtered by key prefix. */
+        list: function (prefix) {
+          return request(
+            'GET',
+            '/api/addon-proxy/storage/kv' +
+              (prefix ? '?prefix=' + encodeURIComponent(prefix) : ''),
+          ).then(function (r) {
+            return r.items;
+          });
+        },
+        /** Delete a key; resolves true if a row was removed. */
+        delete: function (key) {
+          return request(
+            'DELETE',
+            '/api/addon-proxy/storage/kv/' + encodeURIComponent(key),
+          ).then(function (r) {
+            return r.deleted;
+          });
+        },
+      },
+      /** Run a read query (SELECT/…); resolves an array of row objects. */
+      query: function (sql, params) {
+        return request('POST', '/api/addon-proxy/storage/query', {
+          sql: sql,
+          params: params,
+        }).then(function (r) {
+          return r.rows;
+        });
+      },
+      /** Run a write statement; resolves {changes, lastInsertRowid}. */
+      exec: function (sql, params) {
+        return request('POST', '/api/addon-proxy/storage/exec', {
+          sql: sql,
+          params: params,
+        });
+      },
+      /** Full-text search over a declared FTS5 table; resolves matching rows. */
+      search: function (table, match, limit) {
+        return request('POST', '/api/addon-proxy/storage/search', {
+          table: table,
+          match: match,
+          limit: limit,
+        }).then(function (r) {
+          return r.rows;
+        });
+      },
+    },
+
     // ── Raw request (escape hatch) ────────────────────────────────────────
     request: function (method, path, body) {
       return request(method, path, body);

--- a/packages/shared-types/src/addon.ts
+++ b/packages/shared-types/src/addon.ts
@@ -137,6 +137,22 @@ export const AddonOpenAidySchema = z.object({
 export type AddonOpenAidy = z.infer<typeof AddonOpenAidySchema>;
 
 /**
+ * Addon storage block — declares the addon's own per-addon SQLite storage.
+ *
+ * `migrations` is an ordered list of DDL/DML statements the host applies once,
+ * by index, the first time the addon's DB is opened (and again for any newly
+ * added entries after an upgrade). Declaring the schema here — rather than
+ * having the UI create tables on first load — means the tables exist even when
+ * no addon UI has run (e.g. an agent writing to the store headless). Each entry
+ * must be plain SQL without its own BEGIN/COMMIT; `ATTACH`/`DETACH` are rejected.
+ */
+export const AddonStorageConfigSchema = z.object({
+  migrations: z.array(z.string().min(1).max(20_000)).max(200).optional(),
+});
+
+export type AddonStorageConfig = z.infer<typeof AddonStorageConfigSchema>;
+
+/**
  * Main addon manifest structure
  */
 export const AddonManifestSchema = z.object({
@@ -167,6 +183,7 @@ export const AddonManifestSchema = z.object({
   ui: AddonUIConfigSchema.optional(),
   agents: z.array(AddonAgentReferenceSchema).optional(),
   config: AddonConfigBlockSchema.optional(),
+  storage: AddonStorageConfigSchema.optional(),
   dependencies: z.record(z.string()).optional(),
   keywords: z.array(z.string()).optional(),
   /**
@@ -387,6 +404,7 @@ export const PERMISSION_RESOURCES = [
   'mcp',
   'workspace',
   'logs',
+  'storage',
 ] as const;
 
 export type PermissionResource = (typeof PERMISSION_RESOURCES)[number];


### PR DESCRIPTION
Phase 1 of #374 — the storage engine + the addon-facing (iframe) surface. The agent named-query catalog (`addon_run`) is **Phase 2** and not in this PR.

## What addons get

A private SQLite file per addon at `<OPENAIDY_HOME>/addons/<id>/data/store.db`, reachable from the addon's iframe via a new `OpenAidy.storage` SDK namespace:

- `storage.kv.get/set/list/delete(key)` — JSON key/value sugar (auto `_kv` table)
- `storage.query(sql, params)` / `storage.exec(sql, params)` — raw SQL on the addon's own file
- `storage.search(table, match, limit)` — first-class FTS5 search
- Schema declared as `manifest.storage.migrations` (ordered DDL), applied lazily on first open — so tables exist even before any UI runs (needed for the Phase 2 headless-agent writes)

## How it's built

- **Engine** (`apps/server/src/addons/storage/engine.ts`) — per-addon `node:sqlite` connections, cached; lazy idempotent migrations tracked in `_openaidy_migrations`; soft size quota (warn/log) + row cap.
- **Guardrails** — `node:sqlite` has no authorizer, so: extension loading is never enabled (`load_extension` → "not authorized"), and `ATTACH`/`DETACH` are denied at the SQL layer (comments/strings stripped first) so an addon can't escape its own file to reach the main DB. Proportionate defense-in-depth for a self-hosted, single-user tool.
- **Permission** — new `storage` resource → `storage.read` / `storage.write`; routes are permission-gated and scoped to the `addonId` from the validated JWT.
- **Routes** — `/api/addon-proxy/storage/*` (kv, query, exec, search); engine errors map to `400`, missing engine → `503`.
- **Uninstall** — now closes the connection and deletes the addon's entire on-disk directory (source + data). Previously addon files were **never** cleaned up — fixed here.

## Tests
- Engine: 13 unit tests (KV, idempotent migrations + rollback, query/exec/named-params/row-cap, FTS, ATTACH/DETACH guardrail, lifecycle).
- Routes: 7 integration tests through the real auth → permission → engine path (round-trips, read-only write rejection, no-permission 403, ATTACH → 400, 503 without engine).
- All 192 addon tests pass; server lint + typecheck clean.

## Deferred (follow-ups, not blockers)
- `sdk-reference.ts` docs for `storage.*` (so the addon-authoring agent surfaces it).
- `closeAll()` on graceful shutdown (WAL checkpoint); process exit already releases handles.
- **Phase 2:** `storage.agentQueries` catalog + `addon_run` agent tool.

Part of #374 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)