### PR TITLE
feat(addons): agent named-query catalog — Phase 2 (#374)

### DIFF
--- a/apps/server/src/addons/storage/agent-queries.test.ts
+++ b/apps/server/src/addons/storage/agent-queries.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AddonStorageEngine, DEFAULT_QUOTAS } from './engine.js';
+import {
+  AddonAgentQueryService,
+  AgentQueryDenied,
+  type AgentQueryResult,
+} from './agent-queries.js';
+
+const MIGRATIONS = ['CREATE TABLE deals (id INTEGER PRIMARY KEY, title TEXT);'];
+
+const QUERIES = [
+  {
+    name: 'all_deals',
+    description: 'All deal titles',
+    access: 'read' as const,
+    sql: 'SELECT title FROM deals ORDER BY title',
+  },
+  {
+    name: 'by_prefix',
+    description: 'Deals whose title starts with a prefix',
+    access: 'read' as const,
+    params: { p: 'string' as const },
+    sql: "SELECT title FROM deals WHERE title LIKE :p || '%' ORDER BY title",
+  },
+  {
+    name: 'add_deal',
+    description: 'Add a deal',
+    access: 'write' as const,
+    params: { title: 'string' as const },
+    sql: 'INSERT INTO deals (title) VALUES (:title)',
+  },
+];
+
+function addon(addonId: string, storage: unknown) {
+  return { addonId, manifest: { storage } };
+}
+
+const RW = {
+  migrations: MIGRATIONS,
+  agentAccess: 'readwrite',
+  agentQueries: QUERIES,
+};
+const RO = {
+  migrations: MIGRATIONS,
+  agentAccess: 'read',
+  agentQueries: QUERIES,
+};
+
+describe('AddonAgentQueryService', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+  let svc: AddonAgentQueryService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agent-queries-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+    svc = new AddonAgentQueryService(engine);
+  });
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('runs write then read named queries', () => {
+    const a = addon('crm', RW);
+    const w = svc.run(a, 'add_deal', { title: 'Acme' });
+    expect(w).toMatchObject({ kind: 'write', changes: 1 } as AgentQueryResult);
+    svc.run(a, 'add_deal', { title: 'Beta' });
+    expect(svc.run(a, 'all_deals')).toEqual({
+      kind: 'rows',
+      rows: [{ title: 'Acme' }, { title: 'Beta' }],
+    });
+  });
+
+  it('binds and coerces declared params', () => {
+    const a = addon('crm', RW);
+    svc.run(a, 'add_deal', { title: 'Acme' });
+    svc.run(a, 'add_deal', { title: 'Zeta' });
+    const r = svc.run(a, 'by_prefix', { p: 'Ac' });
+    expect(r).toEqual({ kind: 'rows', rows: [{ title: 'Acme' }] });
+  });
+
+  it('rejects a missing required param', () => {
+    try {
+      svc.run(addon('crm', RW), 'add_deal', {});
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(AgentQueryDenied);
+      expect((e as AgentQueryDenied).code).toBe('INVALID_PARAMS');
+    }
+  });
+
+  it('denies a write query when the addon grants agents read-only', () => {
+    try {
+      svc.run(addon('crm', RO), 'add_deal', { title: 'x' });
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('WRITE_NOT_ALLOWED');
+    }
+  });
+
+  it('a read query cannot be tricked into writing (read-only connection)', () => {
+    const sneaky = {
+      migrations: MIGRATIONS,
+      agentAccess: 'read',
+      agentQueries: [
+        {
+          name: 'sneaky',
+          description: 'looks like a read',
+          access: 'read' as const,
+          sql: "INSERT INTO deals (title) VALUES ('x')",
+        },
+      ],
+    };
+    expect(() => svc.run(addon('crm', sneaky), 'sneaky')).toThrow(/readonly/i);
+  });
+
+  it('denies when the addon did not opt into agent access', () => {
+    const noAccess = { migrations: MIGRATIONS, agentQueries: QUERIES };
+    try {
+      svc.run(addon('crm', noAccess), 'all_deals');
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('AGENT_ACCESS_DENIED');
+    }
+  });
+
+  it('reports an unknown query', () => {
+    try {
+      svc.run(addon('crm', RW), 'nope');
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('QUERY_NOT_FOUND');
+    }
+  });
+
+  it('list: shows writes only under readwrite; empty without opt-in', () => {
+    expect(svc.list(addon('c', RW)).map((q) => q.name)).toContain('add_deal');
+    expect(svc.list(addon('c', RO)).map((q) => q.name)).not.toContain(
+      'add_deal',
+    );
+    expect(svc.list(addon('c', RO)).map((q) => q.name)).toContain('all_deals');
+    expect(svc.list(addon('c', { migrations: [] }))).toEqual([]);
+  });
+});

--- a/apps/server/src/addons/storage/agent-queries.ts
+++ b/apps/server/src/addons/storage/agent-queries.ts
@@ -1,0 +1,173 @@
+/**
+ * Agent-facing addon storage — the named-query catalog.
+ *
+ * Agents never write SQL against an addon's DB. Instead the addon declares a
+ * catalog of named, parameterized queries in its manifest
+ * (`storage.agentQueries`), and the agent runs them by name with typed
+ * parameters. A declared query can do exactly — and only — what its author
+ * wrote, so writes are as safe as reads (the agent supplies values, not
+ * statements). Read queries run on a read-only connection; writes go through
+ * `exec` and require the addon to grant `agentAccess: "readwrite"`.
+ */
+import type {
+  AddonAgentQuery,
+  AddonAgentQueryParamType,
+  AddonStorageConfig,
+} from '@openaidy/shared-types';
+import type { AddonStorageEngine } from './engine';
+
+export type AgentQueryErrorCode =
+  | 'AGENT_ACCESS_DENIED'
+  | 'QUERY_NOT_FOUND'
+  | 'WRITE_NOT_ALLOWED'
+  | 'INVALID_PARAMS';
+
+export class AgentQueryDenied extends Error {
+  constructor(
+    message: string,
+    readonly code: AgentQueryErrorCode,
+  ) {
+    super(message);
+    this.name = 'AgentQueryDenied';
+  }
+}
+
+/** Minimal shape of an addon record this service needs. */
+export interface AddonForQueries {
+  addonId: string;
+  manifest: unknown;
+}
+
+export type AgentQueryResult =
+  | { kind: 'rows'; rows: unknown[] }
+  | { kind: 'write'; changes: number; lastInsertRowid: number | bigint };
+
+function getStorage(manifest: unknown): AddonStorageConfig | undefined {
+  return (manifest as { storage?: AddonStorageConfig } | null)?.storage;
+}
+
+function coerceParam(
+  name: string,
+  type: AddonAgentQueryParamType,
+  value: unknown,
+): string | number {
+  if (value === undefined || value === null) {
+    throw new AgentQueryDenied(
+      `Missing required parameter: ${name}`,
+      'INVALID_PARAMS',
+    );
+  }
+  switch (type) {
+    case 'string':
+      if (typeof value !== 'string') {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be a string`,
+          'INVALID_PARAMS',
+        );
+      }
+      return value;
+    case 'int': {
+      const n = Number(value);
+      if (!Number.isInteger(n)) {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be an integer`,
+          'INVALID_PARAMS',
+        );
+      }
+      return n;
+    }
+    case 'number': {
+      const n = Number(value);
+      if (!Number.isFinite(n)) {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be a number`,
+          'INVALID_PARAMS',
+        );
+      }
+      return n;
+    }
+    case 'boolean':
+      // SQLite has no boolean — store as 0/1.
+      return value ? 1 : 0;
+  }
+}
+
+export class AddonAgentQueryService {
+  constructor(private readonly engine: AddonStorageEngine) {}
+
+  /**
+   * The queries an agent may run against this addon: empty unless the addon
+   * opted in via `agentAccess`, and write queries are hidden unless it granted
+   * `readwrite`.
+   */
+  list(addon: AddonForQueries): AddonAgentQuery[] {
+    const storage = getStorage(addon.manifest);
+    if (!storage?.agentAccess || !storage.agentQueries) return [];
+    return storage.agentQueries.filter(
+      (q) =>
+        (q.access ?? 'read') === 'read' || storage.agentAccess === 'readwrite',
+    );
+  }
+
+  /** Run a declared query by name with the supplied parameters. */
+  run(
+    addon: AddonForQueries,
+    queryName: string,
+    params: Record<string, unknown> = {},
+  ): AgentQueryResult {
+    const storage = getStorage(addon.manifest);
+    if (!storage?.agentAccess) {
+      throw new AgentQueryDenied(
+        'This addon does not expose its storage to agents',
+        'AGENT_ACCESS_DENIED',
+      );
+    }
+    const query = storage.agentQueries?.find((q) => q.name === queryName);
+    if (!query) {
+      throw new AgentQueryDenied(
+        `Addon "${addon.addonId}" has no agent query named "${queryName}"`,
+        'QUERY_NOT_FOUND',
+      );
+    }
+    const access = query.access ?? 'read';
+    if (access === 'write' && storage.agentAccess !== 'readwrite') {
+      throw new AgentQueryDenied(
+        `Query "${queryName}" writes, but this addon only grants agents read access`,
+        'WRITE_NOT_ALLOWED',
+      );
+    }
+
+    const bound = this.buildParams(query, params);
+    const migrations = storage.migrations ?? [];
+
+    if (access === 'read') {
+      return {
+        kind: 'rows',
+        rows: this.engine.queryReadOnly(
+          addon.addonId,
+          migrations,
+          query.sql,
+          bound,
+        ),
+      };
+    }
+    const r = this.engine.exec(addon.addonId, migrations, query.sql, bound);
+    return {
+      kind: 'write',
+      changes: r.changes,
+      lastInsertRowid: r.lastInsertRowid,
+    };
+  }
+
+  private buildParams(
+    query: AddonAgentQuery,
+    params: Record<string, unknown>,
+  ): Record<string, string | number> {
+    const declared = query.params ?? {};
+    const out: Record<string, string | number> = {};
+    for (const [name, type] of Object.entries(declared)) {
+      out[name] = coerceParam(name, type, params?.[name]);
+    }
+    return out;
+  }
+}

--- a/apps/server/src/addons/storage/engine.ts
+++ b/apps/server/src/addons/storage/engine.ts
@@ -68,6 +68,8 @@ export class AddonStorageError extends Error {
 
 interface Handle {
   db: DatabaseSync;
+  /** Lazily-opened read-only connection (used for agent read queries). */
+  ro?: DatabaseSync;
   lastUsed: number;
 }
 
@@ -208,16 +210,7 @@ export class AddonStorageEngine {
 
   // ── Raw SQL (iframe SDK) ────────────────────────────────────────────────────
 
-  /** Run a read query and return rows (capped at the row quota). */
-  query(
-    addonId: string,
-    migrations: readonly string[],
-    sql: string,
-    params?: StorageParams,
-  ): unknown[] {
-    this.assertSafe(sql);
-    const db = this.connect(addonId, migrations);
-    const stmt = db.prepare(sql);
+  private iterateCapped(stmt: StatementSync, params: StorageParams): unknown[] {
     const out: unknown[] = [];
     const iter =
       params === undefined
@@ -231,6 +224,38 @@ export class AddonStorageEngine {
       if (out.length >= this.quotas.maxRows) break;
     }
     return out;
+  }
+
+  /** Run a read query and return rows (capped at the row quota). */
+  query(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): unknown[] {
+    this.assertSafe(sql);
+    const db = this.connect(addonId, migrations);
+    return this.iterateCapped(db.prepare(sql), params);
+  }
+
+  /**
+   * Run a read query on a read-only connection. Used for agent read queries so
+   * a mis-tagged write can't mutate data — the connection physically rejects
+   * writes ("attempt to write a readonly database"). Migrations are applied via
+   * the read/write connection first so the schema is present.
+   */
+  queryReadOnly(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): unknown[] {
+    this.assertSafe(sql);
+    // Ensure the file exists + migrations are applied (read/write connection).
+    this.connect(addonId, migrations);
+    const h = this.handles.get(addonId)!;
+    h.ro ??= new DatabaseSync(this.dbPath(addonId), { readOnly: true });
+    return this.iterateCapped(h.ro.prepare(sql), params);
   }
 
   /** Run a write statement and return {changes, lastInsertRowid}. */
@@ -342,14 +367,16 @@ export class AddonStorageEngine {
     }
   }
 
-  /** Close and forget an addon's connection (e.g. on disable or upgrade). */
+  /** Close and forget an addon's connection(s) (e.g. on disable or upgrade). */
   close(addonId: string): void {
     const h = this.handles.get(addonId);
     if (!h) return;
-    try {
-      h.db.close();
-    } catch {
-      /* ignore */
+    for (const conn of [h.ro, h.db]) {
+      try {
+        conn?.close();
+      } catch {
+        /* ignore */
+      }
     }
     this.handles.delete(addonId);
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -265,6 +265,7 @@ export async function buildApp() {
     skills: { registry: skillRegistry },
     addons: {
       addonsDir: path.join(env.OPENAIDY_HOME, 'addons'),
+      storageEngine: addonStorageEngine,
       ...(addonService ? { addonService } : {}),
     },
     agents: {

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -34,6 +34,11 @@ export type AddonToolDeps = {
    * (useful in environments where the DB is not configured).
    */
   addonService?: AddonService;
+  /**
+   * Per-addon storage engine. Required by the addon_run / addon_list_queries
+   * tools; absent when storage is unavailable.
+   */
+  storageEngine?: import('../../addons/storage/engine').AddonStorageEngine;
 };
 
 // ── Validation helpers ────────────────────────────────────────────────────────

--- a/apps/server/src/tools/addons/index.ts
+++ b/apps/server/src/tools/addons/index.ts
@@ -1,17 +1,24 @@
 import type { BuiltinTool } from '@openaidy/runtime';
 import { createAddonCreateTool, type AddonToolDeps } from './create.js';
 import { createAddonUpdateTool } from './update.js';
+import { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 
 export { createAddonCreateTool } from './create.js';
 export { createAddonUpdateTool } from './update.js';
+export { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 export type { AddonToolDeps } from './create.js';
 
 /**
  * Returns all addon builtin tools.
  *
  * Register selectively per-agent via `tools` in the agent config:
- *   "tools": ["addon_create", "addon_update"]
+ *   "tools": ["addon_create", "addon_update", "addon_run", "addon_list_queries"]
  */
 export function createAddonTools(deps: AddonToolDeps): BuiltinTool[] {
-  return [createAddonCreateTool(deps), createAddonUpdateTool(deps)];
+  return [
+    createAddonCreateTool(deps),
+    createAddonUpdateTool(deps),
+    createAddonRunTool(deps),
+    createAddonListQueriesTool(deps),
+  ];
 }

--- a/apps/server/src/tools/addons/run.test.ts
+++ b/apps/server/src/tools/addons/run.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AddonStorageEngine,
+  DEFAULT_QUOTAS,
+} from '../../addons/storage/engine.js';
+import { createAddonRunTool, createAddonListQueriesTool } from './run.js';
+import type { AddonToolDeps } from './create.js';
+
+const CTX = { agentId: 'a1' };
+
+const STORAGE = {
+  migrations: ['CREATE TABLE deals (id INTEGER PRIMARY KEY, title TEXT);'],
+  agentAccess: 'readwrite',
+  agentQueries: [
+    {
+      name: 'all_deals',
+      description: 'All deals',
+      access: 'read',
+      sql: 'SELECT title FROM deals ORDER BY title',
+    },
+    {
+      name: 'add_deal',
+      description: 'Add a deal',
+      access: 'write',
+      params: { title: 'string' },
+      sql: 'INSERT INTO deals (title) VALUES (:title)',
+    },
+  ],
+};
+
+function addonRecord(over: Record<string, unknown> = {}) {
+  return {
+    addonId: 'crm',
+    name: 'CRM',
+    status: 'enabled',
+    manifest: { storage: STORAGE },
+    ...over,
+  };
+}
+
+function makeDeps(
+  engine: AddonStorageEngine | undefined,
+  addon: Record<string, unknown> | null = addonRecord(),
+): AddonToolDeps {
+  return {
+    addonsDir: '/tmp/x',
+    ...(engine ? { storageEngine: engine } : {}),
+    addonService: {
+      getAddon: async (id: string) =>
+        addon && (addon as { addonId: string }).addonId === id ? addon : null,
+      listAddons: async () => ({ addons: addon ? [addon] : [], total: 1 }),
+    } as never,
+  };
+}
+
+describe('addon_run / addon_list_queries tools', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'addon-run-tool-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+  });
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('addon_run: write then read', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const w = await run.execute(
+      { addon_id: 'crm', query: 'add_deal', params: { title: 'Acme' } },
+      CTX,
+    );
+    expect(w.ok).toBe(true);
+    if (w.ok) expect(JSON.parse(w.content).changes).toBe(1);
+
+    const r = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(JSON.parse(r.content).rows).toEqual([{ title: 'Acme' }]);
+  });
+
+  it('addon_run: surfaces a denied query as an error', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const res = await run.execute(
+      { addon_id: 'crm', query: 'does_not_exist' },
+      CTX,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('QUERY_NOT_FOUND');
+  });
+
+  it('addon_run: not-enabled addon is refused', async () => {
+    const run = createAddonRunTool(
+      makeDeps(engine, addonRecord({ status: 'installed' })),
+    );
+    const res = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('not enabled');
+  });
+
+  it('addon_run: unknown addon is refused', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const res = await run.execute(
+      { addon_id: 'ghost', query: 'all_deals' },
+      CTX,
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it('addon_run: unavailable storage is refused', async () => {
+    const run = createAddonRunTool(makeDeps(undefined));
+    const res = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('not available');
+  });
+
+  it('addon_list_queries: returns the catalog for opted-in addons', async () => {
+    const list = createAddonListQueriesTool(makeDeps(engine));
+    const res = await list.execute({}, CTX);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const catalog = JSON.parse(res.content);
+      expect(catalog).toHaveLength(1);
+      expect(catalog[0].addon_id).toBe('crm');
+      expect(catalog[0].queries.map((q: { name: string }) => q.name)).toEqual([
+        'all_deals',
+        'add_deal',
+      ]);
+    }
+  });
+});

--- a/apps/server/src/tools/addons/run.ts
+++ b/apps/server/src/tools/addons/run.ts
@@ -1,0 +1,141 @@
+/**
+ * addon_run / addon_list_queries
+ *
+ * The agent-facing half of addon storage. Agents never write SQL against an
+ * addon's DB — they discover the named queries an addon exposes
+ * (`addon_list_queries`) and run them by name with typed parameters
+ * (`addon_run`). See packages/shared-types AddonAgentQuerySchema and
+ * ../../addons/storage/agent-queries.ts.
+ */
+import type { BuiltinTool } from '@openaidy/runtime';
+import type { AddonToolDeps } from './create.js';
+import {
+  AddonAgentQueryService,
+  AgentQueryDenied,
+} from '../../addons/storage/agent-queries.js';
+import { addonRunMeta, addonListQueriesMeta } from '../catalog.js';
+
+export function createAddonListQueriesTool(deps: AddonToolDeps): BuiltinTool {
+  return {
+    name: addonListQueriesMeta.name,
+    description: addonListQueriesMeta.description,
+    parameters: {
+      type: 'object',
+      properties: {
+        addon_id: {
+          type: 'string',
+          description:
+            'Optional — restrict the catalog to a single addon by its id.',
+        },
+      },
+    },
+    execute: async (args) => {
+      if (!deps.addonService || !deps.storageEngine) {
+        return { ok: false, error: 'Addon storage is not available' };
+      }
+      const service = new AddonAgentQueryService(deps.storageEngine);
+      const filterId = args.addon_id ? String(args.addon_id) : undefined;
+
+      const { addons } = await deps.addonService.listAddons({
+        status: 'enabled',
+      });
+      const catalog: Array<{
+        addon_id: string;
+        name: string;
+        queries: Array<{
+          name: string;
+          description: string;
+          params: Record<string, string>;
+          access: string;
+        }>;
+      }> = [];
+      for (const addon of addons) {
+        if (filterId && addon.addonId !== filterId) continue;
+        const queries = service.list(addon);
+        if (queries.length === 0) continue;
+        catalog.push({
+          addon_id: addon.addonId,
+          name: addon.name,
+          queries: queries.map((q) => ({
+            name: q.name,
+            description: q.description,
+            params: q.params ?? {},
+            access: q.access ?? 'read',
+          })),
+        });
+      }
+      return { ok: true, content: JSON.stringify(catalog, null, 2) };
+    },
+  };
+}
+
+export function createAddonRunTool(deps: AddonToolDeps): BuiltinTool {
+  return {
+    name: addonRunMeta.name,
+    description: addonRunMeta.description,
+    parameters: {
+      type: 'object',
+      properties: {
+        addon_id: {
+          type: 'string',
+          description: 'Id of the addon whose query to run.',
+        },
+        query: {
+          type: 'string',
+          description:
+            'Name of a query the addon exposes (from addon_list_queries).',
+        },
+        params: {
+          type: 'object',
+          description:
+            "The query's declared parameters, keyed by name. Types are coerced/validated against the declaration.",
+        },
+      },
+      required: ['addon_id', 'query'],
+    },
+    execute: async (args) => {
+      const addonId = String(args.addon_id ?? '');
+      const query = String(args.query ?? '');
+      const params = (args.params ?? {}) as Record<string, unknown>;
+      if (!addonId || !query) {
+        return { ok: false, error: 'addon_id and query are required' };
+      }
+      if (!deps.addonService || !deps.storageEngine) {
+        return { ok: false, error: 'Addon storage is not available' };
+      }
+      const addon = await deps.addonService.getAddon(addonId);
+      if (!addon) {
+        return { ok: false, error: `Addon "${addonId}" not found` };
+      }
+      if (addon.status !== 'enabled') {
+        return { ok: false, error: `Addon "${addonId}" is not enabled` };
+      }
+
+      const service = new AddonAgentQueryService(deps.storageEngine);
+      try {
+        const result = service.run(addon, query, params);
+        if (result.kind === 'rows') {
+          return {
+            ok: true,
+            content: JSON.stringify({ rows: result.rows }, null, 2),
+          };
+        }
+        return {
+          ok: true,
+          content: JSON.stringify({
+            changes: result.changes,
+            lastInsertRowid: Number(result.lastInsertRowid),
+          }),
+        };
+      } catch (err) {
+        if (err instanceof AgentQueryDenied) {
+          return { ok: false, error: `${err.code}: ${err.message}` };
+        }
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : 'Query failed',
+        };
+      }
+    },
+  };
+}

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -220,6 +220,22 @@ export const addonUpdateMeta: ToolMeta = {
     'Keeps the on-disk addon.json and the database record in sync.',
 };
 
+export const addonListQueriesMeta: ToolMeta = {
+  name: 'addon_list_queries',
+  category: 'Addons',
+  description:
+    'Discover the named data queries an addon exposes to agents. Returns, per addon that opted in, its addon_id and a catalog of queries (name, description, typed params, read/write). Call this before addon_run to find the right query — never guess a query name or write raw SQL.',
+};
+
+export const addonRunMeta: ToolMeta = {
+  name: 'addon_run',
+  category: 'Addons',
+  description:
+    "Run a named query an addon exposes to agents (see addon_list_queries) against that addon's private storage. " +
+    'You supply the addon_id, the query name, and its declared parameters — never raw SQL. ' +
+    'Read queries return rows; write queries return the number of changes (and require the addon to grant agent write access).',
+};
+
 // ── UI ────────────────────────────────────────────────────────────────────────
 
 export const presentChoicesMeta: ToolMeta = {
@@ -450,6 +466,8 @@ export const ALL_TOOL_METAS: ToolMeta[] = [
   webFetchMeta,
   addonCreateMeta,
   addonUpdateMeta,
+  addonListQueriesMeta,
+  addonRunMeta,
   presentChoicesMeta,
   memorySaveMeta,
   memorySearchMeta,

--- a/packages/shared-types/src/addon.ts
+++ b/packages/shared-types/src/addon.ts
@@ -146,8 +146,60 @@ export type AddonOpenAidy = z.infer<typeof AddonOpenAidySchema>;
  * no addon UI has run (e.g. an agent writing to the store headless). Each entry
  * must be plain SQL without its own BEGIN/COMMIT; `ATTACH`/`DETACH` are rejected.
  */
+/** Parameter types an agent-facing named query accepts. */
+export const AddonAgentQueryParamTypeSchema = z.enum([
+  'string',
+  'int',
+  'number',
+  'boolean',
+]);
+
+export type AddonAgentQueryParamType = z.infer<
+  typeof AddonAgentQueryParamTypeSchema
+>;
+
+/**
+ * A named, parameterized query the addon exposes to agents. The agent supplies
+ * only the declared parameters (never SQL), so a query can do exactly — and
+ * only — what its author wrote. `access: "write"` queries additionally require
+ * the addon's `agentAccess` to be `"readwrite"`.
+ */
+export const AddonAgentQuerySchema = z.object({
+  name: z
+    .string()
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      'query name must be snake_case (start with a letter)',
+    )
+    .max(64),
+  description: z.string().min(1).max(500),
+  /** Named parameters (`:name` in the SQL) mapped to their type. */
+  params: z
+    .record(
+      z.string().regex(/^[a-z][a-z0-9_]*$/, 'param name must be snake_case'),
+      AddonAgentQueryParamTypeSchema,
+    )
+    .optional(),
+  access: z.enum(['read', 'write']).default('read'),
+  sql: z.string().min(1).max(20_000),
+});
+
+export type AddonAgentQuery = z.infer<typeof AddonAgentQuerySchema>;
+
+/**
+ * Addon storage block — declares the addon's own per-addon SQLite storage.
+ *
+ * - `migrations`: ordered DDL/DML the host applies once, by index, the first
+ *   time the DB is opened (and again for newly added entries after an upgrade),
+ *   so the schema exists even when no addon UI has run.
+ * - `agentAccess` + `agentQueries`: opt the addon's data into agent access via a
+ *   catalog of named, parameterized queries the agent runs by name.
+ */
 export const AddonStorageConfigSchema = z.object({
   migrations: z.array(z.string().min(1).max(20_000)).max(200).optional(),
+  /** The ceiling for agent access: reads only, or reads and writes. */
+  agentAccess: z.enum(['read', 'readwrite']).optional(),
+  agentQueries: z.array(AddonAgentQuerySchema).max(100).optional(),
 });
 
 export type AddonStorageConfig = z.infer<typeof AddonStorageConfigSchema>;


### PR DESCRIPTION
Phase 2 of #374 — the **agent-facing** half of addon storage. **Stacked on #377 (Phase 1); base is `feat/addon-storage-phase1`.** Retarget to `main` once #377 merges. Review #377 first.

## What it adds

Agents never write SQL against an addon's DB. The addon declares a catalog of **named, parameterized queries** in its manifest, and the agent runs them by name with typed params — a declared query does exactly, and only, what its author wrote.

**Manifest** (`storage.*`, in shared-types):
```jsonc
"storage": {
  "migrations": [ ... ],                 // Phase 1
  "agentAccess": "read" | "readwrite",   // ceiling the addon opts into
  "agentQueries": [
    { "name": "stalled_deals", "description": "...",
      "params": { "days": "int" }, "access": "read",
      "sql": "SELECT ... WHERE last_touch < date('now', :days || ' days')" },
    { "name": "log_interaction", "description": "...",
      "params": { "contact_id": "string", "note": "string" }, "access": "write",
      "sql": "INSERT INTO interactions ..." }
  ]
}
```

**Tools** (per-agent selectable):
- `addon_list_queries` — discover the catalog (the catalog *is* the interface; no raw-schema introspection).
- `addon_run(addon_id, query, params)` — run a declared query. Read → rows; write → change count.

## Safety
- **Two-level gate:** a write op runs only if it's tagged `write` **and** the addon set `agentAccess: "readwrite"` (and the user approved storage at install). Reads need `agentAccess` at all.
- **Params, never SQL:** the agent supplies typed parameters that are coerced/validated against the declaration and bound as `:name` — so a declared write can't be turned into arbitrary SQL.
- **Read-only connection:** agent reads run on a `readOnly` SQLite connection, so a query mis-tagged `read` that actually writes is physically rejected ("attempt to write a readonly database").
- Plus the Phase 1 engine guardrails (extensions off, ATTACH/DETACH denied).

## Tests
- 8 service tests: read/write flows, param coercion, `WRITE_NOT_ALLOWED`/`AGENT_ACCESS_DENIED`/`QUERY_NOT_FOUND`/`INVALID_PARAMS`, the read-only safety net, and `list` filtering.
- 6 tool tests: `addon_run` read/write, denied/disabled/unknown/unavailable paths, and `addon_list_queries` catalog output.
- All addon + tools tests pass; server lint + typecheck clean.

## Deferred follow-ups
- Teach `addon_create` to emit `migrations` + `agentQueries` so AI-authored addons ship an agent catalog.
- `sdk-reference.ts` docs for the iframe `storage.*` methods (from Phase 1).
- Optional manifest-validator niceties (duplicate query-name detection).

Part of #374 (does not close it — this completes the originally-scoped feature; the follow-ups above are polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)