### PR TITLE
feat(addons): storage-aware addon_create + SDK reference (#374)

### DIFF
--- a/apps/server/src/addons/sdk-reference.ts
+++ b/apps/server/src/addons/sdk-reference.ts
@@ -19,8 +19,10 @@
 export type SdkParamKind =
   | 'string'
   | 'object'
+  | 'number'
   | 'optional_string'
-  | 'optional_object';
+  | 'optional_object'
+  | 'optional_number';
 
 export type SdkParam = {
   readonly name: string;
@@ -192,6 +194,136 @@ export const SDK_METHODS: readonly SdkMethod[] = [
       'Low-level escape hatch for routes not covered by named methods.',
     exampleJs:
       "sdk.request('GET', '/api/addon-proxy/agents').then(function(r) { console.log(r); });",
+  },
+
+  // ── Storage (per-addon SQLite) ────────────────────────────────────────────
+  // Declare the schema in the manifest under `storage.migrations`. KV needs no
+  // schema. Requires the `storage.read` / `storage.write` permissions.
+  {
+    name: 'storage.kv.get',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'GET',
+    requiredPermission: 'storage.read',
+    params: [{ name: 'key', kind: 'string', description: 'Key to read' }],
+    returns: 'Promise<any>',
+    description: 'Read a JSON value by key (resolves undefined if absent).',
+    exampleJs:
+      "sdk.storage.kv.get('prefs').then(function(v) { console.log(v); });",
+  },
+  {
+    name: 'storage.kv.set',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'PATCH',
+    requiredPermission: 'storage.write',
+    params: [
+      { name: 'key', kind: 'string', description: 'Key to write' },
+      {
+        name: 'value',
+        kind: 'object',
+        description: 'Any JSON-serializable value',
+      },
+    ],
+    returns: 'Promise<{ ok: true }>',
+    description: 'Write a JSON value by key.',
+    exampleJs: "sdk.storage.kv.set('prefs', { theme: 'dark' });",
+  },
+  {
+    name: 'storage.kv.list',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv',
+    httpMethod: 'GET',
+    requiredPermission: 'storage.read',
+    params: [
+      {
+        name: 'prefix',
+        kind: 'optional_string',
+        description: 'Only return keys starting with this prefix',
+      },
+    ],
+    returns: 'Promise<{ key: string; value: any }[]>',
+    description: 'List key/value entries, optionally filtered by key prefix.',
+    exampleJs:
+      "sdk.storage.kv.list('note:').then(function(items) { console.log(items); });",
+  },
+  {
+    name: 'storage.kv.delete',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'DELETE',
+    requiredPermission: 'storage.write',
+    params: [{ name: 'key', kind: 'string', description: 'Key to delete' }],
+    returns: 'Promise<boolean>',
+    description: 'Delete a key; resolves true if a row was removed.',
+    exampleJs: "sdk.storage.kv.delete('prefs');",
+  },
+  {
+    name: 'storage.query',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/query',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.read',
+    params: [
+      { name: 'sql', kind: 'string', description: 'A SELECT statement' },
+      {
+        name: 'params',
+        kind: 'optional_object',
+        description: 'Positional (array) or named (:name → object) parameters',
+      },
+    ],
+    returns: 'Promise<object[]>',
+    description:
+      "Run a read query against the addon's own SQLite file; resolves row objects.",
+    exampleJs:
+      "sdk.storage.query('SELECT * FROM notes WHERE tag = ?', ['work']).then(function(rows) { console.log(rows); });",
+  },
+  {
+    name: 'storage.exec',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/exec',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.write',
+    params: [
+      {
+        name: 'sql',
+        kind: 'string',
+        description: 'An INSERT/UPDATE/DELETE/CREATE statement',
+      },
+      {
+        name: 'params',
+        kind: 'optional_object',
+        description: 'Positional (array) or named (:name → object) parameters',
+      },
+    ],
+    returns: 'Promise<{ changes: number; lastInsertRowid: number }>',
+    description: "Run a write statement against the addon's own SQLite file.",
+    exampleJs:
+      "sdk.storage.exec('INSERT INTO notes (title) VALUES (?)', ['Hello']);",
+  },
+  {
+    name: 'storage.search',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/search',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.read',
+    params: [
+      {
+        name: 'table',
+        kind: 'string',
+        description: 'Name of a declared FTS5 virtual table',
+      },
+      { name: 'match', kind: 'string', description: 'FTS5 MATCH query' },
+      {
+        name: 'limit',
+        kind: 'optional_number',
+        description: 'Max rows (default 50)',
+      },
+    ],
+    returns: 'Promise<object[]>',
+    description: 'Full-text search over a declared FTS5 table.',
+    exampleJs:
+      "sdk.storage.search('notes_fts', 'vite').then(function(rows) { console.log(rows); });",
   },
 ] as const;
 

--- a/apps/server/src/tools/addons/create.test.ts
+++ b/apps/server/src/tools/addons/create.test.ts
@@ -409,6 +409,47 @@ OpenAidy.ready(function(sdk) {
     expect(enableCalled).toBe(true);
     if (result.ok) expect(result.content).toContain('Registered and enabled');
   });
+
+  // ── Storage ────────────────────────────────────────────────────────────────
+
+  it('declares a storage parameter and documents it', () => {
+    const props = (
+      tool.parameters as unknown as { properties: Record<string, unknown> }
+    ).properties;
+    expect(props.storage).toBeDefined();
+    expect(tool.description).toContain('storage.migrations');
+    expect(tool.description).toContain('agentQueries');
+    expect(tool.description).toContain('sdk.storage');
+  });
+
+  it('merges the storage block into addon.json', async () => {
+    const storage = {
+      migrations: ['CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT)'],
+      agentAccess: 'readwrite',
+      agentQueries: [
+        {
+          name: 'add_note',
+          description: 'Add a note',
+          params: { title: 'string' },
+          access: 'write',
+          sql: 'INSERT INTO notes (title) VALUES (:title)',
+        },
+      ],
+    };
+    const result = await tool.execute(
+      {
+        ...VALID_ARGS,
+        permissions: ['storage.read', 'storage.write'],
+        storage,
+      },
+      { agentId: 'agent', sessionId: 'test-session' },
+    );
+    expect(result.ok).toBe(true);
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(addonsDir, 'my-addon', 'addon.json'), 'utf-8'),
+    );
+    expect(manifest.storage).toEqual(storage);
+  });
 });
 
 // ── sdk-reference integration ──────────────────────────────────────────────────
@@ -430,5 +471,15 @@ describe('sdk-reference', () => {
     expect(ref).toContain('listAgents');
     expect(ref).toContain('Agents');
     expect(ref).toContain('Sessions');
+  });
+
+  it('documents the storage SDK methods', async () => {
+    const { SDK_METHODS, renderSdkReference } =
+      await import('../../addons/sdk-reference.js');
+    const names = SDK_METHODS.map((m) => m.name);
+    expect(names).toContain('storage.kv.get');
+    expect(names).toContain('storage.query');
+    expect(names).toContain('storage.search');
+    expect(renderSdkReference()).toContain('Storage');
   });
 });

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -140,6 +140,16 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
       '',
       sdkReference,
       '',
+      'STORAGE (optional — give the addon its own database)',
+      '────────────────────────────────────────────────────',
+      'Pass the `storage` parameter to give the addon a private SQLite database — use it',
+      'for anything that accumulates data (notes, contacts, logs, trackers, caches).',
+      'Declare tables in storage.migrations (applied automatically, so they exist even before',
+      'the UI runs). The UI reads/writes via sdk.storage.* — add "storage.read"/"storage.write"',
+      'to permissions for that. To let AGENTS work with the data, set storage.agentAccess',
+      '("read" or "readwrite") and declare storage.agentQueries: named, parameterized queries',
+      'the agent runs by name via the addon_run tool (agents never write raw SQL).',
+      '',
       'AGENT IDS',
       '─────────',
       'NEVER hardcode an agent ID. Agent IDs are user-defined and vary between',
@@ -224,6 +234,35 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
             'Paths must be relative with no ".." segments. Do not include "addon.json".',
           additionalProperties: { type: 'string' },
         },
+        storage: {
+          type: 'object',
+          description:
+            'Optional. Gives the addon its own private SQLite database. ' +
+            'Declare the schema in `migrations` (ordered SQL DDL, applied automatically — so tables exist even before the UI runs). ' +
+            "The UI reads/writes it via the storage SDK (sdk.storage.kv.*, sdk.storage.query/exec/search) — add 'storage.read' and/or 'storage.write' to `permissions` for that. " +
+            "To let AGENTS use the data, set `agentAccess` ('read' or 'readwrite') and declare `agentQueries`: named, parameterized queries the agent runs by name (agents never write raw SQL). " +
+            'Example: { "migrations": ["CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT, created_at TEXT DEFAULT (datetime(\'now\')))"], "agentAccess": "readwrite", "agentQueries": [{ "name": "add_note", "description": "Add a note", "params": { "title": "string" }, "access": "write", "sql": "INSERT INTO notes (title) VALUES (:title)" }, { "name": "recent_notes", "description": "Most recent notes", "access": "read", "sql": "SELECT title FROM notes ORDER BY created_at DESC LIMIT 20" }] }',
+          properties: {
+            migrations: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Ordered SQL DDL statements applied once, by index (CREATE TABLE / INDEX / VIRTUAL TABLE ... USING fts5). No BEGIN/COMMIT; no ATTACH/DETACH.',
+            },
+            agentAccess: {
+              type: 'string',
+              enum: ['read', 'readwrite'],
+              description:
+                "Opt the addon's data into agent access. 'read' allows read queries; 'readwrite' also allows write queries.",
+            },
+            agentQueries: {
+              type: 'array',
+              description:
+                'Named, parameterized queries agents can run via addon_run. Each: { name, description, params?: {name: "string"|"int"|"number"|"boolean"}, access: "read"|"write", sql (use :name for params) }.',
+              items: { type: 'object' },
+            },
+          },
+        },
       },
       required: ['id', 'name', 'description', 'permissions', 'files'],
     },
@@ -241,6 +280,10 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
       const externalImageDomains = Array.isArray(args['externalImageDomains'])
         ? (args['externalImageDomains'] as string[])
         : undefined;
+      const storage =
+        args['storage'] && typeof args['storage'] === 'object'
+          ? (args['storage'] as Record<string, unknown>)
+          : undefined;
       const filesArg = args['files'];
 
       // ── Input validation ────────────────────────────────────────────────
@@ -429,6 +472,20 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
           }
           await writeFile(join(addonDir, filePath), content, 'utf-8');
         }
+      }
+
+      // Merge the declared storage block into the scaffolded addon.json so the
+      // on-disk manifest reflects it (and the DB registration below picks it up).
+      // The full storage schema is validated by installAddon's manifest validator.
+      if (storage) {
+        const { readFileSync, writeFileSync } = await import('node:fs');
+        const manifestPath = join(addonDir, 'addon.json');
+        const m = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<
+          string,
+          unknown
+        >;
+        m.storage = storage;
+        writeFileSync(manifestPath, JSON.stringify(m, null, 2), 'utf-8');
       }
 
       // ── Step 2: register + enable via AddonService (in-process) ──────────


### PR DESCRIPTION
The AI-authoring integration for addon storage — item #2 from the "what's missing" list. **Stacked on #379 (Phase 2); base is `feat/addon-storage-phase2`.** Retarget to `main` after #377 → #379 merge.

## Why

Phases 1 & 2 gave addons storage and gave agents a way to query it — but `addon_create` didn't know about any of it, so an agent asked to "build a CRM addon that stores contacts" wouldn't produce a storage-backed addon. This closes that gap.

## What

- **`sdk-reference.ts`** — documents the iframe storage SDK (`storage.kv.get/set/list/delete`, `storage.query/exec/search`) with required permissions and examples. Because `addon_create` renders `SDK_METHODS` into its description and its per-permission usage hints, the authoring agent now sees storage automatically.
- **`addon_create`** — new optional **`storage`** parameter (`migrations`, `agentAccess`, `agentQueries`) merged into the scaffolded `addon.json` before registration, plus a STORAGE section in the tool description explaining the manifest block, the iframe SDK, and the agent named-query catalog. The full storage schema is validated by the existing manifest validator at install.

Now an agent can, in one `addon_create` call, ship an addon with its own schema, a data-backed UI, and an agent query catalog.

## Tests
- create-tool: storage block merged into `addon.json`, and description/schema coverage.
- sdk-reference: storage methods present + rendered.
- All 275 addon + addon-tool tests pass; server lint + typecheck clean.

Part of #374. With this, #374 is functionally complete end-to-end (engine → iframe SDK → agent catalog → AI authoring). Remaining are minor niceties (duplicate query-name validation, `closeAll()` WAL checkpoint on shutdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)