### PR TITLE
chore(addons): storage polish + release bump to 0.3.0 (#374)

### DIFF
--- a/apps/server/src/addons/manifest-validator.test.ts
+++ b/apps/server/src/addons/manifest-validator.test.ts
@@ -292,4 +292,58 @@ describe('AddonManifestSchema', () => {
       );
     }
   });
+
+  describe('storage validation', () => {
+    const v = createManifestValidator({ openAidyVersion: '1.0.0' });
+    const base = {
+      id: 'store-addon',
+      name: 'Store',
+      version: '1.0.0',
+      description: 'x',
+      openaidy: { minVersion: '0.1.0' },
+      entry: 'app/index.html',
+      permissions: [] as string[],
+    };
+    const withQueries = (
+      agentQueries: Array<{ name: string; sql: string }>,
+    ) => ({
+      ...base,
+      storage: {
+        agentQueries: agentQueries.map((q) => ({
+          ...q,
+          description: 'q',
+          access: 'read' as const,
+        })),
+      },
+    });
+
+    it('rejects duplicate agent query names', () => {
+      const result = v.validate(
+        withQueries([
+          { name: 'dup', sql: 'SELECT 1' },
+          { name: 'dup', sql: 'SELECT 2' },
+        ]),
+        [],
+      );
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some(
+            (e: ValidationError) => e.code === 'DUPLICATE_QUERY_NAME',
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('accepts unique agent query names', () => {
+      const result = v.validate(
+        withQueries([
+          { name: 'a', sql: 'SELECT 1' },
+          { name: 'b', sql: 'SELECT 2' },
+        ]),
+        [],
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
 });

--- a/apps/server/src/addons/manifest-validator.ts
+++ b/apps/server/src/addons/manifest-validator.ts
@@ -372,6 +372,34 @@ function validateEntry(manifest: AddonManifest): ValidationError[] {
 }
 
 /**
+ * Validate the storage block. The Zod schema already checks structure; here we
+ * add the cross-field check it can't: agent query names must be unique (an
+ * addon_run call resolves a query by name, so duplicates would silently shadow).
+ */
+function validateStorage(manifest: AddonManifest): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const queries = (
+    manifest as { storage?: { agentQueries?: Array<{ name: string }> } }
+  ).storage?.agentQueries;
+  if (!queries) return errors;
+
+  const seen = new Set<string>();
+  for (const q of queries) {
+    if (seen.has(q.name)) {
+      errors.push(
+        createValidationError(
+          'storage.agentQueries',
+          `Duplicate agent query name: "${q.name}"`,
+          'DUPLICATE_QUERY_NAME',
+        ),
+      );
+    }
+    seen.add(q.name);
+  }
+  return errors;
+}
+
+/**
  * Validate dependencies
  */
 function validateDependencies(manifest: AddonManifest): ValidationError[] {
@@ -444,6 +472,7 @@ export class ManifestValidator {
     allErrors.push(...validateUIConfig(typedManifest));
     allErrors.push(...validateEntry(typedManifest));
     allErrors.push(...validateDependencies(typedManifest));
+    allErrors.push(...validateStorage(typedManifest));
 
     if (allErrors.length > 0) {
       return {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -919,6 +919,8 @@ export async function buildApp() {
     if (dbAdapter) {
       await dbAdapter.close();
     }
+    // Close per-addon SQLite connections (checkpoints WAL) on shutdown.
+    addonStorageEngine.closeAll();
   });
 
   return app;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Final polish for the addon-storage feature + the release bump. **Top of the stack — base is `feat/addon-storage-authoring`.** Retarget to `main` after the rest of the stack merges.

## Changes
- **Duplicate agentQuery-name validation** — the manifest validator now rejects a `storage.agentQueries` list with duplicate names (a cross-field check Zod can't express; `addon_run` resolves a query by name, so duplicates would silently shadow). +2 tests.
- **Graceful shutdown** — `AddonStorageEngine.closeAll()` runs in the server's `onClose` hook, so per-addon WAL files are checkpointed on shutdown.
- **Release bump `0.2.4 → 0.3.0`** — a minor bump for the whole addon-storage feature (per-addon SQLite engine, iframe storage SDK, agent named-query catalog, storage-aware `addon_create`).

Skipped, deliberately: permission-approval UI copy for `storage.*` — the raw `storage.read` / `storage.write` strings shown at enable time are already self-explanatory, and touching the web approval UI isn't worth it here.

Server lint + typecheck clean; all addon tests pass.

## Full stack (merge in order)
1. #377 Phase 1 (engine + iframe SDK)
2. #379 Phase 2 (agent catalog)
3. #380 authoring (storage-aware addon_create)
4. **this** — polish + bump to 0.3.0

After all four merge to `main`, tag **`v0.3.0`** to publish `@openaidy/app@0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)