### PR TITLE
chore(addons): land the rest of the addon-storage stack on main (#374)

### DIFF
--- a/apps/server/src/addons/manifest-validator.test.ts
+++ b/apps/server/src/addons/manifest-validator.test.ts
@@ -292,4 +292,58 @@ describe('AddonManifestSchema', () => {
       );
     }
   });
+
+  describe('storage validation', () => {
+    const v = createManifestValidator({ openAidyVersion: '1.0.0' });
+    const base = {
+      id: 'store-addon',
+      name: 'Store',
+      version: '1.0.0',
+      description: 'x',
+      openaidy: { minVersion: '0.1.0' },
+      entry: 'app/index.html',
+      permissions: [] as string[],
+    };
+    const withQueries = (
+      agentQueries: Array<{ name: string; sql: string }>,
+    ) => ({
+      ...base,
+      storage: {
+        agentQueries: agentQueries.map((q) => ({
+          ...q,
+          description: 'q',
+          access: 'read' as const,
+        })),
+      },
+    });
+
+    it('rejects duplicate agent query names', () => {
+      const result = v.validate(
+        withQueries([
+          { name: 'dup', sql: 'SELECT 1' },
+          { name: 'dup', sql: 'SELECT 2' },
+        ]),
+        [],
+      );
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some(
+            (e: ValidationError) => e.code === 'DUPLICATE_QUERY_NAME',
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('accepts unique agent query names', () => {
+      const result = v.validate(
+        withQueries([
+          { name: 'a', sql: 'SELECT 1' },
+          { name: 'b', sql: 'SELECT 2' },
+        ]),
+        [],
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
 });

--- a/apps/server/src/addons/manifest-validator.ts
+++ b/apps/server/src/addons/manifest-validator.ts
@@ -372,6 +372,34 @@ function validateEntry(manifest: AddonManifest): ValidationError[] {
 }
 
 /**
+ * Validate the storage block. The Zod schema already checks structure; here we
+ * add the cross-field check it can't: agent query names must be unique (an
+ * addon_run call resolves a query by name, so duplicates would silently shadow).
+ */
+function validateStorage(manifest: AddonManifest): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const queries = (
+    manifest as { storage?: { agentQueries?: Array<{ name: string }> } }
+  ).storage?.agentQueries;
+  if (!queries) return errors;
+
+  const seen = new Set<string>();
+  for (const q of queries) {
+    if (seen.has(q.name)) {
+      errors.push(
+        createValidationError(
+          'storage.agentQueries',
+          `Duplicate agent query name: "${q.name}"`,
+          'DUPLICATE_QUERY_NAME',
+        ),
+      );
+    }
+    seen.add(q.name);
+  }
+  return errors;
+}
+
+/**
  * Validate dependencies
  */
 function validateDependencies(manifest: AddonManifest): ValidationError[] {
@@ -444,6 +472,7 @@ export class ManifestValidator {
     allErrors.push(...validateUIConfig(typedManifest));
     allErrors.push(...validateEntry(typedManifest));
     allErrors.push(...validateDependencies(typedManifest));
+    allErrors.push(...validateStorage(typedManifest));
 
     if (allErrors.length > 0) {
       return {

--- a/apps/server/src/addons/sdk-reference.ts
+++ b/apps/server/src/addons/sdk-reference.ts
@@ -19,8 +19,10 @@
 export type SdkParamKind =
   | 'string'
   | 'object'
+  | 'number'
   | 'optional_string'
-  | 'optional_object';
+  | 'optional_object'
+  | 'optional_number';
 
 export type SdkParam = {
   readonly name: string;
@@ -192,6 +194,136 @@ export const SDK_METHODS: readonly SdkMethod[] = [
       'Low-level escape hatch for routes not covered by named methods.',
     exampleJs:
       "sdk.request('GET', '/api/addon-proxy/agents').then(function(r) { console.log(r); });",
+  },
+
+  // ── Storage (per-addon SQLite) ────────────────────────────────────────────
+  // Declare the schema in the manifest under `storage.migrations`. KV needs no
+  // schema. Requires the `storage.read` / `storage.write` permissions.
+  {
+    name: 'storage.kv.get',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'GET',
+    requiredPermission: 'storage.read',
+    params: [{ name: 'key', kind: 'string', description: 'Key to read' }],
+    returns: 'Promise<any>',
+    description: 'Read a JSON value by key (resolves undefined if absent).',
+    exampleJs:
+      "sdk.storage.kv.get('prefs').then(function(v) { console.log(v); });",
+  },
+  {
+    name: 'storage.kv.set',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'PATCH',
+    requiredPermission: 'storage.write',
+    params: [
+      { name: 'key', kind: 'string', description: 'Key to write' },
+      {
+        name: 'value',
+        kind: 'object',
+        description: 'Any JSON-serializable value',
+      },
+    ],
+    returns: 'Promise<{ ok: true }>',
+    description: 'Write a JSON value by key.',
+    exampleJs: "sdk.storage.kv.set('prefs', { theme: 'dark' });",
+  },
+  {
+    name: 'storage.kv.list',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv',
+    httpMethod: 'GET',
+    requiredPermission: 'storage.read',
+    params: [
+      {
+        name: 'prefix',
+        kind: 'optional_string',
+        description: 'Only return keys starting with this prefix',
+      },
+    ],
+    returns: 'Promise<{ key: string; value: any }[]>',
+    description: 'List key/value entries, optionally filtered by key prefix.',
+    exampleJs:
+      "sdk.storage.kv.list('note:').then(function(items) { console.log(items); });",
+  },
+  {
+    name: 'storage.kv.delete',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/kv/:key',
+    httpMethod: 'DELETE',
+    requiredPermission: 'storage.write',
+    params: [{ name: 'key', kind: 'string', description: 'Key to delete' }],
+    returns: 'Promise<boolean>',
+    description: 'Delete a key; resolves true if a row was removed.',
+    exampleJs: "sdk.storage.kv.delete('prefs');",
+  },
+  {
+    name: 'storage.query',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/query',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.read',
+    params: [
+      { name: 'sql', kind: 'string', description: 'A SELECT statement' },
+      {
+        name: 'params',
+        kind: 'optional_object',
+        description: 'Positional (array) or named (:name → object) parameters',
+      },
+    ],
+    returns: 'Promise<object[]>',
+    description:
+      "Run a read query against the addon's own SQLite file; resolves row objects.",
+    exampleJs:
+      "sdk.storage.query('SELECT * FROM notes WHERE tag = ?', ['work']).then(function(rows) { console.log(rows); });",
+  },
+  {
+    name: 'storage.exec',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/exec',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.write',
+    params: [
+      {
+        name: 'sql',
+        kind: 'string',
+        description: 'An INSERT/UPDATE/DELETE/CREATE statement',
+      },
+      {
+        name: 'params',
+        kind: 'optional_object',
+        description: 'Positional (array) or named (:name → object) parameters',
+      },
+    ],
+    returns: 'Promise<{ changes: number; lastInsertRowid: number }>',
+    description: "Run a write statement against the addon's own SQLite file.",
+    exampleJs:
+      "sdk.storage.exec('INSERT INTO notes (title) VALUES (?)', ['Hello']);",
+  },
+  {
+    name: 'storage.search',
+    category: 'Storage',
+    proxyPath: '/api/addon-proxy/storage/search',
+    httpMethod: 'POST',
+    requiredPermission: 'storage.read',
+    params: [
+      {
+        name: 'table',
+        kind: 'string',
+        description: 'Name of a declared FTS5 virtual table',
+      },
+      { name: 'match', kind: 'string', description: 'FTS5 MATCH query' },
+      {
+        name: 'limit',
+        kind: 'optional_number',
+        description: 'Max rows (default 50)',
+      },
+    ],
+    returns: 'Promise<object[]>',
+    description: 'Full-text search over a declared FTS5 table.',
+    exampleJs:
+      "sdk.storage.search('notes_fts', 'vite').then(function(rows) { console.log(rows); });",
   },
 ] as const;
 

--- a/apps/server/src/addons/storage/agent-queries.test.ts
+++ b/apps/server/src/addons/storage/agent-queries.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AddonStorageEngine, DEFAULT_QUOTAS } from './engine.js';
+import {
+  AddonAgentQueryService,
+  AgentQueryDenied,
+  type AgentQueryResult,
+} from './agent-queries.js';
+
+const MIGRATIONS = ['CREATE TABLE deals (id INTEGER PRIMARY KEY, title TEXT);'];
+
+const QUERIES = [
+  {
+    name: 'all_deals',
+    description: 'All deal titles',
+    access: 'read' as const,
+    sql: 'SELECT title FROM deals ORDER BY title',
+  },
+  {
+    name: 'by_prefix',
+    description: 'Deals whose title starts with a prefix',
+    access: 'read' as const,
+    params: { p: 'string' as const },
+    sql: "SELECT title FROM deals WHERE title LIKE :p || '%' ORDER BY title",
+  },
+  {
+    name: 'add_deal',
+    description: 'Add a deal',
+    access: 'write' as const,
+    params: { title: 'string' as const },
+    sql: 'INSERT INTO deals (title) VALUES (:title)',
+  },
+];
+
+function addon(addonId: string, storage: unknown) {
+  return { addonId, manifest: { storage } };
+}
+
+const RW = {
+  migrations: MIGRATIONS,
+  agentAccess: 'readwrite',
+  agentQueries: QUERIES,
+};
+const RO = {
+  migrations: MIGRATIONS,
+  agentAccess: 'read',
+  agentQueries: QUERIES,
+};
+
+describe('AddonAgentQueryService', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+  let svc: AddonAgentQueryService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agent-queries-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+    svc = new AddonAgentQueryService(engine);
+  });
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('runs write then read named queries', () => {
+    const a = addon('crm', RW);
+    const w = svc.run(a, 'add_deal', { title: 'Acme' });
+    expect(w).toMatchObject({ kind: 'write', changes: 1 } as AgentQueryResult);
+    svc.run(a, 'add_deal', { title: 'Beta' });
+    expect(svc.run(a, 'all_deals')).toEqual({
+      kind: 'rows',
+      rows: [{ title: 'Acme' }, { title: 'Beta' }],
+    });
+  });
+
+  it('binds and coerces declared params', () => {
+    const a = addon('crm', RW);
+    svc.run(a, 'add_deal', { title: 'Acme' });
+    svc.run(a, 'add_deal', { title: 'Zeta' });
+    const r = svc.run(a, 'by_prefix', { p: 'Ac' });
+    expect(r).toEqual({ kind: 'rows', rows: [{ title: 'Acme' }] });
+  });
+
+  it('rejects a missing required param', () => {
+    try {
+      svc.run(addon('crm', RW), 'add_deal', {});
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(AgentQueryDenied);
+      expect((e as AgentQueryDenied).code).toBe('INVALID_PARAMS');
+    }
+  });
+
+  it('denies a write query when the addon grants agents read-only', () => {
+    try {
+      svc.run(addon('crm', RO), 'add_deal', { title: 'x' });
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('WRITE_NOT_ALLOWED');
+    }
+  });
+
+  it('a read query cannot be tricked into writing (read-only connection)', () => {
+    const sneaky = {
+      migrations: MIGRATIONS,
+      agentAccess: 'read',
+      agentQueries: [
+        {
+          name: 'sneaky',
+          description: 'looks like a read',
+          access: 'read' as const,
+          sql: "INSERT INTO deals (title) VALUES ('x')",
+        },
+      ],
+    };
+    expect(() => svc.run(addon('crm', sneaky), 'sneaky')).toThrow(/readonly/i);
+  });
+
+  it('denies when the addon did not opt into agent access', () => {
+    const noAccess = { migrations: MIGRATIONS, agentQueries: QUERIES };
+    try {
+      svc.run(addon('crm', noAccess), 'all_deals');
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('AGENT_ACCESS_DENIED');
+    }
+  });
+
+  it('reports an unknown query', () => {
+    try {
+      svc.run(addon('crm', RW), 'nope');
+      expect.unreachable();
+    } catch (e) {
+      expect((e as AgentQueryDenied).code).toBe('QUERY_NOT_FOUND');
+    }
+  });
+
+  it('list: shows writes only under readwrite; empty without opt-in', () => {
+    expect(svc.list(addon('c', RW)).map((q) => q.name)).toContain('add_deal');
+    expect(svc.list(addon('c', RO)).map((q) => q.name)).not.toContain(
+      'add_deal',
+    );
+    expect(svc.list(addon('c', RO)).map((q) => q.name)).toContain('all_deals');
+    expect(svc.list(addon('c', { migrations: [] }))).toEqual([]);
+  });
+});

--- a/apps/server/src/addons/storage/agent-queries.ts
+++ b/apps/server/src/addons/storage/agent-queries.ts
@@ -1,0 +1,173 @@
+/**
+ * Agent-facing addon storage — the named-query catalog.
+ *
+ * Agents never write SQL against an addon's DB. Instead the addon declares a
+ * catalog of named, parameterized queries in its manifest
+ * (`storage.agentQueries`), and the agent runs them by name with typed
+ * parameters. A declared query can do exactly — and only — what its author
+ * wrote, so writes are as safe as reads (the agent supplies values, not
+ * statements). Read queries run on a read-only connection; writes go through
+ * `exec` and require the addon to grant `agentAccess: "readwrite"`.
+ */
+import type {
+  AddonAgentQuery,
+  AddonAgentQueryParamType,
+  AddonStorageConfig,
+} from '@openaidy/shared-types';
+import type { AddonStorageEngine } from './engine';
+
+export type AgentQueryErrorCode =
+  | 'AGENT_ACCESS_DENIED'
+  | 'QUERY_NOT_FOUND'
+  | 'WRITE_NOT_ALLOWED'
+  | 'INVALID_PARAMS';
+
+export class AgentQueryDenied extends Error {
+  constructor(
+    message: string,
+    readonly code: AgentQueryErrorCode,
+  ) {
+    super(message);
+    this.name = 'AgentQueryDenied';
+  }
+}
+
+/** Minimal shape of an addon record this service needs. */
+export interface AddonForQueries {
+  addonId: string;
+  manifest: unknown;
+}
+
+export type AgentQueryResult =
+  | { kind: 'rows'; rows: unknown[] }
+  | { kind: 'write'; changes: number; lastInsertRowid: number | bigint };
+
+function getStorage(manifest: unknown): AddonStorageConfig | undefined {
+  return (manifest as { storage?: AddonStorageConfig } | null)?.storage;
+}
+
+function coerceParam(
+  name: string,
+  type: AddonAgentQueryParamType,
+  value: unknown,
+): string | number {
+  if (value === undefined || value === null) {
+    throw new AgentQueryDenied(
+      `Missing required parameter: ${name}`,
+      'INVALID_PARAMS',
+    );
+  }
+  switch (type) {
+    case 'string':
+      if (typeof value !== 'string') {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be a string`,
+          'INVALID_PARAMS',
+        );
+      }
+      return value;
+    case 'int': {
+      const n = Number(value);
+      if (!Number.isInteger(n)) {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be an integer`,
+          'INVALID_PARAMS',
+        );
+      }
+      return n;
+    }
+    case 'number': {
+      const n = Number(value);
+      if (!Number.isFinite(n)) {
+        throw new AgentQueryDenied(
+          `Parameter "${name}" must be a number`,
+          'INVALID_PARAMS',
+        );
+      }
+      return n;
+    }
+    case 'boolean':
+      // SQLite has no boolean — store as 0/1.
+      return value ? 1 : 0;
+  }
+}
+
+export class AddonAgentQueryService {
+  constructor(private readonly engine: AddonStorageEngine) {}
+
+  /**
+   * The queries an agent may run against this addon: empty unless the addon
+   * opted in via `agentAccess`, and write queries are hidden unless it granted
+   * `readwrite`.
+   */
+  list(addon: AddonForQueries): AddonAgentQuery[] {
+    const storage = getStorage(addon.manifest);
+    if (!storage?.agentAccess || !storage.agentQueries) return [];
+    return storage.agentQueries.filter(
+      (q) =>
+        (q.access ?? 'read') === 'read' || storage.agentAccess === 'readwrite',
+    );
+  }
+
+  /** Run a declared query by name with the supplied parameters. */
+  run(
+    addon: AddonForQueries,
+    queryName: string,
+    params: Record<string, unknown> = {},
+  ): AgentQueryResult {
+    const storage = getStorage(addon.manifest);
+    if (!storage?.agentAccess) {
+      throw new AgentQueryDenied(
+        'This addon does not expose its storage to agents',
+        'AGENT_ACCESS_DENIED',
+      );
+    }
+    const query = storage.agentQueries?.find((q) => q.name === queryName);
+    if (!query) {
+      throw new AgentQueryDenied(
+        `Addon "${addon.addonId}" has no agent query named "${queryName}"`,
+        'QUERY_NOT_FOUND',
+      );
+    }
+    const access = query.access ?? 'read';
+    if (access === 'write' && storage.agentAccess !== 'readwrite') {
+      throw new AgentQueryDenied(
+        `Query "${queryName}" writes, but this addon only grants agents read access`,
+        'WRITE_NOT_ALLOWED',
+      );
+    }
+
+    const bound = this.buildParams(query, params);
+    const migrations = storage.migrations ?? [];
+
+    if (access === 'read') {
+      return {
+        kind: 'rows',
+        rows: this.engine.queryReadOnly(
+          addon.addonId,
+          migrations,
+          query.sql,
+          bound,
+        ),
+      };
+    }
+    const r = this.engine.exec(addon.addonId, migrations, query.sql, bound);
+    return {
+      kind: 'write',
+      changes: r.changes,
+      lastInsertRowid: r.lastInsertRowid,
+    };
+  }
+
+  private buildParams(
+    query: AddonAgentQuery,
+    params: Record<string, unknown>,
+  ): Record<string, string | number> {
+    const declared = query.params ?? {};
+    const out: Record<string, string | number> = {};
+    for (const [name, type] of Object.entries(declared)) {
+      out[name] = coerceParam(name, type, params?.[name]);
+    }
+    return out;
+  }
+}

--- a/apps/server/src/addons/storage/engine.ts
+++ b/apps/server/src/addons/storage/engine.ts
@@ -68,6 +68,8 @@ export class AddonStorageError extends Error {
 
 interface Handle {
   db: DatabaseSync;
+  /** Lazily-opened read-only connection (used for agent read queries). */
+  ro?: DatabaseSync;
   lastUsed: number;
 }
 
@@ -208,16 +210,7 @@ export class AddonStorageEngine {
 
   // ── Raw SQL (iframe SDK) ────────────────────────────────────────────────────
 
-  /** Run a read query and return rows (capped at the row quota). */
-  query(
-    addonId: string,
-    migrations: readonly string[],
-    sql: string,
-    params?: StorageParams,
-  ): unknown[] {
-    this.assertSafe(sql);
-    const db = this.connect(addonId, migrations);
-    const stmt = db.prepare(sql);
+  private iterateCapped(stmt: StatementSync, params: StorageParams): unknown[] {
     const out: unknown[] = [];
     const iter =
       params === undefined
@@ -231,6 +224,38 @@ export class AddonStorageEngine {
       if (out.length >= this.quotas.maxRows) break;
     }
     return out;
+  }
+
+  /** Run a read query and return rows (capped at the row quota). */
+  query(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): unknown[] {
+    this.assertSafe(sql);
+    const db = this.connect(addonId, migrations);
+    return this.iterateCapped(db.prepare(sql), params);
+  }
+
+  /**
+   * Run a read query on a read-only connection. Used for agent read queries so
+   * a mis-tagged write can't mutate data — the connection physically rejects
+   * writes ("attempt to write a readonly database"). Migrations are applied via
+   * the read/write connection first so the schema is present.
+   */
+  queryReadOnly(
+    addonId: string,
+    migrations: readonly string[],
+    sql: string,
+    params?: StorageParams,
+  ): unknown[] {
+    this.assertSafe(sql);
+    // Ensure the file exists + migrations are applied (read/write connection).
+    this.connect(addonId, migrations);
+    const h = this.handles.get(addonId)!;
+    h.ro ??= new DatabaseSync(this.dbPath(addonId), { readOnly: true });
+    return this.iterateCapped(h.ro.prepare(sql), params);
   }
 
   /** Run a write statement and return {changes, lastInsertRowid}. */
@@ -342,14 +367,16 @@ export class AddonStorageEngine {
     }
   }
 
-  /** Close and forget an addon's connection (e.g. on disable or upgrade). */
+  /** Close and forget an addon's connection(s) (e.g. on disable or upgrade). */
   close(addonId: string): void {
     const h = this.handles.get(addonId);
     if (!h) return;
-    try {
-      h.db.close();
-    } catch {
-      /* ignore */
+    for (const conn of [h.ro, h.db]) {
+      try {
+        conn?.close();
+      } catch {
+        /* ignore */
+      }
     }
     this.handles.delete(addonId);
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -919,6 +919,8 @@ export async function buildApp() {
     if (dbAdapter) {
       await dbAdapter.close();
     }
+    // Close per-addon SQLite connections (checkpoints WAL) on shutdown.
+    addonStorageEngine.closeAll();
   });
 
   return app;

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -265,6 +265,7 @@ export async function buildApp() {
     skills: { registry: skillRegistry },
     addons: {
       addonsDir: path.join(env.OPENAIDY_HOME, 'addons'),
+      storageEngine: addonStorageEngine,
       ...(addonService ? { addonService } : {}),
     },
     agents: {

--- a/apps/server/src/tools/addons/create.test.ts
+++ b/apps/server/src/tools/addons/create.test.ts
@@ -409,6 +409,47 @@ OpenAidy.ready(function(sdk) {
     expect(enableCalled).toBe(true);
     if (result.ok) expect(result.content).toContain('Registered and enabled');
   });
+
+  // ── Storage ────────────────────────────────────────────────────────────────
+
+  it('declares a storage parameter and documents it', () => {
+    const props = (
+      tool.parameters as unknown as { properties: Record<string, unknown> }
+    ).properties;
+    expect(props.storage).toBeDefined();
+    expect(tool.description).toContain('storage.migrations');
+    expect(tool.description).toContain('agentQueries');
+    expect(tool.description).toContain('sdk.storage');
+  });
+
+  it('merges the storage block into addon.json', async () => {
+    const storage = {
+      migrations: ['CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT)'],
+      agentAccess: 'readwrite',
+      agentQueries: [
+        {
+          name: 'add_note',
+          description: 'Add a note',
+          params: { title: 'string' },
+          access: 'write',
+          sql: 'INSERT INTO notes (title) VALUES (:title)',
+        },
+      ],
+    };
+    const result = await tool.execute(
+      {
+        ...VALID_ARGS,
+        permissions: ['storage.read', 'storage.write'],
+        storage,
+      },
+      { agentId: 'agent', sessionId: 'test-session' },
+    );
+    expect(result.ok).toBe(true);
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(addonsDir, 'my-addon', 'addon.json'), 'utf-8'),
+    );
+    expect(manifest.storage).toEqual(storage);
+  });
 });
 
 // ── sdk-reference integration ──────────────────────────────────────────────────
@@ -430,5 +471,15 @@ describe('sdk-reference', () => {
     expect(ref).toContain('listAgents');
     expect(ref).toContain('Agents');
     expect(ref).toContain('Sessions');
+  });
+
+  it('documents the storage SDK methods', async () => {
+    const { SDK_METHODS, renderSdkReference } =
+      await import('../../addons/sdk-reference.js');
+    const names = SDK_METHODS.map((m) => m.name);
+    expect(names).toContain('storage.kv.get');
+    expect(names).toContain('storage.query');
+    expect(names).toContain('storage.search');
+    expect(renderSdkReference()).toContain('Storage');
   });
 });

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -140,6 +140,16 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
       '',
       sdkReference,
       '',
+      'STORAGE (optional — give the addon its own database)',
+      '────────────────────────────────────────────────────',
+      'Pass the `storage` parameter to give the addon a private SQLite database — use it',
+      'for anything that accumulates data (notes, contacts, logs, trackers, caches).',
+      'Declare tables in storage.migrations (applied automatically, so they exist even before',
+      'the UI runs). The UI reads/writes via sdk.storage.* — add "storage.read"/"storage.write"',
+      'to permissions for that. To let AGENTS work with the data, set storage.agentAccess',
+      '("read" or "readwrite") and declare storage.agentQueries: named, parameterized queries',
+      'the agent runs by name via the addon_run tool (agents never write raw SQL).',
+      '',
       'AGENT IDS',
       '─────────',
       'NEVER hardcode an agent ID. Agent IDs are user-defined and vary between',
@@ -224,6 +234,35 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
             'Paths must be relative with no ".." segments. Do not include "addon.json".',
           additionalProperties: { type: 'string' },
         },
+        storage: {
+          type: 'object',
+          description:
+            'Optional. Gives the addon its own private SQLite database. ' +
+            'Declare the schema in `migrations` (ordered SQL DDL, applied automatically — so tables exist even before the UI runs). ' +
+            "The UI reads/writes it via the storage SDK (sdk.storage.kv.*, sdk.storage.query/exec/search) — add 'storage.read' and/or 'storage.write' to `permissions` for that. " +
+            "To let AGENTS use the data, set `agentAccess` ('read' or 'readwrite') and declare `agentQueries`: named, parameterized queries the agent runs by name (agents never write raw SQL). " +
+            'Example: { "migrations": ["CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT, created_at TEXT DEFAULT (datetime(\'now\')))"], "agentAccess": "readwrite", "agentQueries": [{ "name": "add_note", "description": "Add a note", "params": { "title": "string" }, "access": "write", "sql": "INSERT INTO notes (title) VALUES (:title)" }, { "name": "recent_notes", "description": "Most recent notes", "access": "read", "sql": "SELECT title FROM notes ORDER BY created_at DESC LIMIT 20" }] }',
+          properties: {
+            migrations: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Ordered SQL DDL statements applied once, by index (CREATE TABLE / INDEX / VIRTUAL TABLE ... USING fts5). No BEGIN/COMMIT; no ATTACH/DETACH.',
+            },
+            agentAccess: {
+              type: 'string',
+              enum: ['read', 'readwrite'],
+              description:
+                "Opt the addon's data into agent access. 'read' allows read queries; 'readwrite' also allows write queries.",
+            },
+            agentQueries: {
+              type: 'array',
+              description:
+                'Named, parameterized queries agents can run via addon_run. Each: { name, description, params?: {name: "string"|"int"|"number"|"boolean"}, access: "read"|"write", sql (use :name for params) }.',
+              items: { type: 'object' },
+            },
+          },
+        },
       },
       required: ['id', 'name', 'description', 'permissions', 'files'],
     },
@@ -241,6 +280,10 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
       const externalImageDomains = Array.isArray(args['externalImageDomains'])
         ? (args['externalImageDomains'] as string[])
         : undefined;
+      const storage =
+        args['storage'] && typeof args['storage'] === 'object'
+          ? (args['storage'] as Record<string, unknown>)
+          : undefined;
       const filesArg = args['files'];
 
       // ── Input validation ────────────────────────────────────────────────
@@ -429,6 +472,20 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
           }
           await writeFile(join(addonDir, filePath), content, 'utf-8');
         }
+      }
+
+      // Merge the declared storage block into the scaffolded addon.json so the
+      // on-disk manifest reflects it (and the DB registration below picks it up).
+      // The full storage schema is validated by installAddon's manifest validator.
+      if (storage) {
+        const { readFileSync, writeFileSync } = await import('node:fs');
+        const manifestPath = join(addonDir, 'addon.json');
+        const m = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<
+          string,
+          unknown
+        >;
+        m.storage = storage;
+        writeFileSync(manifestPath, JSON.stringify(m, null, 2), 'utf-8');
       }
 
       // ── Step 2: register + enable via AddonService (in-process) ──────────

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -34,6 +34,11 @@ export type AddonToolDeps = {
    * (useful in environments where the DB is not configured).
    */
   addonService?: AddonService;
+  /**
+   * Per-addon storage engine. Required by the addon_run / addon_list_queries
+   * tools; absent when storage is unavailable.
+   */
+  storageEngine?: import('../../addons/storage/engine').AddonStorageEngine;
 };
 
 // ── Validation helpers ────────────────────────────────────────────────────────

--- a/apps/server/src/tools/addons/index.ts
+++ b/apps/server/src/tools/addons/index.ts
@@ -1,17 +1,24 @@
 import type { BuiltinTool } from '@openaidy/runtime';
 import { createAddonCreateTool, type AddonToolDeps } from './create.js';
 import { createAddonUpdateTool } from './update.js';
+import { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 
 export { createAddonCreateTool } from './create.js';
 export { createAddonUpdateTool } from './update.js';
+export { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 export type { AddonToolDeps } from './create.js';
 
 /**
  * Returns all addon builtin tools.
  *
  * Register selectively per-agent via `tools` in the agent config:
- *   "tools": ["addon_create", "addon_update"]
+ *   "tools": ["addon_create", "addon_update", "addon_run", "addon_list_queries"]
  */
 export function createAddonTools(deps: AddonToolDeps): BuiltinTool[] {
-  return [createAddonCreateTool(deps), createAddonUpdateTool(deps)];
+  return [
+    createAddonCreateTool(deps),
+    createAddonUpdateTool(deps),
+    createAddonRunTool(deps),
+    createAddonListQueriesTool(deps),
+  ];
 }

--- a/apps/server/src/tools/addons/run.test.ts
+++ b/apps/server/src/tools/addons/run.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AddonStorageEngine,
+  DEFAULT_QUOTAS,
+} from '../../addons/storage/engine.js';
+import { createAddonRunTool, createAddonListQueriesTool } from './run.js';
+import type { AddonToolDeps } from './create.js';
+
+const CTX = { agentId: 'a1' };
+
+const STORAGE = {
+  migrations: ['CREATE TABLE deals (id INTEGER PRIMARY KEY, title TEXT);'],
+  agentAccess: 'readwrite',
+  agentQueries: [
+    {
+      name: 'all_deals',
+      description: 'All deals',
+      access: 'read',
+      sql: 'SELECT title FROM deals ORDER BY title',
+    },
+    {
+      name: 'add_deal',
+      description: 'Add a deal',
+      access: 'write',
+      params: { title: 'string' },
+      sql: 'INSERT INTO deals (title) VALUES (:title)',
+    },
+  ],
+};
+
+function addonRecord(over: Record<string, unknown> = {}) {
+  return {
+    addonId: 'crm',
+    name: 'CRM',
+    status: 'enabled',
+    manifest: { storage: STORAGE },
+    ...over,
+  };
+}
+
+function makeDeps(
+  engine: AddonStorageEngine | undefined,
+  addon: Record<string, unknown> | null = addonRecord(),
+): AddonToolDeps {
+  return {
+    addonsDir: '/tmp/x',
+    ...(engine ? { storageEngine: engine } : {}),
+    addonService: {
+      getAddon: async (id: string) =>
+        addon && (addon as { addonId: string }).addonId === id ? addon : null,
+      listAddons: async () => ({ addons: addon ? [addon] : [], total: 1 }),
+    } as never,
+  };
+}
+
+describe('addon_run / addon_list_queries tools', () => {
+  let dir: string;
+  let engine: AddonStorageEngine;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'addon-run-tool-'));
+    engine = new AddonStorageEngine(dir, DEFAULT_QUOTAS);
+  });
+  afterEach(() => {
+    engine.closeAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('addon_run: write then read', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const w = await run.execute(
+      { addon_id: 'crm', query: 'add_deal', params: { title: 'Acme' } },
+      CTX,
+    );
+    expect(w.ok).toBe(true);
+    if (w.ok) expect(JSON.parse(w.content).changes).toBe(1);
+
+    const r = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(JSON.parse(r.content).rows).toEqual([{ title: 'Acme' }]);
+  });
+
+  it('addon_run: surfaces a denied query as an error', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const res = await run.execute(
+      { addon_id: 'crm', query: 'does_not_exist' },
+      CTX,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('QUERY_NOT_FOUND');
+  });
+
+  it('addon_run: not-enabled addon is refused', async () => {
+    const run = createAddonRunTool(
+      makeDeps(engine, addonRecord({ status: 'installed' })),
+    );
+    const res = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('not enabled');
+  });
+
+  it('addon_run: unknown addon is refused', async () => {
+    const run = createAddonRunTool(makeDeps(engine));
+    const res = await run.execute(
+      { addon_id: 'ghost', query: 'all_deals' },
+      CTX,
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it('addon_run: unavailable storage is refused', async () => {
+    const run = createAddonRunTool(makeDeps(undefined));
+    const res = await run.execute({ addon_id: 'crm', query: 'all_deals' }, CTX);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('not available');
+  });
+
+  it('addon_list_queries: returns the catalog for opted-in addons', async () => {
+    const list = createAddonListQueriesTool(makeDeps(engine));
+    const res = await list.execute({}, CTX);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const catalog = JSON.parse(res.content);
+      expect(catalog).toHaveLength(1);
+      expect(catalog[0].addon_id).toBe('crm');
+      expect(catalog[0].queries.map((q: { name: string }) => q.name)).toEqual([
+        'all_deals',
+        'add_deal',
+      ]);
+    }
+  });
+});

--- a/apps/server/src/tools/addons/run.ts
+++ b/apps/server/src/tools/addons/run.ts
@@ -1,0 +1,141 @@
+/**
+ * addon_run / addon_list_queries
+ *
+ * The agent-facing half of addon storage. Agents never write SQL against an
+ * addon's DB — they discover the named queries an addon exposes
+ * (`addon_list_queries`) and run them by name with typed parameters
+ * (`addon_run`). See packages/shared-types AddonAgentQuerySchema and
+ * ../../addons/storage/agent-queries.ts.
+ */
+import type { BuiltinTool } from '@openaidy/runtime';
+import type { AddonToolDeps } from './create.js';
+import {
+  AddonAgentQueryService,
+  AgentQueryDenied,
+} from '../../addons/storage/agent-queries.js';
+import { addonRunMeta, addonListQueriesMeta } from '../catalog.js';
+
+export function createAddonListQueriesTool(deps: AddonToolDeps): BuiltinTool {
+  return {
+    name: addonListQueriesMeta.name,
+    description: addonListQueriesMeta.description,
+    parameters: {
+      type: 'object',
+      properties: {
+        addon_id: {
+          type: 'string',
+          description:
+            'Optional — restrict the catalog to a single addon by its id.',
+        },
+      },
+    },
+    execute: async (args) => {
+      if (!deps.addonService || !deps.storageEngine) {
+        return { ok: false, error: 'Addon storage is not available' };
+      }
+      const service = new AddonAgentQueryService(deps.storageEngine);
+      const filterId = args.addon_id ? String(args.addon_id) : undefined;
+
+      const { addons } = await deps.addonService.listAddons({
+        status: 'enabled',
+      });
+      const catalog: Array<{
+        addon_id: string;
+        name: string;
+        queries: Array<{
+          name: string;
+          description: string;
+          params: Record<string, string>;
+          access: string;
+        }>;
+      }> = [];
+      for (const addon of addons) {
+        if (filterId && addon.addonId !== filterId) continue;
+        const queries = service.list(addon);
+        if (queries.length === 0) continue;
+        catalog.push({
+          addon_id: addon.addonId,
+          name: addon.name,
+          queries: queries.map((q) => ({
+            name: q.name,
+            description: q.description,
+            params: q.params ?? {},
+            access: q.access ?? 'read',
+          })),
+        });
+      }
+      return { ok: true, content: JSON.stringify(catalog, null, 2) };
+    },
+  };
+}
+
+export function createAddonRunTool(deps: AddonToolDeps): BuiltinTool {
+  return {
+    name: addonRunMeta.name,
+    description: addonRunMeta.description,
+    parameters: {
+      type: 'object',
+      properties: {
+        addon_id: {
+          type: 'string',
+          description: 'Id of the addon whose query to run.',
+        },
+        query: {
+          type: 'string',
+          description:
+            'Name of a query the addon exposes (from addon_list_queries).',
+        },
+        params: {
+          type: 'object',
+          description:
+            "The query's declared parameters, keyed by name. Types are coerced/validated against the declaration.",
+        },
+      },
+      required: ['addon_id', 'query'],
+    },
+    execute: async (args) => {
+      const addonId = String(args.addon_id ?? '');
+      const query = String(args.query ?? '');
+      const params = (args.params ?? {}) as Record<string, unknown>;
+      if (!addonId || !query) {
+        return { ok: false, error: 'addon_id and query are required' };
+      }
+      if (!deps.addonService || !deps.storageEngine) {
+        return { ok: false, error: 'Addon storage is not available' };
+      }
+      const addon = await deps.addonService.getAddon(addonId);
+      if (!addon) {
+        return { ok: false, error: `Addon "${addonId}" not found` };
+      }
+      if (addon.status !== 'enabled') {
+        return { ok: false, error: `Addon "${addonId}" is not enabled` };
+      }
+
+      const service = new AddonAgentQueryService(deps.storageEngine);
+      try {
+        const result = service.run(addon, query, params);
+        if (result.kind === 'rows') {
+          return {
+            ok: true,
+            content: JSON.stringify({ rows: result.rows }, null, 2),
+          };
+        }
+        return {
+          ok: true,
+          content: JSON.stringify({
+            changes: result.changes,
+            lastInsertRowid: Number(result.lastInsertRowid),
+          }),
+        };
+      } catch (err) {
+        if (err instanceof AgentQueryDenied) {
+          return { ok: false, error: `${err.code}: ${err.message}` };
+        }
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : 'Query failed',
+        };
+      }
+    },
+  };
+}

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -220,6 +220,22 @@ export const addonUpdateMeta: ToolMeta = {
     'Keeps the on-disk addon.json and the database record in sync.',
 };
 
+export const addonListQueriesMeta: ToolMeta = {
+  name: 'addon_list_queries',
+  category: 'Addons',
+  description:
+    'Discover the named data queries an addon exposes to agents. Returns, per addon that opted in, its addon_id and a catalog of queries (name, description, typed params, read/write). Call this before addon_run to find the right query — never guess a query name or write raw SQL.',
+};
+
+export const addonRunMeta: ToolMeta = {
+  name: 'addon_run',
+  category: 'Addons',
+  description:
+    "Run a named query an addon exposes to agents (see addon_list_queries) against that addon's private storage. " +
+    'You supply the addon_id, the query name, and its declared parameters — never raw SQL. ' +
+    'Read queries return rows; write queries return the number of changes (and require the addon to grant agent write access).',
+};
+
 // ── UI ────────────────────────────────────────────────────────────────────────
 
 export const presentChoicesMeta: ToolMeta = {
@@ -450,6 +466,8 @@ export const ALL_TOOL_METAS: ToolMeta[] = [
   webFetchMeta,
   addonCreateMeta,
   addonUpdateMeta,
+  addonListQueriesMeta,
+  addonRunMeta,
   presentChoicesMeta,
   memorySaveMeta,
   memorySearchMeta,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",

--- a/packages/shared-types/src/addon.ts
+++ b/packages/shared-types/src/addon.ts
@@ -146,8 +146,60 @@ export type AddonOpenAidy = z.infer<typeof AddonOpenAidySchema>;
  * no addon UI has run (e.g. an agent writing to the store headless). Each entry
  * must be plain SQL without its own BEGIN/COMMIT; `ATTACH`/`DETACH` are rejected.
  */
+/** Parameter types an agent-facing named query accepts. */
+export const AddonAgentQueryParamTypeSchema = z.enum([
+  'string',
+  'int',
+  'number',
+  'boolean',
+]);
+
+export type AddonAgentQueryParamType = z.infer<
+  typeof AddonAgentQueryParamTypeSchema
+>;
+
+/**
+ * A named, parameterized query the addon exposes to agents. The agent supplies
+ * only the declared parameters (never SQL), so a query can do exactly — and
+ * only — what its author wrote. `access: "write"` queries additionally require
+ * the addon's `agentAccess` to be `"readwrite"`.
+ */
+export const AddonAgentQuerySchema = z.object({
+  name: z
+    .string()
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      'query name must be snake_case (start with a letter)',
+    )
+    .max(64),
+  description: z.string().min(1).max(500),
+  /** Named parameters (`:name` in the SQL) mapped to their type. */
+  params: z
+    .record(
+      z.string().regex(/^[a-z][a-z0-9_]*$/, 'param name must be snake_case'),
+      AddonAgentQueryParamTypeSchema,
+    )
+    .optional(),
+  access: z.enum(['read', 'write']).default('read'),
+  sql: z.string().min(1).max(20_000),
+});
+
+export type AddonAgentQuery = z.infer<typeof AddonAgentQuerySchema>;
+
+/**
+ * Addon storage block — declares the addon's own per-addon SQLite storage.
+ *
+ * - `migrations`: ordered DDL/DML the host applies once, by index, the first
+ *   time the DB is opened (and again for newly added entries after an upgrade),
+ *   so the schema exists even when no addon UI has run.
+ * - `agentAccess` + `agentQueries`: opt the addon's data into agent access via a
+ *   catalog of named, parameterized queries the agent runs by name.
+ */
 export const AddonStorageConfigSchema = z.object({
   migrations: z.array(z.string().min(1).max(20_000)).max(200).optional(),
+  /** The ceiling for agent access: reads only, or reads and writes. */
+  agentAccess: z.enum(['read', 'readwrite']).optional(),
+  agentQueries: z.array(AddonAgentQuerySchema).max(100).optional(),
 });
 
 export type AddonStorageConfig = z.infer<typeof AddonStorageConfigSchema>;


### PR DESCRIPTION
## What happened

The addon-storage feature was a 4-PR stack. #377 (Phase 1) merged into `main`, but #379/#380/#381 each merged into their **stacked base branch** instead of `main` — so Phase 2, the authoring integration, and the polish/version-bump chained through the intermediate branches and never reached `main`. `main` is currently at `0.2.4` with only Phase 1.

This PR brings the remainder onto `main` in one merge. It's the accumulation branch (`feat/addon-storage-authoring`, which received the #381 polish merge), so it contains the full stack. Verified: clean merge into `main`, no conflicts.

## Brings to main
- **#379** — agent named-query catalog (`storage.agentAccess` + `agentQueries`, `addon_run` / `addon_list_queries`, read-only agent-read connection)
- **#380** — storage-aware `addon_create` + SDK reference
- **#381** — duplicate agentQuery-name validation, `closeAll()` on shutdown, and **version bump `0.2.4 → 0.3.0`**

All content already reviewed as #379/#380/#381. No new code — this is purely landing the merged work on `main`.

After merge, `main` is at `0.3.0` and `v0.3.0` can be tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)