### PR TITLE
fix(chat): recover from stuck/lost streams so the UI never freezes

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -846,6 +846,7 @@ export async function buildApp() {
 
   // Start scheduler after server is ready
   let stuckSubtaskInterval: ReturnType<typeof setInterval> | undefined;
+  let stuckRunInterval: ReturnType<typeof setInterval> | undefined;
   app.addHook('onReady', async () => {
     if (scheduler) {
       // Recover any stuck jobs from previous run
@@ -865,6 +866,47 @@ export async function buildApp() {
         5 * 60 * 1000,
       ); // Every 5 minutes
       log.info('Stuck subtask checker started (every 5 minutes)');
+    }
+
+    // Recover / reap stuck agent runs. The streaming consume loop has no
+    // timeout, so a hung provider stream — or a process restart mid-run —
+    // leaves a session_run pinned at `running` forever, with no terminal
+    // status. On startup, fail any `running` run (it is orphaned from a prior
+    // process); then periodically fail runs that have been `running` far longer
+    // than any real run should take.
+    if (dbAdapter) {
+      const runsRepo = dbAdapter.repositories.sessionRuns;
+      const RUN_STUCK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+      const reapStuckRuns = async (maxAgeMs: number) => {
+        const running = await runsRepo.listRunning();
+        const cutoff = Date.now() - maxAgeMs;
+        let failed = 0;
+        for (const run of running) {
+          const startedAt = new Date(run.startedAt ?? run.createdAt).getTime();
+          if (startedAt <= cutoff) {
+            await runsRepo.markFailed(run.id, {
+              errorCode: 'STUCK',
+              errorMessage:
+                'Run did not reach a terminal state and was reaped as stuck.',
+            });
+            failed++;
+          }
+        }
+        if (failed > 0) log.warn(`Reaped ${failed} stuck run(s)`);
+      };
+
+      await reapStuckRuns(0).catch((err) =>
+        log.error('Startup stuck-run recovery failed', err),
+      );
+      stuckRunInterval = setInterval(
+        () => {
+          reapStuckRuns(RUN_STUCK_TIMEOUT_MS).catch((err) => {
+            log.error('Failed to reap stuck runs', err);
+          });
+        },
+        5 * 60 * 1000,
+      );
+      log.info('Stuck run reaper started (every 5 minutes)');
     }
 
     // Auto-connect MCP servers from config — non-blocking. These are
@@ -908,6 +950,9 @@ export async function buildApp() {
     if (stuckSubtaskInterval) {
       clearInterval(stuckSubtaskInterval);
       log.info('Stuck subtask checker stopped');
+    }
+    if (stuckRunInterval) {
+      clearInterval(stuckRunInterval);
     }
     if (recurringTasksService) {
       await recurringTasksService.stop();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -125,6 +125,40 @@ function AppContent(props: AppContentProps) {
   );
   const [isDeletingSession, setIsDeletingSession] = createSignal(false);
 
+  // ── Stream watchdog ────────────────────────────────────────────────────────
+  // `isStreaming` is a single app-wide flag that gates ALL sends and is only
+  // cleared by a `session.stream.end` event. If a run hangs server-side, or an
+  // `end` is lost (e.g. a reconnect after a network blip / server restart), the
+  // flag would stay `true` forever — silently queueing every future message in
+  // every session and never refetching messages. This watchdog recovers the UI
+  // if the stream goes idle (no start/delta/tool_call/end) for too long.
+  const STREAM_IDLE_TIMEOUT_MS = 120_000;
+  let streamWatchdog: ReturnType<typeof setTimeout> | undefined;
+  const clearStreamWatchdog = () => {
+    if (streamWatchdog !== undefined) {
+      clearTimeout(streamWatchdog);
+      streamWatchdog = undefined;
+    }
+  };
+  const armStreamWatchdog = () => {
+    clearStreamWatchdog();
+    streamWatchdog = setTimeout(() => {
+      streamWatchdog = undefined;
+      if (!isStreaming()) return;
+      // Assume the stream is dead — recover so the UI isn't permanently stuck.
+      setIsStreaming(false);
+      setStreamingContent('');
+      setStreamingToolCalls([]);
+      setPendingUserMessage(undefined);
+      const sid = selectedSessionId();
+      if (sid) {
+        queryClient.invalidateQueries({ queryKey: ['messages', sid] });
+        queryClient.invalidateQueries({ queryKey: ['runs', sid] });
+      }
+      processQueue();
+    }, STREAM_IDLE_TIMEOUT_MS);
+  };
+
   // Subscribe to streaming events when a session is selected
   createEffect(() => {
     const sessionId = selectedSessionId();
@@ -137,10 +171,12 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(true);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      armStreamWatchdog();
     };
 
     const handleStreamDelta = (event: { payload: { content: string } }) => {
       setStreamingContent((prev) => prev + event.payload.content);
+      armStreamWatchdog();
     };
 
     const handleStreamToolCall = (event: {
@@ -157,9 +193,11 @@ function AppContent(props: AppContentProps) {
         ...prev,
         { id: tc.id, name: tc.name, input: tc.arguments },
       ]);
+      armStreamWatchdog();
     };
 
     const handleStreamEnd = () => {
+      clearStreamWatchdog();
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
@@ -180,6 +218,7 @@ function AppContent(props: AppContentProps) {
     const handleStreamError = (event: {
       payload: { error: { message: string } };
     }) => {
+      clearStreamWatchdog();
       setSubmitError(event.payload.error.message);
       setIsStreaming(false);
       setStreamingContent('');
@@ -192,6 +231,7 @@ function AppContent(props: AppContentProps) {
     };
 
     const handleChoicesEvent = (event: { payload: ChoicesEvent }) => {
+      clearStreamWatchdog();
       setCurrentChoices(event.payload);
       // Clear streaming state so input becomes enabled for user to type their own answer
       setIsStreaming(false);
@@ -363,6 +403,8 @@ function AppContent(props: AppContentProps) {
     setIsStreaming(true);
     setStreamingContent('');
     setStreamingToolCalls([]);
+    // Guard against a `start`/`end` that never arrives (hung run, lost event).
+    armStreamWatchdog();
     setPendingUserMessage({
       id: `pending-${Date.now()}`,
       sessionId,
@@ -486,11 +528,19 @@ function AppContent(props: AppContentProps) {
     }
   });
 
-  // Clear choices card when switching sessions
+  // Reset transient chat state when switching sessions. Critically, this clears
+  // `isStreaming` — otherwise a hung or lost stream in the previous session
+  // would leave the app-wide flag stuck `true`, freezing composing and message
+  // rendering in every session you switch to afterwards.
   createEffect(() => {
     const sessionId = selectedSessionId();
     if (sessionId) {
+      clearStreamWatchdog();
       setCurrentChoices(null);
+      setIsStreaming(false);
+      setStreamingContent('');
+      setStreamingToolCalls([]);
+      setPendingUserMessage(undefined);
     }
   });
 

--- a/packages/db/src/repositories/index.test.ts
+++ b/packages/db/src/repositories/index.test.ts
@@ -11,7 +11,7 @@ type Database = NodePgDatabase<typeof schema>;
 
 /**
  * Integration tests for session repositories
- * 
+ *
  * These tests require a PostgreSQL database. Set DATABASE_URL to run.
  */
 describe('Session Repositories (integration)', () => {
@@ -30,7 +30,7 @@ describe('Session Repositories (integration)', () => {
 
     pool = new Pool({ connectionString: databaseUrl });
     db = drizzle(pool, { schema }) as Database;
-    
+
     sessionsRepo = new SessionsRepository(db);
     messagesRepo = new SessionMessagesRepository(db);
     runsRepo = new SessionRunsRepository(db);
@@ -53,7 +53,7 @@ describe('Session Repositories (integration)', () => {
   describe('SessionsRepository', () => {
     test('should create a session', async () => {
       const session = await sessionsRepo!.create({ title: 'Test Session' });
-      
+
       expect(session.id).toBeDefined();
       expect(session.title).toBe('Test Session');
       expect(session.status).toBe('active');
@@ -63,7 +63,7 @@ describe('Session Repositories (integration)', () => {
     test('should find session by id', async () => {
       const created = await sessionsRepo!.create({ title: 'Find Me' });
       const found = await sessionsRepo!.findById(created.id);
-      
+
       expect(found).toBeDefined();
       expect(found?.id).toBe(created.id);
       expect(found?.title).toBe('Find Me');
@@ -72,7 +72,7 @@ describe('Session Repositories (integration)', () => {
     test('should list sessions', async () => {
       await sessionsRepo!.create({ title: 'Session 1' });
       await sessionsRepo!.create({ title: 'Session 2' });
-      
+
       const list = await sessionsRepo!.list();
       expect(list).toHaveLength(2);
     });
@@ -80,7 +80,7 @@ describe('Session Repositories (integration)', () => {
     test('should update session status', async () => {
       const session = await sessionsRepo!.create({ title: 'To Archive' });
       const updated = await sessionsRepo!.updateStatus(session.id, 'archived');
-      
+
       expect(updated?.status).toBe('archived');
       expect(updated?.archivedAt).toBeInstanceOf(Date);
     });
@@ -117,29 +117,47 @@ describe('Session Repositories (integration)', () => {
 
     test('should get latest message', async () => {
       await messagesRepo!.append({ sessionId, role: 'user', content: 'First' });
-      await messagesRepo!.append({ sessionId, role: 'assistant', content: 'Second' });
-      
+      await messagesRepo!.append({
+        sessionId,
+        role: 'assistant',
+        content: 'Second',
+      });
+
       const latest = await messagesRepo!.getLatest(sessionId);
       expect(latest?.content).toBe('Second');
     });
 
     test('should count messages', async () => {
       await messagesRepo!.append({ sessionId, role: 'user', content: 'A' });
-      await messagesRepo!.append({ sessionId, role: 'assistant', content: 'B' });
-      
+      await messagesRepo!.append({
+        sessionId,
+        role: 'assistant',
+        content: 'B',
+      });
+
       const count = await messagesRepo!.countBySession(sessionId);
       expect(count).toBe(2);
     });
 
     test('should isolate messages between sessions', async () => {
       const otherSession = await sessionsRepo!.create({ title: 'Other' });
-      
-      await messagesRepo!.append({ sessionId, role: 'user', content: 'Session 1' });
-      await messagesRepo!.append({ sessionId: otherSession.id, role: 'user', content: 'Session 2' });
-      
+
+      await messagesRepo!.append({
+        sessionId,
+        role: 'user',
+        content: 'Session 1',
+      });
+      await messagesRepo!.append({
+        sessionId: otherSession.id,
+        role: 'user',
+        content: 'Session 2',
+      });
+
       const session1Messages = await messagesRepo!.listBySession(sessionId);
-      const session2Messages = await messagesRepo!.listBySession(otherSession.id);
-      
+      const session2Messages = await messagesRepo!.listBySession(
+        otherSession.id,
+      );
+
       expect(session1Messages).toHaveLength(1);
       expect(session2Messages).toHaveLength(1);
       expect(session1Messages[0]?.content).toBe('Session 1');
@@ -213,20 +231,70 @@ describe('Session Repositories (integration)', () => {
 
     test('should get active run', async () => {
       // Create multiple runs
-      await runsRepo!.create({ sessionId, agentId: 'agent1', providerId: 'p1', modelId: 'm1' });
-      const runningRun = await runsRepo!.create({ sessionId, agentId: 'agent2', providerId: 'p2', modelId: 'm2' });
-      
+      await runsRepo!.create({
+        sessionId,
+        agentId: 'agent1',
+        providerId: 'p1',
+        modelId: 'm1',
+      });
+      const runningRun = await runsRepo!.create({
+        sessionId,
+        agentId: 'agent2',
+        providerId: 'p2',
+        modelId: 'm2',
+      });
+
       await runsRepo!.markRunning(runningRun.id);
-      
+
       const active = await runsRepo!.getActive(sessionId);
       expect(active?.id).toBe(runningRun.id);
       expect(active?.status).toBe('running');
     });
 
+    test('listRunning returns only runs in the running state', async () => {
+      const queued = await runsRepo!.create({
+        sessionId,
+        agentId: 'a1',
+        providerId: 'p1',
+        modelId: 'm1',
+      });
+      const stuck = await runsRepo!.create({
+        sessionId,
+        agentId: 'a2',
+        providerId: 'p2',
+        modelId: 'm2',
+      });
+      const done = await runsRepo!.create({
+        sessionId,
+        agentId: 'a3',
+        providerId: 'p3',
+        modelId: 'm3',
+      });
+      await runsRepo!.markRunning(stuck.id);
+      await runsRepo!.markRunning(done.id);
+      await runsRepo!.markSucceeded(done.id, { finishReason: 'stop' });
+
+      const running = await runsRepo!.listRunning();
+      const ids = running.map((r) => r.id);
+      expect(ids).toContain(stuck.id);
+      expect(ids).not.toContain(queued.id);
+      expect(ids).not.toContain(done.id);
+    });
+
     test('should list runs for session with agentId', async () => {
-      await runsRepo!.create({ sessionId, agentId: 'agent1', providerId: 'p1', modelId: 'm1' });
-      await runsRepo!.create({ sessionId, agentId: 'agent2', providerId: 'p2', modelId: 'm2' });
-      
+      await runsRepo!.create({
+        sessionId,
+        agentId: 'agent1',
+        providerId: 'p1',
+        modelId: 'm1',
+      });
+      await runsRepo!.create({
+        sessionId,
+        agentId: 'agent2',
+        providerId: 'p2',
+        modelId: 'm2',
+      });
+
       const runs = await runsRepo!.listBySession(sessionId);
       expect(runs).toHaveLength(2);
       expect(runs[0]?.agentId).toBe('agent2');
@@ -235,13 +303,23 @@ describe('Session Repositories (integration)', () => {
 
     test('should isolate runs between sessions', async () => {
       const otherSession = await sessionsRepo!.create({ title: 'Other' });
-      
-      await runsRepo!.create({ sessionId, agentId: 'agent1', providerId: 'p1', modelId: 'm1' });
-      await runsRepo!.create({ sessionId: otherSession.id, agentId: 'agent2', providerId: 'p2', modelId: 'm2' });
-      
+
+      await runsRepo!.create({
+        sessionId,
+        agentId: 'agent1',
+        providerId: 'p1',
+        modelId: 'm1',
+      });
+      await runsRepo!.create({
+        sessionId: otherSession.id,
+        agentId: 'agent2',
+        providerId: 'p2',
+        modelId: 'm2',
+      });
+
       const session1Runs = await runsRepo!.listBySession(sessionId);
       const session2Runs = await runsRepo!.listBySession(otherSession.id);
-      
+
       expect(session1Runs).toHaveLength(1);
       expect(session2Runs).toHaveLength(1);
       expect(session1Runs[0]?.providerId).toBe('p1');

--- a/packages/db/src/repositories/session-runs.ts
+++ b/packages/db/src/repositories/session-runs.ts
@@ -110,6 +110,19 @@ export class SessionRunsRepository {
   }
 
   /**
+   * List every run currently in the `running` state. Used by startup recovery
+   * and the periodic reaper to find runs whose provider stream hung — or that
+   * were left `running` by a process restart — and never reached a terminal
+   * status on their own.
+   */
+  async listRunning(): Promise<schema.SessionRun[]> {
+    return this.db
+      .select()
+      .from(schema.sessionRuns)
+      .where(eq(schema.sessionRuns.status, 'running'));
+  }
+
+  /**
    * Mark a run as succeeded
    */
   async markSucceeded(

--- a/packages/db/src/types/index.ts
+++ b/packages/db/src/types/index.ts
@@ -171,6 +171,7 @@ export type SessionRunsStore = Pick<
   | 'markSucceeded'
   | 'markFailed'
   | 'markCancelled'
+  | 'listRunning'
   | 'getLatest'
   | 'getActive'
   | 'countByStatus'


### PR DESCRIPTION
## The bug

Sometimes a run stays stuck in `running` (e.g. `5LR-A0bT…`) and **new messages stop rendering in later chats — even though the agent keeps responding correctly on the backend**. It also happens *without* a visibly stuck run.

## Root cause

The chat UI tracks streaming with a **single app-wide `isStreaming` flag** (`apps/web/src/App.tsx`). That flag:
- gates **every** send (`handleSubmit` queues instead of sending while it's true), across **all** sessions, and
- is cleared **only** by a `session.stream.end` WebSocket event — which is also the **only** place the message list is re-fetched.

So if an `end` never arrives, the flag stays `true` forever: every message you type in any chat is silently queued and never sent, and persisted assistant messages are never re-fetched (→ "the agent responds but the UI doesn't show it"). It's never reset on session switch, so one bad stream freezes every later chat.

`end` goes missing when:
- a run **hangs** — the streaming consume loop has no timeout/abort and the terminal status isn't in a `finally`, and **nothing reaps stuck `session_runs`**; or
- an `end` is **lost on reconnect** (server restart / network blip) — the client resubscribes to the *session* but not to the in-flight *run stream*, so the completion is delivered to a dead connection. (This is why it happens without a stuck run.)

## The fix — two layers

**Frontend, self-healing (`App.tsx`):**
- **Reset streaming state on session switch** (`isStreaming`, content, tool calls, pending message) — a hung stream in one chat can no longer freeze the others. This alone unblocks "later chats" instantly.
- **Stream watchdog** — if no `start`/`delta`/`tool_call`/`end` arrives for 120s while streaming, clear the flag, refetch messages + runs, and drain the queue. Recovers the same session without a manual switch.

**Backend, stop runs staying `running` (`apps/server/src/app.ts`, `packages/db`):**
- `SessionRunsRepository.listRunning()` + **startup recovery** (fail any run left `running` by a prior process — it's orphaned) and a **periodic reaper** (fail runs `running` > 30 min). Wired next to the existing stuck-subtask checker; interval cleared on shutdown.

## Verification
- Full server suite: **3052 passed / 0 failed**.
- web (`tsc --noEmit`), db, and server typecheck clean; server lint clean.
- `listRunning` unit test added (runs in the Postgres integration suite in CI).

## Deeper follow-up (not in this PR)
The true root of hangs is the **missing timeout/AbortSignal on the streaming consume loop** (`sessions/service.ts` `for await (const event of stream)`). Adding an idle-abort there would prevent hangs at the source; this PR makes the system *recover* from them (UI self-heals, runs get reaped). Worth a focused follow-up on the streaming loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)