### PR TITLE
fix(web): compact single-row mobile chat composer (#371)

### DIFF
--- a/apps/web/src/components/AgentPicker.tsx
+++ b/apps/web/src/components/AgentPicker.tsx
@@ -1,5 +1,5 @@
 import { Show, For, createSignal } from 'solid-js';
-import { ChevronDown, Bot } from 'lucide-solid';
+import { ChevronDown, Bot, X } from 'lucide-solid';
 import type { Agent } from '../lib/api';
 
 type AgentPickerProps = {
@@ -7,10 +7,20 @@ type AgentPickerProps = {
   selectedAgentId?: string;
   onSelect: (agentId: string | undefined) => void;
   disabled?: boolean;
+  /**
+   * Presentation:
+   *  - 'inline' (default): fixed-width button + upward dropdown (desktop).
+   *  - 'icon': a single round icon button + full-width bottom sheet (mobile).
+   *    Icon-only keeps the composer to one compact row; the agent's name (and
+   *    every option's name + description) is shown in the sheet when picking.
+   */
+  variant?: 'inline' | 'icon';
 };
 
 export function AgentPicker(props: AgentPickerProps) {
   const [isOpen, setIsOpen] = createSignal(false);
+  const variant = () => props.variant ?? 'inline';
+  const enabledAgents = () => props.agents.filter((a) => a.enabled);
 
   const handleSelect = (agentId: string | undefined) => {
     props.onSelect(agentId);
@@ -19,72 +29,125 @@ export function AgentPicker(props: AgentPickerProps) {
 
   const selectedAgent = () =>
     props.agents.find((a) => a.id === props.selectedAgentId);
+  const selectedLabel = () => selectedAgent()?.name ?? 'Default agent';
 
-  return (
-    <div class="relative flex-shrink-0">
-      {/* Picker button */}
+  // Option list shared by the desktop dropdown and the mobile bottom sheet.
+  const OptionList = () => (
+    <>
       <button
         type="button"
-        onClick={() => !props.disabled && setIsOpen(!isOpen())}
-        disabled={props.disabled}
-        class="flex items-center gap-2 px-3 h-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed min-w-[140px]"
+        onClick={() => handleSelect(undefined)}
+        class={`w-full px-3 py-3 md:py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 ${
+          props.selectedAgentId === undefined
+            ? 'bg-blue-50 dark:bg-blue-900/30 text-text-primary'
+            : 'text-text-tertiary'
+        }`}
       >
-        <Bot class="w-4 h-4 text-text-tertiary" />
-        <span class="flex-1 text-left text-sm text-text-secondary truncate">
-          {selectedAgent()?.name ?? 'Default agent'}
-        </span>
-        <ChevronDown class="w-4 h-4 text-text-tertiary" />
+        <Bot class="w-4 h-4 flex-shrink-0" />
+        <span>Default agent</span>
       </button>
 
-      {/* Dropdown */}
-      <Show when={isOpen()}>
-        <div class="absolute bottom-full left-0 mb-1 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto">
-          {/* Default option */}
+      <div class="border-t border-gray-200 dark:border-gray-700" />
+
+      <For each={enabledAgents()}>
+        {(agent) => (
           <button
             type="button"
-            onClick={() => handleSelect(undefined)}
-            class="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 text-text-tertiary"
+            onClick={() => handleSelect(agent.id)}
+            class={`w-full px-3 py-3 md:py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 ${
+              props.selectedAgentId === agent.id
+                ? 'bg-blue-50 dark:bg-blue-900/30'
+                : ''
+            }`}
           >
-            <Bot class="w-4 h-4" />
-            <span>Default agent</span>
-          </button>
-
-          {/* Divider */}
-          <div class="border-t border-gray-200 dark:border-gray-700" />
-
-          {/* Agent options */}
-          <For each={props.agents.filter((a) => a.enabled)}>
-            {(agent) => (
-              <button
-                type="button"
-                onClick={() => handleSelect(agent.id)}
-                class={`w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 ${
-                  props.selectedAgentId === agent.id
-                    ? 'bg-blue-50 dark:bg-blue-900/30'
-                    : ''
-                }`}
-              >
-                <Bot class="w-4 h-4 text-text-tertiary" />
-                <div class="flex-1 min-w-0">
-                  <div class="font-medium text-text-primary truncate">
-                    {agent.name}
-                  </div>
-                  <Show when={agent.description}>
-                    <div class="text-xs text-text-tertiary truncate">
-                      {agent.description}
-                    </div>
-                  </Show>
+            <Bot class="w-4 h-4 text-text-tertiary flex-shrink-0" />
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-text-primary truncate">
+                {agent.name}
+              </div>
+              <Show when={agent.description}>
+                <div class="text-xs text-text-tertiary truncate">
+                  {agent.description}
                 </div>
-              </button>
-            )}
-          </For>
-
-          {/* Empty state */}
-          <Show when={props.agents.filter((a) => a.enabled).length === 0}>
-            <div class="px-3 py-4 text-center text-sm text-text-tertiary">
-              No agents available
+              </Show>
             </div>
-          </Show>
+          </button>
+        )}
+      </For>
+
+      <Show when={enabledAgents().length === 0}>
+        <div class="px-3 py-4 text-center text-sm text-text-tertiary">
+          No agents available
+        </div>
+      </Show>
+    </>
+  );
+
+  return (
+    <div
+      class={
+        variant() === 'inline' ? 'relative flex-shrink-0' : 'flex-shrink-0'
+      }
+    >
+      {/* Trigger */}
+      <Show
+        when={variant() === 'icon'}
+        fallback={
+          <button
+            type="button"
+            onClick={() => !props.disabled && setIsOpen(!isOpen())}
+            disabled={props.disabled}
+            aria-label="Select agent"
+            class="flex items-center gap-2 px-3 h-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed min-w-[140px]"
+          >
+            <Bot class="w-4 h-4 text-text-tertiary" />
+            <span class="flex-1 text-left text-sm text-text-secondary truncate">
+              {selectedLabel()}
+            </span>
+            <ChevronDown class="w-4 h-4 text-text-tertiary" />
+          </button>
+        }
+      >
+        <button
+          type="button"
+          onClick={() => !props.disabled && setIsOpen(true)}
+          disabled={props.disabled}
+          aria-label="Select agent"
+          title={selectedLabel()}
+          class="flex items-center justify-center w-8 h-8 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-text-tertiary hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Bot class="w-4 h-4" />
+        </button>
+      </Show>
+
+      {/* Desktop dropdown */}
+      <Show when={isOpen() && variant() === 'inline'}>
+        <div class="absolute bottom-full left-0 mb-1 w-full min-w-[220px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto">
+          <OptionList />
+        </div>
+      </Show>
+
+      {/* Mobile bottom sheet */}
+      <Show when={isOpen() && variant() === 'icon'}>
+        <div
+          class="fixed inset-0 z-40 bg-black/40"
+          onClick={() => setIsOpen(false)}
+        />
+        <div class="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-2xl max-h-[70vh] overflow-y-auto pb-6">
+          <div class="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+            <span class="text-sm font-medium text-text-primary">
+              Choose an agent
+            </span>
+            <button
+              type="button"
+              aria-label="Close agent picker"
+              onClick={() => setIsOpen(false)}
+              class="p-1 text-text-tertiary hover:text-text-primary"
+            >
+              <X class="w-5 h-5" />
+            </button>
+          </div>
+          <OptionList />
         </div>
       </Show>
     </div>

--- a/apps/web/src/components/ChatComposer.test.tsx
+++ b/apps/web/src/components/ChatComposer.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@solidjs/testing-library';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
 import { ChatComposer } from './ChatComposer';
 
 // Stub the icons ChatComposer + AgentPicker render. Plain-object factory
@@ -9,7 +9,22 @@ vi.mock('lucide-solid', () => ({
   ListPlus: () => <span data-testid="list-plus" />,
   ChevronDown: () => <span data-testid="chevron-down" />,
   Bot: () => <span data-testid="bot" />,
+  X: () => <span data-testid="x" />,
 }));
+
+/** Force ChatComposer's `isMobile()` on by stubbing matchMedia. */
+function stubMobile(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+}
 
 describe('ChatComposer', () => {
   const mockOnSend = vi.fn().mockResolvedValue(undefined);
@@ -91,6 +106,80 @@ describe('ChatComposer', () => {
     // Falls back to the Send affordance, not Queue, when hard-disabled.
     expect(
       container.querySelector('button[aria-label="Send message"]'),
+    ).toBeTruthy();
+  });
+});
+
+describe('ChatComposer (mobile layout)', () => {
+  const mockOnSend = vi.fn().mockResolvedValue(undefined);
+  const mockOnAgentSelect = vi.fn();
+  const mockAgents = [
+    {
+      id: 'agent-1',
+      name: 'Test Agent',
+      description: 'Does testing things',
+      enabled: true,
+      systemPrompt: 'Test',
+      model: 'openai/gpt-4o-mini',
+      defaults: {},
+    },
+  ];
+
+  afterEach(() => {
+    // Restore jsdom's default (no matchMedia) so other suites see desktop.
+    delete (window as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('renders the agent chip, textarea, and an inline send button', () => {
+    stubMobile(true);
+    const { container } = render(() => (
+      <ChatComposer
+        onSend={mockOnSend}
+        agents={mockAgents}
+        onAgentSelect={mockOnAgentSelect}
+      />
+    ));
+    expect(
+      container.querySelector('button[aria-label="Select agent"]'),
+    ).toBeTruthy();
+    expect(container.querySelector('textarea')).toBeTruthy();
+    expect(
+      container.querySelector('button[aria-label="Send message"]'),
+    ).toBeTruthy();
+  });
+
+  it('opens a bottom sheet listing agents when the chip is tapped', async () => {
+    stubMobile(true);
+    const { container, getByText } = render(() => (
+      <ChatComposer
+        onSend={mockOnSend}
+        agents={mockAgents}
+        onAgentSelect={mockOnAgentSelect}
+      />
+    ));
+    const chip = container.querySelector(
+      'button[aria-label="Select agent"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(chip);
+    expect(getByText('Choose an agent')).toBeTruthy();
+    expect(getByText('Test Agent')).toBeTruthy();
+    expect(getByText('Does testing things')).toBeTruthy();
+  });
+
+  it('still queues while streaming on mobile', () => {
+    stubMobile(true);
+    const { container } = render(() => (
+      <ChatComposer
+        onSend={mockOnSend}
+        isStreaming={true}
+        agents={mockAgents}
+        onAgentSelect={mockOnAgentSelect}
+      />
+    ));
+    const textarea = container.querySelector('textarea');
+    expect(textarea?.disabled).toBe(false);
+    expect(
+      container.querySelector('button[aria-label="Queue message"]'),
     ).toBeTruthy();
   });
 });

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -23,6 +23,11 @@ type ChatComposerProps = {
 export function ChatComposer(props: ChatComposerProps) {
   const [input, setInput] = createSignal('');
   const [isSending, setIsSending] = createSignal(false);
+  // Below Tailwind's `md` (768px) we use the mobile layout: the agent picker
+  // moves to a chip above the input, and the send button is merged into the
+  // input pill — reclaiming horizontal room for typing. Defaults to desktop
+  // when matchMedia is unavailable (e.g. jsdom under test).
+  const [isMobile, setIsMobile] = createSignal(false);
   let textareaRef: HTMLTextAreaElement | undefined;
 
   // Queue mode: usable composer, but submitting enqueues for later send.
@@ -33,6 +38,15 @@ export function ChatComposer(props: ChatComposerProps) {
     if (props.onInputReady) {
       props.onInputReady(() => textareaRef?.focus());
     }
+
+    const mq = window.matchMedia?.('(max-width: 767px)');
+    if (mq) {
+      const update = () => setIsMobile(mq.matches);
+      update();
+      mq.addEventListener?.('change', update);
+      onCleanup(() => mq.removeEventListener?.('change', update));
+    }
+
     onCleanup(() => {
       textareaRef = undefined; // Clear ref on unmount to prevent stale closures
     });
@@ -68,57 +82,106 @@ export function ChatComposer(props: ChatComposerProps) {
     textareaRef = el;
   };
 
+  const inputDisabled = () => props.disabled || isSending();
+  const sendDisabled = () => props.disabled || isSending() || !input().trim();
+  const sendAriaLabel = () => (isQueueing() ? 'Queue message' : 'Send message');
+  const sendTitle = () =>
+    isQueueing()
+      ? 'Agent is responding — your message will be queued'
+      : 'Send message';
+
+  // Send-button inner content (spinner while sending, else queue/send icon).
+  const sendIcon = () => (
+    <Show
+      when={isSending()}
+      fallback={
+        <Show when={isQueueing()} fallback={<Send class="w-4 h-4" />}>
+          <ListPlus class="w-4 h-4" />
+        </Show>
+      }
+    >
+      <div class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+    </Show>
+  );
+
   return (
     <form
       onSubmit={handleSubmit}
-      class="border-t border-gray-200 dark:border-gray-700 p-4"
+      class="border-t border-gray-200 dark:border-gray-700 px-3 py-2 md:p-4"
     >
-      <div class="flex items-center gap-3">
-        {/* Agent picker */}
-        <AgentPicker
-          agents={props.agents}
-          selectedAgentId={props.selectedAgentId}
-          onSelect={props.onAgentSelect}
-          disabled={props.disabled || isSending()}
-        />
+      <Show
+        when={isMobile()}
+        fallback={
+          /* ── Desktop / tablet (≥ md): [picker] [input] [send] ── */
+          <div class="flex items-center gap-3">
+            <AgentPicker
+              agents={props.agents}
+              selectedAgentId={props.selectedAgentId}
+              onSelect={props.onAgentSelect}
+              disabled={inputDisabled()}
+            />
 
-        {/* Text input */}
-        <div class="flex-1">
+            <div class="flex-1">
+              <textarea
+                ref={setRef}
+                value={input()}
+                onInput={(e) => setInput(e.currentTarget.value)}
+                onKeyDown={handleKeyDown}
+                disabled={inputDisabled()}
+                placeholder={placeholder()}
+                rows={1}
+                class="w-full resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-2 text-text-primary placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed min-h-10 max-h-32 overflow-y-auto mt-1"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={sendDisabled()}
+              class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white flex items-center justify-center transition-colors disabled:cursor-not-allowed"
+              aria-label={sendAriaLabel()}
+              title={sendTitle()}
+            >
+              {sendIcon()}
+            </button>
+          </div>
+        }
+      >
+        {/* ── Mobile (< md): one compact row — agent icon, input, send — in a
+            single pill, so the chat scrollback keeps the vertical space. The
+            agent is icon-only (its name shows in the picker sheet), and the
+            keyboard hint below is hidden. ── */}
+        <div class="flex items-end gap-1.5 rounded-2xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-1.5 py-1 focus-within:ring-2 focus-within:ring-primary focus-within:border-transparent">
+          <AgentPicker
+            variant="icon"
+            agents={props.agents}
+            selectedAgentId={props.selectedAgentId}
+            onSelect={props.onAgentSelect}
+            disabled={inputDisabled()}
+          />
           <textarea
             ref={setRef}
             value={input()}
             onInput={(e) => setInput(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
-            disabled={props.disabled || isSending()}
+            disabled={inputDisabled()}
             placeholder={placeholder()}
             rows={1}
-            class="w-full resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-2 text-text-primary placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed min-h-10 max-h-32 overflow-y-auto mt-1"
+            class="flex-1 min-w-0 resize-none bg-transparent py-1 text-text-primary placeholder-text-tertiary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed min-h-8 max-h-32 overflow-y-auto"
           />
+          <button
+            type="submit"
+            disabled={sendDisabled()}
+            class="flex-shrink-0 w-8 h-8 rounded-full bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white flex items-center justify-center transition-colors disabled:cursor-not-allowed"
+            aria-label={sendAriaLabel()}
+            title={sendTitle()}
+          >
+            {sendIcon()}
+          </button>
         </div>
+      </Show>
 
-        {/* Send / queue button */}
-        <button
-          type="submit"
-          disabled={props.disabled || isSending() || !input().trim()}
-          class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white flex items-center justify-center transition-colors disabled:cursor-not-allowed"
-          aria-label={isQueueing() ? 'Queue message' : 'Send message'}
-          title={
-            isQueueing()
-              ? 'Agent is responding — your message will be queued'
-              : 'Send message'
-          }
-        >
-          <Show when={isSending()}>
-            <div class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-          </Show>
-          <Show when={!isSending()}>
-            <Show when={isQueueing()} fallback={<Send class="w-4 h-4" />}>
-              <ListPlus class="w-4 h-4" />
-            </Show>
-          </Show>
-        </button>
-      </div>
-      <p class="mt-2 text-xs text-text-tertiary">
+      {/* Keyboard hint — desktop only; hidden on mobile to maximize chat space. */}
+      <p class="mt-2 text-xs text-text-tertiary hidden md:block">
         <Show
           when={isQueueing()}
           fallback="Press Enter to send, Shift+Enter for new line"


### PR DESCRIPTION
Closes #371.

## Problem
On a 375px viewport the composer was `[AgentPicker ≥140px][textarea][send]`, leaving ~125px to type in, and the picker + input + keyboard hint ate a lot of vertical space — which on mobile should go to the chat scrollback.

## Fix (mobile `< md` only; desktop unchanged)
One compact pill row: **`[agent icon] [textarea] [inline send]`**.

- **AgentPicker `variant`**
  - `inline` (default): the existing fixed-width button + dropdown — desktop untouched.
  - `icon`: a round **icon-only** trigger (Bot). Tapping opens a **full-width bottom sheet** listing every enabled agent with **name + description**, so names stay discoverable when choosing (and the selected name is on the trigger's `title`). Icon-only is what keeps the row short.
- **ChatComposer** uses `matchMedia('(max-width: 767px)')` to render the single pill row on mobile with tight padding, and **hides the keyboard hint** on mobile. Reduced the form padding (`px-3 py-2` vs `p-4`). Falls back to the original desktop row when `matchMedia` is unavailable (jsdom) or at `≥ md`.
- Preserved: queue mode (`ListPlus` while streaming), Enter-to-send / Shift+Enter, focus (`onInputReady`/ref), aria labels.

This trims the mobile composer from ~3 stacked elements to a single ~40px row, maximizing chat text visibility (the design goal, refined from the issue's original chip-above-input proposal toward compactness).

## Verification
- Web `tsc --noEmit` clean; full web suite **352 passing**.
- 3 mobile tests added (icon trigger + inline send render, bottom-sheet opens with agent names/descriptions, queue-while-streaming); desktop tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)