### PR TITLE
feat: show OpenAidy version in Settings page

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -21,6 +21,8 @@ import {
   noopInvalidator,
 } from './lib/credential-provider';
 import { healthRoutes } from './routes/health';
+import { infoRoutes } from './routes/info';
+import { OPEN_AIDY_VERSION } from './lib/version';
 import { authRoutes } from './routes/auth';
 import { accessTokenRoutes } from './routes/access-tokens';
 import { createAccessTokenService } from './access-tokens/service';
@@ -228,7 +230,7 @@ export async function buildApp() {
 
   // Create AddonService early so it can be injected into the builtin tool registry
   const addonManifestValidator = new ManifestValidator();
-  const openAidyVersion = process.env.npm_package_version ?? '0.0.0';
+  const openAidyVersion = OPEN_AIDY_VERSION;
   const addonService = dbAdapter
     ? createAddonService({
         repository: dbAdapter.repositories.addons,
@@ -470,6 +472,10 @@ export async function buildApp() {
         configService: services.config,
         authMiddleware,
       });
+
+      // /api/info — build/runtime info (version, node, platform, uptime).
+      // Unauthenticated; discloses nothing sensitive (same level as /health).
+      await api.register(infoRoutes);
 
       // Pass shared services to session routes
       await api.register(sessionRoutes, {

--- a/apps/server/src/lib/version.test.ts
+++ b/apps/server/src/lib/version.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveOpenAidyVersion } from './version';
+
+function makeTree(files: Record<string, string | null>): string {
+  const root = mkdtempSync(join(tmpdir(), 'openaidy-version-test-'));
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = join(root, relPath);
+    if (content === null) {
+      mkdirSync(fullPath, { recursive: true });
+      continue;
+    }
+    mkdirSync(resolve(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content, 'utf-8');
+  }
+  return root;
+}
+
+describe('resolveOpenAidyVersion', () => {
+  let root: string;
+
+  afterEach(() => {
+    if (root) {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('returns the version from the nearest package.json walking up', () => {
+    root = makeTree({
+      'package.json': JSON.stringify({ name: 'openaidy', version: '1.2.3' }),
+      'apps/server/src/deep.txt': 'leaf',
+    });
+    const start = join(root, 'apps/server/src');
+    expect(resolveOpenAidyVersion(start)).toBe('1.2.3');
+  });
+
+  it('skips package.json files without a version field', () => {
+    root = makeTree({
+      'package.json': JSON.stringify({ name: 'openaidy', version: '9.9.9' }),
+      'apps/server/package.json': JSON.stringify({ name: '@openaidy/server' }),
+      'apps/server/src/server.ts': '// server',
+    });
+    const start = join(root, 'apps/server/src');
+    expect(resolveOpenAidyVersion(start)).toBe('9.9.9');
+  });
+
+  it('stops at the first package.json with a version (does not skip)', () => {
+    root = makeTree({
+      'package.json': JSON.stringify({ name: 'openaidy', version: '2.0.0' }),
+      'inner/package.json': JSON.stringify({ name: 'inner', version: '1.0.0' }),
+    });
+    const start = join(root, 'inner');
+    expect(resolveOpenAidyVersion(start)).toBe('1.0.0');
+  });
+
+  it('tolerates malformed package.json files and keeps walking', () => {
+    root = makeTree({
+      'package.json': JSON.stringify({ name: 'openaidy', version: '4.5.6' }),
+      'bad/package.json': '{not valid json',
+      'bad/leaf.txt': 'x',
+    });
+    const start = join(root, 'bad');
+    expect(resolveOpenAidyVersion(start)).toBe('4.5.6');
+  });
+
+  it('falls back to "0.0.0" when no package.json with a version is found', () => {
+    root = makeTree({
+      'package.json': JSON.stringify({ name: 'no-version' }),
+      'src/leaf.txt': 'x',
+    });
+    const start = join(root, 'src');
+    expect(resolveOpenAidyVersion(start)).toBe('0.0.0');
+  });
+
+  it('falls back to "0.0.0" when no package.json files exist at all', () => {
+    root = makeTree({
+      'a/b/c/leaf.txt': 'x',
+    });
+    const start = join(root, 'a/b/c');
+    expect(resolveOpenAidyVersion(start)).toBe('0.0.0');
+  });
+});

--- a/apps/server/src/lib/version.ts
+++ b/apps/server/src/lib/version.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for the OpenAidy version.
+ *
+ * Resolution algorithm: walk up from this server file's directory looking for
+ * the nearest `package.json` that has a `version` field. Return that version.
+ *
+ * Why walk-up?
+ *  - In dev (`pnpm dev`): server file is `apps/server/src/server.ts`. The walk
+ *    skips `apps/server/package.json` (no `version` field) and lands on the repo
+ *    root `package.json` which has `version: "0.3.0"`.
+ *  - In a packaged install (`npm i -g @openaidy/app`): server file is
+ *    `<install>/dist/server.mjs`. The walk lands on `<install>/package.json`
+ *    which has the package version.
+ *
+ * This is the ONLY code path that reads the version. No env vars, no compiled
+ * constants, no CLI injection. Bump `package.json`, restart, get the new
+ * version — no rebuild required.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FALLBACK_VERSION = '0.0.0';
+
+export function resolveOpenAidyVersion(startDir?: string): string {
+  const here = startDir ?? dirname(fileURLToPath(import.meta.url));
+  for (let dir = here; dirname(dir) !== dir; dir = dirname(dir)) {
+    const candidate = resolve(dir, 'package.json');
+    if (!existsSync(candidate)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as {
+        version?: unknown;
+      };
+      if (typeof pkg.version === 'string' && pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // malformed package.json — keep walking
+    }
+  }
+  return FALLBACK_VERSION;
+}
+
+/**
+ * OpenAidy version, resolved once at module load.
+ *
+ * Returned value is semver (`"0.3.0"`, no `v` prefix). The UI prepends `v` for
+ * display to match the GitHub release tag format.
+ */
+export const OPEN_AIDY_VERSION = resolveOpenAidyVersion();

--- a/apps/server/src/routes/info.test.ts
+++ b/apps/server/src/routes/info.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { infoRoutes } from './info';
+import { resolveOpenAidyVersion } from '../lib/version';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('GET /api/info', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  async function buildApp(): Promise<FastifyInstance> {
+    const a = Fastify({ logger: false });
+    // Mirror production: infoRoutes is registered inside the /api scope,
+    // so its declared route (/info) gets the /api prefix at registration time.
+    await a.register(
+      async (api) => {
+        await api.register(infoRoutes);
+      },
+      { prefix: '/api' },
+    );
+    await a.ready();
+    return a;
+  }
+
+  it('returns version, nodeVersion, platform, arch, pid, startedAt, uptimeMs', async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/info' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+
+    expect(typeof body['version']).toBe('string');
+    expect(typeof body['nodeVersion']).toBe('string');
+    expect(body['nodeVersion']).toBe(process.version);
+    expect(typeof body['platform']).toBe('string');
+    expect(body['platform']).toBe(process.platform);
+    expect(typeof body['arch']).toBe('string');
+    expect(body['arch']).toBe(process.arch);
+    expect(typeof body['pid']).toBe('number');
+    expect(body['pid']).toBe(process.pid);
+    expect(typeof body['startedAt']).toBe('string');
+    expect(new Date(body['startedAt'] as string).toString()).not.toBe(
+      'Invalid Date',
+    );
+    expect(typeof body['uptimeMs']).toBe('number');
+    expect(body['uptimeMs'] as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it('version field is semver without a "v" prefix', async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/info' });
+    const body = res.json() as { version: string };
+    expect(body.version.startsWith('v')).toBe(false);
+    // Looks like semver: major.minor.patch with optional pre-release / build
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('reflects the version from a package.json placed near the server file (no env var injection)', async () => {
+    // Build a temp package.json in a directory, then run the resolver from
+    // inside it. Proves the resolver does NOT read process.env.
+    const root = mkdtempSync(join(tmpdir(), 'openaidy-info-test-'));
+    const pkgDir = join(root, 'pkg');
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'openaidy', version: '7.7.7-test' }),
+      'utf-8',
+    );
+    const beforeEnv = process.env['npm_package_version'];
+    process.env['npm_package_version'] = '9.9.9-env-override';
+    try {
+      const resolved = resolveOpenAidyVersion(pkgDir);
+      expect(resolved).toBe('7.7.7-test');
+      expect(resolved).not.toBe('9.9.9-env-override');
+    } finally {
+      if (beforeEnv === undefined) delete process.env['npm_package_version'];
+      else process.env['npm_package_version'] = beforeEnv;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to "0.0.0" when no package.json with version is reachable', async () => {
+    // This is hard to test directly without isolating the import.meta.url of
+    // the version module. The unit test for resolveOpenAidyVersion covers the
+    // fallback in detail; here we just assert the field is a string.
+    app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/info' });
+    const body = res.json() as { version: string };
+    expect(typeof body.version).toBe('string');
+    expect(body.version.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/src/routes/info.ts
+++ b/apps/server/src/routes/info.ts
@@ -1,0 +1,38 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { OPEN_AIDY_VERSION } from '../lib/version';
+
+/**
+ * Build / runtime info exposed to the web client.
+ *
+ * Returned values:
+ *  - version: semver only ("0.3.0", no "v" prefix). The UI prepends "v" for
+ *    display to match the GitHub release tag format.
+ *  - nodeVersion, platform, arch: standard runtime introspection.
+ *  - pid: the server's PID, useful for support requests.
+ *  - startedAt: ISO timestamp of when the server booted.
+ *  - uptimeMs: milliseconds since boot.
+ */
+export interface AppInfo {
+  version: string;
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+  pid: number;
+  startedAt: string;
+  uptimeMs: number;
+}
+
+export const infoRoutes: FastifyPluginAsync = async (app) => {
+  app.get(
+    '/info',
+    async (): Promise<AppInfo> => ({
+      version: OPEN_AIDY_VERSION,
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      uptimeMs: Math.round(process.uptime() * 1000),
+    }),
+  );
+};

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -3,7 +3,13 @@ import { Save } from 'lucide-solid';
 import type { AppConfig, RewiredAgentNotice } from '../../lib/api';
 import { useConfig } from './hooks/useConfig';
 import { SaveMessage, Tabs, type Tab } from '../ui';
-import { DefaultsTab, ProvidersTab, AgentsTab, RawJsonTab } from './tabs';
+import {
+  DefaultsTab,
+  ProvidersTab,
+  AgentsTab,
+  RawJsonTab,
+  AboutTab,
+} from './tabs';
 import type { ConfigTab } from './types';
 
 const tabs: { id: ConfigTab; label: string }[] = [
@@ -11,6 +17,7 @@ const tabs: { id: ConfigTab; label: string }[] = [
   { id: 'providers', label: 'Providers' },
   { id: 'agents', label: 'Agents' },
   { id: 'raw', label: 'Raw JSON' },
+  { id: 'about', label: 'About' },
 ];
 
 export function SettingsView() {
@@ -321,6 +328,11 @@ export function SettingsView() {
                   setHasChanges(true);
                 }}
               />
+            </Show>
+
+            {/* About Tab */}
+            <Show when={activeTab() === 'about'}>
+              <AboutTab />
             </Show>
           </Show>
         </div>

--- a/apps/web/src/components/settings/tabs/AboutTab.test.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@solidjs/testing-library';
+import { AboutTab } from './AboutTab';
+import * as api from '../../../lib/api';
+
+vi.mock('../../../lib/api', () => ({
+  fetchAppInfo: vi.fn(),
+}));
+
+const sampleInfo: api.AppInfo = {
+  version: '0.3.0',
+  nodeVersion: 'v22.13.0',
+  platform: 'linux',
+  arch: 'x64',
+  pid: 4242,
+  startedAt: '2026-07-11T10:00:00.000Z',
+  uptimeMs: 12_345,
+};
+
+describe('AboutTab', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the version with the "v" prefix once info loads', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    render(() => <AboutTab />);
+    // The big version heading is the first match.
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+  });
+
+  it('renders node, platform/arch, pid, uptime once info loads', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    render(() => <AboutTab />);
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText('v22.13.0')).toBeInTheDocument();
+    expect(screen.getByText('linux/x64')).toBeInTheDocument();
+    expect(screen.getByText('4242')).toBeInTheDocument();
+    // 12_345ms => "12s"
+    expect(screen.getByText('12s')).toBeInTheDocument();
+  });
+
+  it('builds a GitHub release link that matches the displayed version', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    render(() => <AboutTab />);
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+    const link = screen.getByRole('link', { name: /view release on github/i });
+    expect(link.getAttribute('href')).toBe(
+      'https://github.com/imzodev/openaidy/releases/tag/v0.3.0',
+    );
+  });
+
+  it('copies a debug block to the clipboard that uses the "v" prefix', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(() => <AboutTab />);
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /copy debug info/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    const payload = writeText.mock.calls[0]?.[0] as string;
+    expect(payload).toContain('OpenAidy v0.3.0');
+    expect(payload).toContain('Node v22.13.0');
+    expect(payload).toContain('linux/x64');
+    expect(payload).toContain('PID 4242');
+  });
+
+  // Note: the error/retry path is not unit-tested here because Solid's
+  // createResource has tricky timing around promise rejection in jsdom —
+  // the production error UI (red banner + Retry button) is straightforward
+  // to verify by manual smoke test. The success path and refetch are
+  // covered above.
+
+  it('Refresh button triggers a refetch', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    render(() => <AboutTab />);
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+
+    expect(api.fetchAppInfo).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    await waitFor(() => expect(api.fetchAppInfo).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/components/settings/tabs/AboutTab.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.tsx
@@ -1,0 +1,171 @@
+import { createResource, createSignal, Show } from 'solid-js';
+import { Copy, RefreshCw } from 'lucide-solid';
+import { fetchAppInfo, type AppInfo } from '../../../lib/api';
+
+const RELEASES_URL = 'https://github.com/imzodev/openaidy/releases';
+
+/**
+ * Format an uptime duration (ms) as a compact human string.
+ * Examples: "12s", "3m 14s", "1h 27m", "2d 4h".
+ */
+function formatUptime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+function buildDebugBlock(info: AppInfo): string {
+  return [
+    `OpenAidy v${info.version}`,
+    `Node ${info.nodeVersion}`,
+    `Platform ${info.platform}/${info.arch}`,
+    `PID ${info.pid}`,
+    `Uptime ${formatUptime(info.uptimeMs)}`,
+    `Captured ${new Date().toISOString()}`,
+  ].join('\n');
+}
+
+export function AboutTab() {
+  const [info, { refetch }] = createResource(fetchAppInfo);
+  const [copied, setCopied] = createSignal(false);
+
+  const handleCopy = async () => {
+    const value = info();
+    if (!value) return;
+    const text = buildDebugBlock(value);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1_500);
+    } catch {
+      // Clipboard not available (insecure context). Fall back to a visible
+      // textarea selection so the user can copy manually.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1_500);
+      } catch {
+        // ignore — user can still copy by hand
+      } finally {
+        document.body.removeChild(ta);
+      }
+    }
+  };
+
+  return (
+    <div class="p-6 max-w-2xl">
+      <h2 class="text-lg font-semibold text-text-primary mb-1">
+        About OpenAidy
+      </h2>
+      <p class="text-sm text-text-tertiary mb-6">
+        Build and runtime information for this OpenAidy instance.
+      </p>
+
+      <Show when={info.loading}>
+        <div class="text-text-tertiary">Loading version info…</div>
+      </Show>
+
+      <Show when={info.error}>
+        <div class="rounded-lg border border-red-300 bg-red-50 dark:bg-red-900/20 dark:border-red-800 p-4">
+          <div class="text-red-700 dark:text-red-300 font-medium mb-2">
+            Unable to retrieve version info
+          </div>
+          <div class="text-sm text-red-600 dark:text-red-400 mb-3">
+            The server did not respond. It may be unreachable or restarting.
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-red-600 hover:bg-red-700 text-white text-sm"
+          >
+            <RefreshCw class="w-3.5 h-3.5" />
+            Retry
+          </button>
+        </div>
+      </Show>
+
+      <Show when={info()}>
+        {(data) => (
+          <>
+            <div class="mb-6">
+              <div class="text-xs uppercase tracking-wide text-text-tertiary mb-1">
+                Version
+              </div>
+              <div class="font-mono text-3xl font-semibold text-text-primary">
+                v{data().version}
+              </div>
+              <a
+                href={`${RELEASES_URL}/tag/v${data().version}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                class="inline-block mt-2 text-sm text-primary hover:text-primary-hover hover:underline"
+              >
+                View release on GitHub →
+              </a>
+            </div>
+
+            <dl class="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 text-sm mb-6">
+              <dt class="text-text-tertiary">Node</dt>
+              <dd class="font-mono text-text-primary">{data().nodeVersion}</dd>
+
+              <dt class="text-text-tertiary">Platform</dt>
+              <dd class="font-mono text-text-primary">
+                {data().platform}/{data().arch}
+              </dd>
+
+              <dt class="text-text-tertiary">PID</dt>
+              <dd class="font-mono text-text-primary">{data().pid}</dd>
+
+              <dt class="text-text-tertiary">Uptime</dt>
+              <dd class="font-mono text-text-primary">
+                {formatUptime(data().uptimeMs)}
+              </dd>
+
+              <dt class="text-text-tertiary">Started</dt>
+              <dd class="font-mono text-text-primary">
+                {new Date(data().startedAt).toLocaleString()}
+              </dd>
+            </dl>
+
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleCopy}
+                class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary hover:bg-primary-hover text-white text-sm disabled:opacity-50"
+              >
+                <Copy class="w-3.5 h-3.5" />
+                {copied() ? 'Copied!' : 'Copy debug info'}
+              </button>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 text-text-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-sm"
+              >
+                <RefreshCw class="w-3.5 h-3.5" />
+                Refresh
+              </button>
+            </div>
+
+            <p class="mt-6 text-xs text-text-tertiary">
+              The version is read directly from the server's{' '}
+              <code class="font-mono">package.json</code> at startup. The
+              display prefix <span class="font-mono">v</span> matches the GitHub
+              release tag (e.g. <span class="font-mono">v{data().version}</span>
+              ).
+            </p>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/tabs/index.ts
+++ b/apps/web/src/components/settings/tabs/index.ts
@@ -2,3 +2,4 @@ export { DefaultsTab } from './DefaultsTab';
 export { ProvidersTab } from './ProvidersTab';
 export { AgentsTab } from './AgentsTab';
 export { RawJsonTab } from './RawJsonTab';
+export { AboutTab } from './AboutTab';

--- a/apps/web/src/components/settings/types.ts
+++ b/apps/web/src/components/settings/types.ts
@@ -6,7 +6,7 @@ export type ConfigResponse =
 
 export { type ConfigStatus };
 
-export type ConfigTab = 'defaults' | 'providers' | 'agents' | 'raw';
+export type ConfigTab = 'defaults' | 'providers' | 'agents' | 'raw' | 'about';
 
 export type SaveMessage = {
   type: 'success' | 'error';

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -46,6 +46,7 @@ export type {
   ScheduleInput,
   CreatePulseBody,
   UpdatePulseBody,
+  AppInfo,
 } from './types';
 
 export type {
@@ -92,6 +93,7 @@ import type {
   PulseRun,
   CreatePulseBody,
   UpdatePulseBody,
+  AppInfo,
 } from './types';
 
 import type {
@@ -1295,4 +1297,17 @@ export async function disconnectProvider(providerId: string): Promise<void> {
     },
   );
   if (!res.ok) throw new Error(`disconnectProvider: ${res.status}`);
+}
+
+/**
+ * Fetch build / runtime info (version, node, platform, uptime).
+ * Returns the raw AppInfo shape — `version` is semver ("0.3.0", no "v");
+ * callers that want the GitHub-tag display format must prepend "v".
+ */
+export async function fetchAppInfo(): Promise<AppInfo> {
+  const response = await apiFetch(`${API_BASE}/api/info`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch app info: ${response.statusText}`);
+  }
+  return response.json();
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -517,3 +517,17 @@ export type {
   CreatePulseInput as CreatePulseBody,
   UpdatePulseInput as UpdatePulseBody,
 } from '@openaidy/shared-types';
+
+/**
+ * Build / runtime info exposed by GET /api/info.
+ * `version` is semver ("0.3.0", no "v"). The UI prepends "v" for display.
+ */
+export type AppInfo = {
+  version: string;
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+  pid: number;
+  startedAt: string;
+  uptimeMs: number;
+};


### PR DESCRIPTION
## What

Adds a Settings → **About** tab that displays the running OpenAidy version plus build/runtime info. The version is read with a single-source-of-truth resolver on the server and exposed via `GET /api/info`.

## Why

The version was invisible to users. The previous server-side read (`process.env.npm_package_version`) only worked when npm/pnpm spawned the process — `openaidy start` and packaged installs silently fell back to `"0.0.0"`, which also broke the addon manifest compatibility check (`AddonService.openAidyVersion`). Issue #385.

## Changes

**Server**
- `apps/server/src/lib/version.ts` — `resolveOpenAidyVersion()` walks up from `import.meta.url` looking for the nearest `package.json` with a `version` field. No env vars, no compiled constants.
- `apps/server/src/routes/info.ts` — `GET /api/info` returns `{ version, nodeVersion, platform, arch, pid, startedAt, uptimeMs }`. Unauthenticated (same disclosure level as `/health`).
- `apps/server/src/app.ts` — registers `infoRoutes` in the `/api` scope; uses `OPEN_AIDY_VERSION` instead of `process.env.npm_package_version`.

**Web**
- `apps/web/src/lib/types.ts` — `AppInfo` type.
- `apps/web/src/lib/api.ts` — `fetchAppInfo()` helper.
- `apps/web/src/components/settings/tabs/AboutTab.tsx` — new tab: big monospace `v0.3.0`, build info list, **Copy debug info** button, **View release on GitHub** link, Refresh button, retry-able error state.
- `apps/web/src/components/settings/tabs/index.ts` — exports `AboutTab`.
- `apps/web/src/components/settings/types.ts` — adds `'about'` to `ConfigTab`.
- `apps/web/src/components/settings/SettingsView.tsx` — registers the tab + renders it.

**Tests**
- `apps/server/src/lib/version.test.ts` — 6 tests covering walk-up, package.json without version, malformed JSON, fallback to `"0.0.0"`, etc.
- `apps/server/src/routes/info.test.ts` — 4 tests covering endpoint shape, semver-no-v invariant, and a guard test that proves the resolver does **not** read `npm_package_version` even when set.
- `apps/web/src/components/settings/tabs/AboutTab.test.tsx` — 5 tests covering render, build info display, GitHub link, copy-to-clipboard, refetch.

## Single-source-of-truth design

The version lives in **exactly one place**: the `package.json` of the package containing the running server. Both dev and packaged modes read it directly. The CLI does NOT inject `OPENAIDY_VERSION` and the build does NOT inline any compiled constant — if either of those is ever needed, the door to drift is open, so neither exists.

Bump `package.json`, restart, get the new version. No rebuild required.

## Display format

The server returns semver (`"0.3.0"`, no `v` prefix). The UI prepends `v` so the displayed value (`v0.3.0`) matches the GitHub release tag exactly. Copy debug info and the View on GitHub link use the same `vX.Y.Z` format.

## Verification

- ✅ `pnpm -r lint` — clean
- ✅ `tsc --noEmit` on `apps/server` and `apps/web` — clean
- ✅ Server tests in affected area: 33/33 (version resolver, info endpoint, addon manifest validator)
- ✅ Web tests in affected area: 30/30 (api + settings tabs including new AboutTab)

## Closes

Closes #385