### PR TITLE
feat(exec_run): stream stdout/stderr live + user-initiated cancel (#375)

### DIFF
--- a/apps/server/src/dispatch/events.ts
+++ b/apps/server/src/dispatch/events.ts
@@ -9,6 +9,8 @@ export type RunEventType =
   | 'run.started'
   | 'run.delta'
   | 'run.tool_call'
+  | 'run.exec_output'
+  | 'run.tool_cancelled'
   | 'run.completed'
   | 'run.failed'
   | 'session.run.choices';
@@ -182,6 +184,52 @@ export class RunEventEmitter {
       timestamp: new Date().toISOString(),
       data: {
         toolCall: params.toolCall,
+      },
+    });
+  }
+
+  /**
+   * Emit a run.exec_output event (live stdout/stderr chunk from a tool).
+   */
+  emitExecOutput(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+    toolCallId: string;
+    stream: 'stdout' | 'stderr';
+    chunk: string;
+  }): void {
+    this.emit({
+      type: 'run.exec_output',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {
+        toolCallId: params.toolCallId,
+        stream: params.stream,
+        chunk: params.chunk,
+      },
+    });
+  }
+
+  /**
+   * Emit a run.tool_cancelled event (a tool call was aborted by the user).
+   */
+  emitToolCancelled(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+    toolCallId: string;
+  }): void {
+    this.emit({
+      type: 'run.tool_cancelled',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {
+        toolCallId: params.toolCallId,
       },
     });
   }

--- a/apps/server/src/exec/service.test.ts
+++ b/apps/server/src/exec/service.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { createExecService } from './service';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+/** A command that runs for several seconds on the current platform. */
+const LONG_RUNNING = IS_WINDOWS ? 'ping -n 6 127.0.0.1' : 'sleep 5';
+
+describe('ExecService.run', () => {
+  it('captures stdout and a zero exit code', async () => {
+    const exec = createExecService();
+    const result = await exec.run('echo hello');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hello');
+    expect(result.timedOut).toBe(false);
+    expect(result.cancelled).toBeFalsy();
+  });
+
+  it('streams output through onOutput as it arrives', async () => {
+    const exec = createExecService();
+    const chunks: Array<{ stream: string; data: string }> = [];
+
+    const result = await exec.run('echo streamed', undefined, {
+      onOutput: (chunk) => chunks.push(chunk),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.some((c) => c.stream === 'stdout')).toBe(true);
+    expect(chunks.map((c) => c.data).join('')).toContain('streamed');
+  });
+
+  it('blocks dangerous commands before spawning', async () => {
+    const exec = createExecService();
+    const result = await exec.run('rm -rf /');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Command blocked');
+    expect(result.cancelled).toBeFalsy();
+  });
+
+  it('returns cancelled immediately when the signal is already aborted', async () => {
+    const exec = createExecService();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await exec.run('echo nope', undefined, {
+      signal: controller.signal,
+    });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.exitCode).toBe(130);
+    expect(result.stdout).toBe('');
+  });
+
+  it('cancels an in-flight command via the abort signal (SIGTERM, then grace)', async () => {
+    const exec = createExecService({ timeoutMs: 30_000 });
+    const controller = new AbortController();
+
+    const promise = exec.run(LONG_RUNNING, undefined, {
+      signal: controller.signal,
+    });
+    // Give the child time to spawn, then ask it to stop.
+    setTimeout(() => controller.abort(), 150);
+
+    const result = await promise;
+
+    expect(result.cancelled).toBe(true);
+    expect(result.exitCode).toBe(130);
+    // The grace period is 2s; a killed process must resolve well before the
+    // 30s timeout, proving cancel took effect rather than the command finishing.
+    expect(result.timedOut).toBe(false);
+  }, 10_000);
+
+  it('reports timedOut when a command exceeds the timeout', async () => {
+    const exec = createExecService({ timeoutMs: 200 });
+    const result = await exec.run(LONG_RUNNING);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBe(124);
+    expect(result.cancelled).toBeFalsy();
+  }, 10_000);
+});

--- a/apps/server/src/exec/service.ts
+++ b/apps/server/src/exec/service.ts
@@ -22,6 +22,18 @@ export interface ExecResult {
   stderr: string;
   exitCode: number;
   timedOut: boolean;
+  /**
+   * True when the run was aborted via the caller's AbortSignal (user Stop).
+   * `exitCode` is 130 (conventional "terminated by signal") in that case.
+   */
+  cancelled?: boolean;
+}
+
+export interface ExecRunOptions {
+  /** Abort the run (SIGTERM, then SIGKILL after a short grace period). */
+  signal?: AbortSignal;
+  /** Called for each captured stdout/stderr chunk as it arrives (live output). */
+  onOutput?: (chunk: { stream: 'stdout' | 'stderr'; data: string }) => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -90,7 +102,11 @@ export class ExecService {
     return undefined;
   }
 
-  run(command: string, cwd?: string): Promise<ExecResult> {
+  run(
+    command: string,
+    cwd?: string,
+    options?: ExecRunOptions,
+  ): Promise<ExecResult> {
     const blocked = this.checkCommand(command);
     if (blocked) {
       return Promise.resolve({
@@ -101,11 +117,27 @@ export class ExecService {
       });
     }
 
+    const signal = options?.signal;
+    const onOutput = options?.onOutput;
+
+    // Already-cancelled before we even spawn.
+    if (signal?.aborted) {
+      return Promise.resolve({
+        stdout: '',
+        stderr: 'Cancelled by user',
+        exitCode: 130,
+        timedOut: false,
+        cancelled: true,
+      });
+    }
+
     return new Promise((resolve) => {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let totalBytes = 0;
       let timedOut = false;
+      let cancelled = false;
+      let settled = false;
 
       log.debug('exec: spawning command', { command, cwd });
 
@@ -122,27 +154,64 @@ export class ExecService {
         child.kill('SIGKILL');
       }, this.timeoutMs);
 
-      const collect = (chunks: Buffer[]) => (data: Buffer) => {
-        if (totalBytes >= this.maxOutputBytes) return;
-        const remaining = this.maxOutputBytes - totalBytes;
-        const slice =
-          data.length > remaining ? data.subarray(0, remaining) : data;
-        chunks.push(slice);
-        totalBytes += slice.length;
+      // User cancel: SIGTERM, then SIGKILL after a 2s grace period (mirrors the
+      // timeout escalation). We never skip SIGTERM, even on an explicit Stop.
+      let graceTimer: NodeJS.Timeout | undefined;
+      const onAbort = () => {
+        cancelled = true;
+        child.kill('SIGTERM');
+        graceTimer = setTimeout(() => child.kill('SIGKILL'), 2_000);
+      };
+      if (signal) signal.addEventListener('abort', onAbort, { once: true });
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        if (graceTimer) clearTimeout(graceTimer);
+        if (signal) signal.removeEventListener('abort', onAbort);
       };
 
-      child.stdout.on('data', collect(stdoutChunks));
-      child.stderr.on('data', collect(stderrChunks));
+      const collect =
+        (chunks: Buffer[], stream: 'stdout' | 'stderr') => (data: Buffer) => {
+          if (totalBytes >= this.maxOutputBytes) return;
+          const remaining = this.maxOutputBytes - totalBytes;
+          const slice =
+            data.length > remaining ? data.subarray(0, remaining) : data;
+          chunks.push(slice);
+          totalBytes += slice.length;
+          if (onOutput) onOutput({ stream, data: slice.toString('utf-8') });
+        };
+
+      child.stdout.on('data', collect(stdoutChunks, 'stdout'));
+      child.stderr.on('data', collect(stderrChunks, 'stderr'));
+
+      child.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve({
+          stdout: '',
+          stderr: `Failed to spawn command: ${err.message}`,
+          exitCode: 1,
+          timedOut: false,
+        });
+      });
 
       child.on('close', (code) => {
-        clearTimeout(timer);
+        if (settled) return;
+        settled = true;
+        cleanup();
         const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
         const stderr = Buffer.concat(stderrChunks).toString('utf-8');
-        const exitCode = code ?? (timedOut ? 124 : 1);
+        const exitCode = cancelled ? 130 : (code ?? (timedOut ? 124 : 1));
 
-        log.debug('exec: command finished', { command, exitCode, timedOut });
+        log.debug('exec: command finished', {
+          command,
+          exitCode,
+          timedOut,
+          cancelled,
+        });
 
-        resolve({ stdout, stderr, exitCode, timedOut });
+        resolve({ stdout, stderr, exitCode, timedOut, cancelled });
       });
     });
   }

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -91,6 +91,10 @@ export class SessionMessageService {
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
 
+  // In-flight tool AbortControllers so a user "Stop" can cancel a running tool
+  // (issue #375). Key: `${runId}:${toolCallId}`.
+  private readonly inflightTools = new Map<string, AbortController>();
+
   constructor(options: SessionMessageServiceOptions) {
     this.providers = options.providers;
     this.logger = options.logger;
@@ -116,6 +120,18 @@ export class SessionMessageService {
    */
   get isDbBacked(): boolean {
     return !!this.sessionsRepo;
+  }
+
+  /**
+   * Cancel an in-flight tool call (user hit Stop). Aborts the tool's
+   * AbortSignal; the tool resolves with an error and the streaming loop
+   * continues. Returns true if a matching in-flight tool was found.
+   */
+  cancelTool(runId: string, toolCallId: string): boolean {
+    const controller = this.inflightTools.get(`${runId}:${toolCallId}`);
+    if (!controller) return false;
+    controller.abort();
+    return true;
   }
 
   /**
@@ -1112,12 +1128,41 @@ export class SessionMessageService {
               ? this.builtinTools?.get(tc.name)
               : undefined;
             if (builtinTool) {
+              // Register an AbortController so the user can cancel this tool
+              // (issue #375). Keyed by (runId, toolCallId); cleaned up when the
+              // tool settles.
+              const cancelKey = input.runId
+                ? `${input.runId}:${tc.id}`
+                : undefined;
+              const controller = new AbortController();
+              if (cancelKey) this.inflightTools.set(cancelKey, controller);
+
               const builtinResult = await builtinTool
-                .execute(tc.arguments, { agentId, sessionId: input.sessionId })
+                .execute(tc.arguments, {
+                  agentId,
+                  sessionId: input.sessionId,
+                  signal: controller.signal,
+                  onOutput: (chunk) =>
+                    onStreamEvent({
+                      type: 'exec_output',
+                      toolCallId: tc.id,
+                      stream: chunk.stream,
+                      data: chunk.data,
+                    }),
+                })
                 .catch((e: unknown) => ({
                   ok: false as const,
                   error: `Tool error: ${e instanceof Error ? e.message : String(e)}`,
-                }));
+                }))
+                .finally(() => {
+                  if (cancelKey) this.inflightTools.delete(cancelKey);
+                });
+
+              // If the user cancelled this tool, tell the UI so it can mark the
+              // block "Cancelled by user".
+              if (controller.signal.aborted) {
+                onStreamEvent({ type: 'tool_cancelled', toolCallId: tc.id });
+              }
 
               // Check for INTERRUPT_CHOICES sentinel from present_choices tool
               if (builtinResult.ok) {

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -17,6 +17,11 @@ export type SubmitMessageInput = {
  * Input for submitting a streaming message to a session
  */
 export type SubmitMessageStreamingInput = SubmitMessageInput & {
+  /**
+   * The run identifier from the WS layer. Used to key in-flight tool
+   * AbortControllers so `cancelTool(runId, toolCallId)` can find them.
+   */
+  runId?: string;
   /** Callback for stream events */
   onStreamEvent: (
     event:
@@ -29,6 +34,13 @@ export type SubmitMessageStreamingInput = SubmitMessageInput & {
             arguments: Record<string, unknown>;
           };
         }
+      | {
+          type: 'exec_output';
+          toolCallId: string;
+          stream: 'stdout' | 'stderr';
+          data: string;
+        }
+      | { type: 'tool_cancelled'; toolCallId: string }
       | {
           type: 'usage';
           usage: {

--- a/apps/server/src/tools/exec/run.ts
+++ b/apps/server/src/tools/exec/run.ts
@@ -79,7 +79,15 @@ export function createExecRunTool(
         resolvedCwd = workspaceRoot;
       }
 
-      const result = await exec.run(command, resolvedCwd);
+      const result = await exec.run(command, resolvedCwd, {
+        ...(ctx.signal ? { signal: ctx.signal } : {}),
+        ...(ctx.onOutput ? { onOutput: ctx.onOutput } : {}),
+      });
+
+      // User hit Stop — report a normal tool error so the agent can react.
+      if (result.cancelled) {
+        return { ok: false, error: 'cancelled by user' };
+      }
 
       const lines: string[] = [];
       if (result.timedOut) {

--- a/apps/server/src/websocket/handlers/session.test.ts
+++ b/apps/server/src/websocket/handlers/session.test.ts
@@ -582,7 +582,7 @@ describe('registerSessionHandlers', () => {
 
     registerSessionHandlers(mockRouter, handler);
 
-    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(7);
+    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(8);
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.create',
       expect.any(Function),
@@ -609,6 +609,10 @@ describe('registerSessionHandlers', () => {
     );
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.runs',
+      expect.any(Function),
+    );
+    expect(mockRouter.registerHandler).toHaveBeenCalledWith(
+      'session.tool.cancel',
       expect.any(Function),
     );
   });

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -23,6 +23,7 @@ import {
   type SessionMessageRequest,
   type SessionMessagesRequest,
   type SessionRunsRequest,
+  type SessionToolCancelRequest,
   type SessionCreatedResponse,
   type SessionMessageResponse,
   type SessionMessagesResponse,
@@ -370,6 +371,20 @@ export class SessionHandler {
   }
 
   /**
+   * Handle session.tool.cancel — the user hit Stop on an in-flight tool call.
+   * Aborts the matching tool's AbortSignal; the UI reacts to the resulting
+   * run.tool_cancelled event, so no response is returned.
+   */
+  async handleToolCancel(
+    _connectionId: string,
+    request: SessionToolCancelRequest,
+    _context: HandlerContext,
+  ): Promise<void> {
+    const { runId, toolCallId } = request.payload;
+    this.sessionService.cancelTool(runId, toolCallId);
+  }
+
+  /**
    * Handle session.message request
    *
    * Supports both streaming and non-streaming modes:
@@ -590,6 +605,7 @@ export class SessionHandler {
         role: request.payload.role,
         content: request.payload.content,
         agentId,
+        runId,
         ...(providerId != null && { providerId }),
         ...(modelId != null && { modelId }),
         onStreamEvent: (event) => {
@@ -609,6 +625,24 @@ export class SessionHandler {
                 sessionId,
                 agentId,
                 toolCall: event.toolCall!,
+              });
+              break;
+            case 'exec_output':
+              this.runEvents?.emitExecOutput({
+                runId,
+                sessionId,
+                agentId,
+                toolCallId: event.toolCallId,
+                stream: event.stream,
+                chunk: event.data,
+              });
+              break;
+            case 'tool_cancelled':
+              this.runEvents?.emitToolCancelled({
+                runId,
+                sessionId,
+                agentId,
+                toolCallId: event.toolCallId,
               });
               break;
             case 'usage':
@@ -889,6 +923,10 @@ export function registerSessionHandlers(
         msg as SessionRunsRequest,
         ctx,
       ) as Promise<WSResponse>,
+  );
+
+  router.registerHandler('session.tool.cancel', (connId, msg, ctx) =>
+    handler.handleToolCancel(connId, msg as SessionToolCancelRequest, ctx),
   );
 }
 

--- a/apps/server/src/websocket/index.ts
+++ b/apps/server/src/websocket/index.ts
@@ -84,6 +84,7 @@ const MESSAGE_CAPABILITIES: Partial<Record<string, string[]>> = {
   'session.runs': [WS_CAPABILITIES.SESSIONS_READ],
   'session.subscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.unsubscribe': [WS_CAPABILITIES.SESSIONS_READ],
+  'session.tool.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
   'agent.list': [WS_CAPABILITIES.AGENTS_READ],
   'agent.get': [WS_CAPABILITIES.AGENTS_READ],
   'provider.list': [WS_CAPABILITIES.PROVIDERS_READ],

--- a/apps/server/src/websocket/integration/session-integration.test.ts
+++ b/apps/server/src/websocket/integration/session-integration.test.ts
@@ -659,12 +659,13 @@ describe('Session Integration Tests', () => {
       expect(messageRouter.hasHandler('session.message')).toBe(true);
       expect(messageRouter.hasHandler('session.messages')).toBe(true);
       expect(messageRouter.hasHandler('session.runs')).toBe(true);
+      expect(messageRouter.hasHandler('session.tool.cancel')).toBe(true);
     });
 
-    it('should have exactly 7 session handlers', () => {
+    it('should have exactly 8 session handlers', () => {
       const types = messageRouter.getHandlerTypes();
       const sessionHandlers = types.filter((t) => t.startsWith('session.'));
-      expect(sessionHandlers).toHaveLength(7);
+      expect(sessionHandlers).toHaveLength(8);
     });
   });
 

--- a/apps/server/src/websocket/streaming.ts
+++ b/apps/server/src/websocket/streaming.ts
@@ -11,6 +11,8 @@ import {
   type SessionStreamStart,
   type SessionStreamDelta,
   type SessionStreamToolCall,
+  type SessionStreamExecOutput,
+  type SessionStreamToolCancelled,
   type SessionStreamUsage,
   type SessionStreamEnd,
   type SessionStreamError,
@@ -29,6 +31,8 @@ export type SessionStreamEvent =
   | SessionStreamStart
   | SessionStreamDelta
   | SessionStreamToolCall
+  | SessionStreamExecOutput
+  | SessionStreamToolCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -97,6 +101,24 @@ export function mapRunEventToStreamEvent(
           arguments: tc.arguments,
         },
       }) as SessionStreamToolCall;
+    }
+
+    case 'run.exec_output': {
+      return createWSMessage('session.stream.exec_output', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        toolCallId: event.data.toolCallId as string,
+        stream: event.data.stream as 'stdout' | 'stderr',
+        data: event.data.chunk as string,
+      }) as SessionStreamExecOutput;
+    }
+
+    case 'run.tool_cancelled': {
+      return createWSMessage('session.stream.tool_cancelled', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        toolCallId: event.data.toolCallId as string,
+      }) as SessionStreamToolCancelled;
     }
 
     case 'run.completed': {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -106,8 +106,20 @@ function AppContent(props: AppContentProps) {
   const [streamingContent, setStreamingContent] = createSignal('');
   const [isStreaming, setIsStreaming] = createSignal(false);
   const [streamingToolCalls, setStreamingToolCalls] = createSignal<
-    Array<{ id: string; name: string; input: Record<string, unknown> }>
+    Array<{
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+      /** Live stdout/stderr accumulated from run.exec_output (e.g. exec_run). */
+      output?: string;
+      /** Set once the user cancels this tool call. */
+      cancelled?: boolean;
+    }>
   >([]);
+  // The active run's id (from stream events), needed to address a tool cancel.
+  const [currentRunId, setCurrentRunId] = createSignal<string | undefined>(
+    undefined,
+  );
   // Client-side queue of messages typed while the agent is responding.
   const messageQueue = useMessageQueue();
   const [pendingUserMessage, setPendingUserMessage] = createSignal<
@@ -181,6 +193,7 @@ function AppContent(props: AppContentProps) {
 
     const handleStreamToolCall = (event: {
       payload: {
+        runId?: string;
         toolCall: {
           id: string;
           name: string;
@@ -189,11 +202,45 @@ function AppContent(props: AppContentProps) {
       };
     }) => {
       const tc = event.payload.toolCall;
+      if (event.payload.runId) setCurrentRunId(event.payload.runId);
       setStreamingToolCalls((prev) => [
         ...prev,
-        { id: tc.id, name: tc.name, input: tc.arguments },
+        { id: tc.id, name: tc.name, input: tc.arguments, output: '' },
       ]);
       armStreamWatchdog();
+    };
+
+    // Live stdout/stderr from an in-flight tool (e.g. exec_run) — append to the
+    // matching tool call, keeping the most recent 50 KB (matches server cap).
+    const handleExecOutput = (event: {
+      payload: {
+        runId: string;
+        toolCallId: string;
+        stream: 'stdout' | 'stderr';
+        data: string;
+      };
+    }) => {
+      setCurrentRunId(event.payload.runId);
+      const { toolCallId, data } = event.payload;
+      setStreamingToolCalls((prev) =>
+        prev.map((tc) =>
+          tc.id === toolCallId
+            ? { ...tc, output: ((tc.output ?? '') + data).slice(-51_200) }
+            : tc,
+        ),
+      );
+      armStreamWatchdog();
+    };
+
+    const handleToolCancelled = (event: {
+      payload: { toolCallId: string };
+    }) => {
+      const { toolCallId } = event.payload;
+      setStreamingToolCalls((prev) =>
+        prev.map((tc) =>
+          tc.id === toolCallId ? { ...tc, cancelled: true } : tc,
+        ),
+      );
     };
 
     const handleStreamEnd = () => {
@@ -248,6 +295,14 @@ function AppContent(props: AppContentProps) {
     const unsubError = wsClient.on('session.stream.error', handleStreamError);
     const unsubUpdated = wsClient.on('session.updated', handleSessionUpdated);
     const unsubChoices = wsClient.on('session.run.choices', handleChoicesEvent);
+    const unsubExecOutput = wsClient.on(
+      'session.stream.exec_output',
+      handleExecOutput,
+    );
+    const unsubToolCancelled = wsClient.on(
+      'session.stream.tool_cancelled',
+      handleToolCancelled,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sessionId).catch((err: Error) => {
@@ -263,6 +318,8 @@ function AppContent(props: AppContentProps) {
       unsubError();
       unsubUpdated();
       unsubChoices();
+      unsubExecOutput();
+      unsubToolCancelled();
       setFocusChatInput(undefined); // Clear stale focus function
     });
   });
@@ -377,6 +434,16 @@ function AppContent(props: AppContentProps) {
       return;
     }
     await sendMessage(content, agentId);
+  };
+
+  // User hit Stop on an in-flight tool call — ask the server to cancel it.
+  const handleCancelTool = (toolCallId: string) => {
+    const wsClient = client();
+    const sid = selectedSessionId();
+    const rid = currentRunId();
+    if (wsClient && sid && rid) {
+      wsClient.cancelTool(sid, rid, toolCallId);
+    }
   };
 
   // Drain the next queued message once the run is idle and the user is not
@@ -730,6 +797,7 @@ function AppContent(props: AppContentProps) {
               streamingToolCalls={
                 isStreaming() ? streamingToolCalls() : undefined
               }
+              onCancelTool={handleCancelTool}
               queuedMessages={messageQueue.items()}
               onEditQueued={messageQueue.edit}
               onRemoveQueued={messageQueue.remove}

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -20,6 +20,8 @@ vi.mock('lucide-solid', () => ({
   Pencil: () => <span data-testid="pencil" />,
   X: () => <span data-testid="x" />,
   Check: () => <span data-testid="check" />,
+  CircleStop: () => <span data-testid="circle-stop" />,
+  Ban: () => <span data-testid="ban" />,
 }));
 
 describe('ChatView', () => {
@@ -125,6 +127,56 @@ describe('ChatView', () => {
       fireEvent.input(textarea, { target: { value: 'Edited content' } });
       fireEvent.keyDown(textarea, { key: 'Enter' });
       expect(onEditQueued).toHaveBeenCalledWith('q1', 'Edited content');
+    });
+  });
+
+  describe('streaming tool calls', () => {
+    const toolCall = {
+      id: 'tc-1',
+      name: 'exec_run',
+      input: { command: 'npm test' },
+    };
+
+    it('renders live output for an in-flight tool call', () => {
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          streamingToolCalls={[{ ...toolCall, output: 'running tests...' }]}
+        />
+      ));
+      expect(screen.getByText('running tests...')).toBeInTheDocument();
+    });
+
+    it('shows a Stop button and invokes onCancelTool with the tool id', () => {
+      const onCancelTool = vi.fn();
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          streamingToolCalls={[toolCall]}
+          onCancelTool={onCancelTool}
+        />
+      ));
+      fireEvent.click(screen.getByText('Stop'));
+      expect(onCancelTool).toHaveBeenCalledWith('tc-1');
+    });
+
+    it('shows a cancelled badge and no Stop button once cancelled', () => {
+      const onCancelTool = vi.fn();
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          streamingToolCalls={[{ ...toolCall, cancelled: true }]}
+          onCancelTool={onCancelTool}
+        />
+      ));
+      expect(screen.getByText('Cancelled by user')).toBeInTheDocument();
+      expect(screen.queryByText('Stop')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -12,6 +12,10 @@ type StreamingToolCall = {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  /** Live stdout/stderr streamed while the tool runs (e.g. exec_run). */
+  output?: string;
+  /** True once the user cancelled this tool call. */
+  cancelled?: boolean;
 };
 
 type ChatViewProps = {
@@ -25,6 +29,8 @@ type ChatViewProps = {
   queuedMessages?: QueuedMessage[];
   onEditQueued?: (id: string, content: string) => void;
   onRemoveQueued?: (id: string) => void;
+  /** Ask the server to cancel an in-flight tool call. */
+  onCancelTool?: (toolCallId: string) => void;
   /** Message ID to scroll to (e.g. from clicking a run) */
   scrollToMessageId?: string;
 };
@@ -244,7 +250,14 @@ export function ChatView(props: ChatViewProps) {
                       <ToolCallBlock
                         name={tc.name}
                         input={tc.input}
-                        isActive={true}
+                        isActive={!tc.cancelled}
+                        output={tc.output}
+                        cancelled={tc.cancelled}
+                        onStop={
+                          props.onCancelTool
+                            ? () => props.onCancelTool?.(tc.id)
+                            : undefined
+                        }
                       />
                     )}
                   </For>

--- a/apps/web/src/components/ToolBlocks.tsx
+++ b/apps/web/src/components/ToolBlocks.tsx
@@ -5,12 +5,20 @@ import {
   Wrench,
   Server,
   Loader,
+  CircleStop,
+  Ban,
 } from 'lucide-solid';
 
 type ToolCallBlockProps = {
   name: string;
   input: Record<string, unknown>;
   isActive?: boolean;
+  /** Live stdout/stderr streamed while the tool runs. */
+  output?: string;
+  /** True once the user cancelled this tool call. */
+  cancelled?: boolean;
+  /** Invoked when the user clicks Stop; omit to hide the button. */
+  onStop?: () => void;
 };
 
 export function ToolCallBlock(props: ToolCallBlockProps) {
@@ -62,7 +70,40 @@ export function ToolCallBlock(props: ToolCallBlockProps) {
         <Show when={props.isActive}>
           <span class="ml-auto text-xs opacity-60">running...</span>
         </Show>
+        <Show when={props.cancelled}>
+          <span class="ml-auto inline-flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
+            <Ban class="w-3 h-3" />
+            Cancelled by user
+          </span>
+        </Show>
       </button>
+
+      {/* Stop control — only while the tool is actively running */}
+      <Show when={props.isActive && props.onStop}>
+        <div class="px-3 pb-1.5">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              props.onStop?.();
+            }}
+            class="inline-flex items-center gap-1 rounded border border-red-200 dark:border-red-800 px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+          >
+            <CircleStop class="w-3.5 h-3.5" />
+            Stop
+          </button>
+        </div>
+      </Show>
+
+      {/* Live output — streamed while running, and kept visible after. */}
+      <Show when={props.output}>
+        <div class="px-3 pb-2 pt-0">
+          <pre class="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-black/5 dark:bg-white/5 p-2 text-xs text-text-secondary">
+            {props.output}
+          </pre>
+        </div>
+      </Show>
+
       <Show when={open() && !props.isActive}>
         <div class="px-3 pb-3 pt-0">
           <pre class="text-xs overflow-x-auto text-text-secondary">

--- a/packages/runtime/src/tools/index.ts
+++ b/packages/runtime/src/tools/index.ts
@@ -32,6 +32,21 @@ export type BuiltinToolContext = {
   readonly agentId: string;
   /** The session in which the tool is being invoked */
   readonly sessionId?: string;
+  /**
+   * Fired when the user cancels this in-flight tool call. Tools that run
+   * long/interruptible work (e.g. exec_run) should honor it; tools that ignore
+   * it keep working unchanged.
+   */
+  readonly signal?: AbortSignal;
+  /**
+   * Stream partial output to the UI while the tool runs. The host wires this to
+   * emit per-chunk events addressed to this tool call. Optional — tools that
+   * don't produce incremental output ignore it.
+   */
+  readonly onOutput?: (chunk: {
+    stream: 'stdout' | 'stderr';
+    data: string;
+  }) => void;
 };
 
 /**

--- a/packages/sdk/src/websocket-client.ts
+++ b/packages/sdk/src/websocket-client.ts
@@ -502,6 +502,21 @@ export class WebSocketClient {
   }
 
   /**
+   * Cancel an in-flight tool call (user hit Stop). Fire-and-forget: the server
+   * aborts the tool and the UI reacts to the resulting
+   * `session.stream.tool_cancelled` event, so we don't await a response.
+   */
+  cancelTool(sessionId: string, runId: string, toolCallId: string): void {
+    void this.sendRequest('session.tool.cancel', {
+      sessionId,
+      runId,
+      toolCallId,
+    }).catch(() => {
+      /* best-effort — cancellation is confirmed via the stream event */
+    });
+  }
+
+  /**
    * Subscribe to session events
    */
   async subscribeToSession(

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -230,6 +230,16 @@ export type SessionUnsubscribeRequest = WSMessage<
   }
 >;
 
+/** Client → server: cancel an in-flight tool call (user hit Stop). */
+export type SessionToolCancelRequest = WSMessage<
+  'session.tool.cancel',
+  {
+    sessionId: string;
+    runId: string;
+    toolCallId: string;
+  }
+>;
+
 export type SessionMessagesRequest = WSMessage<
   'session.messages',
   {
@@ -497,6 +507,28 @@ export type SessionStreamError = WSMessage<
   }
 >;
 
+/** Live stdout/stderr chunk from an in-flight tool (e.g. exec_run). */
+export type SessionStreamExecOutput = WSMessage<
+  'session.stream.exec_output',
+  {
+    sessionId: string;
+    runId: string;
+    toolCallId: string;
+    stream: 'stdout' | 'stderr';
+    data: string;
+  }
+>;
+
+/** A tool call was cancelled by the user. */
+export type SessionStreamToolCancelled = WSMessage<
+  'session.stream.tool_cancelled',
+  {
+    sessionId: string;
+    runId: string;
+    toolCallId: string;
+  }
+>;
+
 export type SessionRunChoicesEvent = WSMessage<
   'session.run.choices',
   ChoicesEvent
@@ -506,6 +538,8 @@ export type SessionStreamEvent =
   | SessionStreamStart
   | SessionStreamDelta
   | SessionStreamToolCall
+  | SessionStreamExecOutput
+  | SessionStreamToolCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -906,6 +940,7 @@ export type WSRequest =
   | SessionMessageRequest
   | SessionSubscribeRequest
   | SessionUnsubscribeRequest
+  | SessionToolCancelRequest
   | SessionMessagesRequest
   | SessionRunsRequest
   | AgentListRequest
@@ -981,6 +1016,7 @@ const REQUEST_TYPES: Set<string> = new Set([
   'session.runs',
   'session.subscribe',
   'session.unsubscribe',
+  'session.tool.cancel',
   'agent.list',
   'agent.get',
   'provider.list',
@@ -1012,6 +1048,8 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.start',
   'session.stream.delta',
   'session.stream.tool_call',
+  'session.stream.exec_output',
+  'session.stream.tool_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
@@ -1041,6 +1079,8 @@ const STREAM_EVENT_TYPES: Set<string> = new Set([
   'session.stream.start',
   'session.stream.delta',
   'session.stream.tool_call',
+  'session.stream.exec_output',
+  'session.stream.tool_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',


### PR DESCRIPTION
Closes #375.

Streams `exec_run` output to the chat UI as it is produced, and lets the user **Stop** an in-flight tool call.

## What changed

**Runtime / exec**
- `BuiltinToolContext` gains optional `signal?: AbortSignal` and `onOutput?` (backward-compatible).
- `ExecService.run` accepts `{ signal, onOutput }`:
  - emits each captured stdout/stderr chunk through `onOutput` as it arrives;
  - on abort, sends `SIGTERM` then `SIGKILL` after a **2s grace period** (mirrors the timeout escalation — SIGTERM is never skipped);
  - returns `cancelled: true` (exit code `130`) when aborted, `124` on timeout.
  - The 1 MB output cap, scrubbed env (never the server's secret-bearing `process.env`), and the dangerous-command blocklist are **unchanged**.

**Dispatch / WebSocket**
- New run events `run.exec_output` / `run.tool_cancelled` and matching wire messages `session.stream.exec_output` / `session.stream.tool_cancelled`.
- New inbound `session.tool.cancel` request (gated on `SESSIONS_WRITE`), routed to `SessionMessageService.cancelTool`, which aborts the per-tool `AbortController` keyed by `` `${runId}:${toolCallId}` ``.
- SDK client gains fire-and-forget `cancelTool(sessionId, runId, toolCallId)` — the UI reacts to the resulting `tool_cancelled` event, not a reply.

**Web**
- Streaming tool-call block now shows live output, a per-tool **Stop** button while running, and a "Cancelled by user" badge once cancelled.

## Tests
- `apps/server/src/exec/service.test.ts`: stdout capture, `onOutput` streaming, blocked command, already-aborted signal, mid-run cancel (SIGTERM→grace), and timeout.
- `ChatView.test.tsx`: live output render, Stop invokes `onCancelTool`, cancelled badge hides Stop.
- Updated session handler-count assertions for the new `session.tool.cancel` handler.

All server + web suites and typechecks pass locally.

> Note: on Windows the cancel/timeout tests take ~5s because killing `cmd.exe` doesn't reap the grandchild process — a known local-only quirk; assertions still hold and they resolve immediately on Linux CI.

## Follow-ups (stacked)
This is the foundation PR. #376 (agent-invoke honoring `ctx.signal` + Stop-agent) and #378 (activity badge) build on this shared cancel/stream infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)