### PR TITLE
feat(cancel): cancel agents_invoke_await + Stop-agent aborts the whole turn (#376)

### DIFF
--- a/apps/server/src/dispatch/events.ts
+++ b/apps/server/src/dispatch/events.ts
@@ -11,6 +11,7 @@ export type RunEventType =
   | 'run.tool_call'
   | 'run.exec_output'
   | 'run.tool_cancelled'
+  | 'run.cancelled'
   | 'run.completed'
   | 'run.failed'
   | 'session.run.choices';
@@ -231,6 +232,24 @@ export class RunEventEmitter {
       data: {
         toolCallId: params.toolCallId,
       },
+    });
+  }
+
+  /**
+   * Emit a run.cancelled event (the whole run was aborted by the user).
+   */
+  emitRunCancelled(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+  }): void {
+    this.emit({
+      type: 'run.cancelled',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {},
     });
   }
 

--- a/apps/server/src/providers/infrastructure/anthropic/adapter.test.ts
+++ b/apps/server/src/providers/infrastructure/anthropic/adapter.test.ts
@@ -186,7 +186,10 @@ describe('AnthropicProvider', () => {
       });
 
       const provider = createAnthropicProvider({ apiKey: 'my-api-key' });
-      await provider.invoke({ model: 'claude-sonnet-4-20250514', messages: [{ role: 'user', content: 'Hi' }] });
+      await provider.invoke({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
@@ -195,7 +198,7 @@ describe('AnthropicProvider', () => {
             'x-api-key': 'my-api-key',
             'anthropic-version': expect.any(String),
           }),
-        })
+        }),
       );
     });
 
@@ -208,7 +211,9 @@ describe('AnthropicProvider', () => {
       const request: ModelRequest = {
         model: 'claude-sonnet-4-20250514',
         messages: [{ role: 'user', content: 'Hello' }],
-        tools: [{ name: 'test', description: 'Test', parameters: { type: 'object' } }],
+        tools: [
+          { name: 'test', description: 'Test', parameters: { type: 'object' } },
+        ],
       };
 
       const result = await provider.invoke(request);
@@ -229,8 +234,8 @@ describe('AnthropicProvider', () => {
             status: 429,
             statusText: 'Too Many Requests',
             headers: { 'Content-Type': 'application/json' },
-          }
-        )
+          },
+        ),
       );
 
       const provider = createAnthropicProvider({ apiKey: 'test-key' });
@@ -253,7 +258,12 @@ describe('AnthropicProvider', () => {
           type: 'message',
           role: 'assistant',
           content: [
-            { type: 'tool_use', id: 'toolu_1', name: 'get_weather', input: { city: 'Berlin' } },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'get_weather',
+              input: { city: 'Berlin' },
+            },
           ],
           model: 'claude-sonnet-4-20250514',
           stop_reason: 'tool_use',
@@ -298,6 +308,68 @@ describe('AnthropicProvider', () => {
       if (firstEvent && !firstEvent.ok) {
         expect(firstEvent.error.code).toBe('provider.capability_unsupported');
       }
+    });
+
+    it('aborts the fetch when the external request signal aborts (#376)', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+        headers: new Headers(),
+      });
+
+      const provider = createAnthropicProvider({ apiKey: 'test-key' });
+      const external = new AbortController();
+
+      const events = [];
+      for await (const event of provider.invokeStream({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hello' }],
+        signal: external.signal,
+      })) {
+        events.push(event);
+      }
+
+      // The signal handed to fetch is a combined signal, distinct from the
+      // external one, but aborting the external must propagate to it.
+      const passedSignal = mockFetch.mock.calls[0]?.[1]?.signal as AbortSignal;
+      expect(passedSignal).toBeInstanceOf(AbortSignal);
+      expect(passedSignal.aborted).toBe(false);
+      external.abort();
+      expect(passedSignal.aborted).toBe(true);
+    });
+
+    it('passes an already-aborted external signal through to fetch (#376)', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+        headers: new Headers(),
+      });
+
+      const provider = createAnthropicProvider({ apiKey: 'test-key' });
+      const external = new AbortController();
+      external.abort();
+
+      const events = [];
+      for await (const event of provider.invokeStream({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hello' }],
+        signal: external.signal,
+      })) {
+        events.push(event);
+      }
+
+      const passedSignal = mockFetch.mock.calls[0]?.[1]?.signal as AbortSignal;
+      expect(passedSignal.aborted).toBe(true);
     });
 
     it('should stream model output', async () => {
@@ -354,7 +426,10 @@ describe('Factory functions', () => {
   });
 
   it('createClaudeModelProvider should create provider with specific model', () => {
-    const provider = createClaudeModelProvider('test-key', 'claude-opus-4-20250514');
+    const provider = createClaudeModelProvider(
+      'test-key',
+      'claude-opus-4-20250514',
+    );
 
     expect(provider.descriptor.id).toBe('anthropic-claude-opus-4-20250514');
     expect(provider.descriptor.name).toBe('Anthropic claude-opus-4-20250514');

--- a/apps/server/src/providers/infrastructure/anthropic/adapter.ts
+++ b/apps/server/src/providers/infrastructure/anthropic/adapter.ts
@@ -54,7 +54,10 @@ const PROVIDER_NAME = 'Anthropic';
 /**
  * Common Anthropic models with their capabilities
  */
-const KNOWN_MODELS: Record<string, { name: string; capabilities: ProviderCapability[] }> = {
+const KNOWN_MODELS: Record<
+  string,
+  { name: string; capabilities: ProviderCapability[] }
+> = {
   'claude-opus-4-20250514': {
     name: 'Claude Opus 4',
     capabilities: ['text_generation', 'streaming', 'tool_calls', 'vision'],
@@ -146,12 +149,14 @@ export class AnthropicProvider implements ModelProvider {
   async listModels(): Promise<ProviderResult<readonly ModelDescriptor[]>> {
     // Anthropic doesn't have a list models endpoint
     // Return known models based on documentation
-    const models: ModelDescriptor[] = Object.entries(KNOWN_MODELS).map(([id, info]) => ({
-      id,
-      providerId: this.descriptor.id,
-      name: info.name,
-      capabilities: this.buildModelCapabilities(info.capabilities),
-    }));
+    const models: ModelDescriptor[] = Object.entries(KNOWN_MODELS).map(
+      ([id, info]) => ({
+        id,
+        providerId: this.descriptor.id,
+        name: info.name,
+        capabilities: this.buildModelCapabilities(info.capabilities),
+      }),
+    );
 
     // Add default model if not in known list
     if (!models.find((m) => m.id === this.config.defaultModel)) {
@@ -184,16 +189,22 @@ export class AnthropicProvider implements ModelProvider {
       id: modelId,
       providerId: this.descriptor.id,
       name: modelId,
-      capabilities: this.buildModelCapabilities(['text_generation', 'streaming']),
+      capabilities: this.buildModelCapabilities([
+        'text_generation',
+        'streaming',
+      ]),
     });
   }
 
   private buildModelCapabilities(
-    modelCaps: ProviderCapability[]
+    modelCaps: ProviderCapability[],
   ): ProviderCapability[] {
     const caps: ProviderCapability[] = ['text_generation'];
 
-    if (modelCaps.includes('streaming') && this.config.enableStreaming !== false) {
+    if (
+      modelCaps.includes('streaming') &&
+      this.config.enableStreaming !== false
+    ) {
       caps.push('streaming');
     }
     if (modelCaps.includes('tool_calls') && this.config.enableTools !== false) {
@@ -220,33 +231,40 @@ export class AnthropicProvider implements ModelProvider {
 
   async invoke(request: ModelRequest): Promise<ProviderResult<ModelResponse>> {
     // Check capabilities
-    if (request.tools && request.tools.length > 0 && !this.hasCapability('tool_calls')) {
+    if (
+      request.tools &&
+      request.tools.length > 0 &&
+      !this.hasCapability('tool_calls')
+    ) {
       return err(
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${this.descriptor.id}" does not support tool calls`,
-          { providerId: this.descriptor.id, modelId: request.model }
-        )
+          { providerId: this.descriptor.id, modelId: request.model },
+        ),
       );
     }
 
     try {
       // Build options, filtering out undefined values for exactOptionalPropertyTypes
-      const mapperOptions: { defaultMaxTokens?: number; defaultTemperature?: number } = {};
+      const mapperOptions: {
+        defaultMaxTokens?: number;
+        defaultTemperature?: number;
+      } = {};
       if (this.config.defaultMaxTokens !== undefined) {
         mapperOptions.defaultMaxTokens = this.config.defaultMaxTokens;
       }
       if (this.config.defaultTemperature !== undefined) {
         mapperOptions.defaultTemperature = this.config.defaultTemperature;
       }
-      
+
       const anthropicRequest = mapRequest(request, mapperOptions);
 
       const response = await this.fetch(`${this.config.baseUrl}/messages`, {
         method: 'POST',
         headers: this.getHeaders(),
         body: JSON.stringify(anthropicRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -261,14 +279,19 @@ export class AnthropicProvider implements ModelProvider {
           normalizeError(isAnthropicError(errorData) ? errorData : response, {
             providerId: this.descriptor.id,
             modelId: request.model,
-          })
+          }),
         );
       }
 
       const data = (await response.json()) as AnthropicMessagesResponse;
       return ok(mapResponse(data, this.descriptor.id));
     } catch (error) {
-      return err(normalizeError(error, { providerId: this.descriptor.id, modelId: request.model }));
+      return err(
+        normalizeError(error, {
+          providerId: this.descriptor.id,
+          modelId: request.model,
+        }),
+      );
     }
   }
 
@@ -276,15 +299,17 @@ export class AnthropicProvider implements ModelProvider {
   // Streaming Invocation
   // =====================
 
-  async *invokeStream(request: ModelRequest): AsyncIterable<ProviderResult<ModelStreamEvent>> {
+  async *invokeStream(
+    request: ModelRequest,
+  ): AsyncIterable<ProviderResult<ModelStreamEvent>> {
     // Check streaming capability
     if (!this.hasCapability('streaming')) {
       yield err(
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${this.descriptor.id}" does not support streaming`,
-          { providerId: this.descriptor.id, modelId: request.model }
-        )
+          { providerId: this.descriptor.id, modelId: request.model },
+        ),
       );
       return;
     }
@@ -299,21 +324,27 @@ export class AnthropicProvider implements ModelProvider {
 
     try {
       // Build options, filtering out undefined values for exactOptionalPropertyTypes
-      const mapperOptions: { defaultMaxTokens?: number; defaultTemperature?: number } = {};
+      const mapperOptions: {
+        defaultMaxTokens?: number;
+        defaultTemperature?: number;
+      } = {};
       if (this.config.defaultMaxTokens !== undefined) {
         mapperOptions.defaultMaxTokens = this.config.defaultMaxTokens;
       }
       if (this.config.defaultTemperature !== undefined) {
         mapperOptions.defaultTemperature = this.config.defaultTemperature;
       }
-      
-      const anthropicRequest = mapRequest({ ...request, stream: true }, mapperOptions);
+
+      const anthropicRequest = mapRequest(
+        { ...request, stream: true },
+        mapperOptions,
+      );
 
       const response = await this.fetch(`${this.config.baseUrl}/messages`, {
         method: 'POST',
         headers: { ...this.getHeaders(), Accept: 'text/event-stream' },
         body: JSON.stringify(anthropicRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -328,17 +359,21 @@ export class AnthropicProvider implements ModelProvider {
           normalizeError(isAnthropicError(errorData) ? errorData : response, {
             providerId: this.descriptor.id,
             modelId: request.model,
-          })
+          }),
         );
         return;
       }
 
       if (!response.body) {
         yield err(
-          createProviderError('provider.stream_error', 'Response body is null', {
-            providerId: this.descriptor.id,
-            modelId: request.model,
-          })
+          createProviderError(
+            'provider.stream_error',
+            'Response body is null',
+            {
+              providerId: this.descriptor.id,
+              modelId: request.model,
+            },
+          ),
         );
         return;
       }
@@ -399,7 +434,7 @@ export class AnthropicProvider implements ModelProvider {
                 event,
                 this.descriptor.id,
                 messageId,
-                model
+                model,
               )) {
                 yield ok(normalizedEvent);
               }
@@ -426,7 +461,12 @@ export class AnthropicProvider implements ModelProvider {
 
       // Note: finish reason tracking for tool calls could be added here if needed
     } catch (error) {
-      yield err(normalizeError(error, { providerId: this.descriptor.id, modelId: request.model }));
+      yield err(
+        normalizeError(error, {
+          providerId: this.descriptor.id,
+          modelId: request.model,
+        }),
+      );
       return;
     }
 
@@ -457,9 +497,27 @@ export class AnthropicProvider implements ModelProvider {
     return headers;
   }
 
-  private createAbortSignal(): AbortSignal {
+  private createAbortSignal(external?: AbortSignal): AbortSignal {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    if (external) {
+      if (external.aborted) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      } else {
+        external.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeoutId);
+            controller.abort();
+          },
+          { once: true },
+        );
+      }
+    }
     return controller.signal;
   }
 
@@ -475,7 +533,9 @@ export class AnthropicProvider implements ModelProvider {
 /**
  * Creates an Anthropic provider instance
  */
-export function createAnthropicProvider(config: AnthropicAdapterConfig): ModelProvider {
+export function createAnthropicProvider(
+  config: AnthropicAdapterConfig,
+): ModelProvider {
   return new AnthropicProvider(config);
 }
 
@@ -484,7 +544,7 @@ export function createAnthropicProvider(config: AnthropicAdapterConfig): ModelPr
  */
 export function createClaudeProvider(
   apiKey: string,
-  options?: Partial<AnthropicAdapterConfig>
+  options?: Partial<AnthropicAdapterConfig>,
 ): ModelProvider {
   return createAnthropicProvider({
     apiKey,
@@ -502,7 +562,7 @@ export function createClaudeProvider(
 export function createClaudeModelProvider(
   apiKey: string,
   model: string,
-  options?: Partial<AnthropicAdapterConfig>
+  options?: Partial<AnthropicAdapterConfig>,
 ): ModelProvider {
   return createAnthropicProvider({
     apiKey,

--- a/apps/server/src/providers/infrastructure/gemini/adapter.ts
+++ b/apps/server/src/providers/infrastructure/gemini/adapter.ts
@@ -471,7 +471,7 @@ export class GeminiProvider implements ModelProvider {
         method: 'POST',
         headers: this.getHeaders(),
         body: JSON.stringify(geminiRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -565,7 +565,7 @@ export class GeminiProvider implements ModelProvider {
         method: 'POST',
         headers: { ...this.getHeaders(), Accept: 'text/event-stream' },
         body: JSON.stringify(geminiRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -695,12 +695,27 @@ export class GeminiProvider implements ModelProvider {
     return headers;
   }
 
-  private createAbortSignal(): AbortSignal {
+  private createAbortSignal(external?: AbortSignal): AbortSignal {
     const controller = new AbortController();
-    setTimeout(
+    const timeoutId = setTimeout(
       () => controller.abort(),
       this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     );
+    if (external) {
+      if (external.aborted) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      } else {
+        external.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeoutId);
+            controller.abort();
+          },
+          { once: true },
+        );
+      }
+    }
     return controller.signal;
   }
 

--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
@@ -374,7 +374,10 @@ export class OpenAICompatibleProvider implements ModelProvider {
       this.logger.info(
         `invoke: final requestParams = ${JSON.stringify({ ...requestParams, messages: '[...]' })}`,
       );
-      const response = await this.client.chat.completions.create(requestParams);
+      const response = await this.client.chat.completions.create(
+        requestParams,
+        request.signal ? { signal: request.signal } : {},
+      );
 
       return ok(
         this.mapResponse(response, modelId, toolMapping?.nameMap ?? new Map()),
@@ -444,7 +447,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
         requestParams.tools = tools;
       }
 
-      const stream = await this.client.chat.completions.create(requestParams);
+      // Forward the caller's abort signal (e.g. user "Stop agent") to the SDK
+      // so aborting it cancels the in-flight streaming request. The SDK applies
+      // its own per-request timeout (config.timeoutMs) alongside this.
+      const stream = await this.client.chat.completions.create(
+        requestParams,
+        request.signal ? { signal: request.signal } : {},
+      );
 
       let finishReason: 'stop' | 'length' | 'tool_calls' | 'content_filter' =
         'stop';

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -38,6 +38,7 @@ import {
   markRunRunning,
   markRunSucceeded,
   markRunFailed,
+  markRunCancelled,
   listSessionRunRecords,
   deleteSessionRecord,
 } from './store';
@@ -95,6 +96,11 @@ export class SessionMessageService {
   // (issue #375). Key: `${runId}:${toolCallId}`.
   private readonly inflightTools = new Map<string, AbortController>();
 
+  // In-flight run-level AbortControllers so a user "Stop agent" can abort the
+  // whole turn — the provider stream and any running tools (issue #376).
+  // Key: runId (the WS-level run id the client addresses).
+  private readonly inflightRuns = new Map<string, AbortController>();
+
   constructor(options: SessionMessageServiceOptions) {
     this.providers = options.providers;
     this.logger = options.logger;
@@ -129,6 +135,20 @@ export class SessionMessageService {
    */
   cancelTool(runId: string, toolCallId: string): boolean {
     const controller = this.inflightTools.get(`${runId}:${toolCallId}`);
+    if (!controller) return false;
+    controller.abort();
+    return true;
+  }
+
+  /**
+   * Cancel an in-flight run (user hit "Stop agent"). Aborts the run-level
+   * AbortSignal, which cancels the provider stream and any tool currently
+   * running under this run. The streaming loop marks the run `cancelled` and
+   * emits `run.cancelled` without persisting a final assistant message.
+   * Returns true if a matching in-flight run was found.
+   */
+  cancelRun(runId: string): boolean {
+    const controller = this.inflightRuns.get(runId);
     if (!controller) return false;
     controller.abort();
     return true;
@@ -824,6 +844,14 @@ export class SessionMessageService {
     // 4. Mark run as running
     await this.markRunRunning(run.id);
 
+    // Run-level AbortController: a user "Stop agent" aborts this, which cancels
+    // the provider stream and any tool running under this run (issue #376).
+    // Registered under the WS-level runId the client uses to address a cancel.
+    const runController = new AbortController();
+    if (input.runId) {
+      this.inflightRuns.set(input.runId, runController);
+    }
+
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
     const historyMessages: Message[] = history.map((m) => {
@@ -959,6 +987,8 @@ export class SessionMessageService {
           model: modelId,
           messages: loopMessages,
           ...(allTools.length > 0 && { tools: allTools, toolChoice: 'auto' }),
+          // Run-level cancel: aborting this signal cancels the provider fetch.
+          signal: runController.signal,
         };
 
         // Local accumulator for the tool calls the model
@@ -1136,6 +1166,16 @@ export class SessionMessageService {
                 : undefined;
               const controller = new AbortController();
               if (cancelKey) this.inflightTools.set(cancelKey, controller);
+              // A run-level "Stop agent" also aborts the tool in flight (#376).
+              if (runController.signal.aborted) {
+                controller.abort();
+              } else {
+                runController.signal.addEventListener(
+                  'abort',
+                  () => controller.abort(),
+                  { once: true },
+                );
+              }
 
               const builtinResult = await builtinTool
                 .execute(tc.arguments, {
@@ -1363,6 +1403,16 @@ export class SessionMessageService {
         break;
       }
 
+      // If the user hit "Stop agent", mark the run cancelled and bail without
+      // persisting a final assistant message (issue #376).
+      if (runController.signal.aborted) {
+        await this.markRunCancelled(run);
+        return {
+          ok: false,
+          error: { code: 'cancelled', message: 'Run cancelled by user' },
+        };
+      }
+
       // 7. Persist assistant message with accumulated content
       const assistantMessage = await this.appendMessage({
         sessionId: input.sessionId,
@@ -1394,6 +1444,15 @@ export class SessionMessageService {
 
       return { ok: true, userMessage, assistantMessage, run: updatedRun! };
     } catch (error) {
+      // A user "Stop agent" aborts the provider fetch, which surfaces here as
+      // an AbortError. Treat that as a cancellation, not a failure (issue #376).
+      if (runController.signal.aborted) {
+        await this.markRunCancelled(run);
+        return {
+          ok: false,
+          error: { code: 'cancelled', message: 'Run cancelled by user' },
+        };
+      }
       const errorMsg =
         error instanceof Error ? error.message : 'Streaming failed';
       return this.handleFailure(
@@ -1402,6 +1461,8 @@ export class SessionMessageService {
         'streaming_error',
         errorMsg,
       );
+    } finally {
+      if (input.runId) this.inflightRuns.delete(input.runId);
     }
   }
 
@@ -1608,6 +1669,25 @@ export class SessionMessageService {
       return this.runsRepo.markFailed(id, input);
     }
     return markRunFailed(id, input) ?? null;
+  }
+
+  /**
+   * Mark a run as cancelled (user hit "Stop agent") and emit run.cancelled.
+   */
+  private async markRunCancelled(
+    run: SessionRunRecord | SessionRun,
+  ): Promise<SessionRunRecord | SessionRun | null> {
+    const updated = this.runsRepo
+      ? await this.runsRepo.markCancelled(run.id)
+      : (markRunCancelled(run.id) ?? null);
+    if (this.runEvents && updated) {
+      this.runEvents.emitRunCancelled({
+        runId: run.id,
+        sessionId: run.sessionId,
+        agentId: run.agentId,
+      });
+    }
+    return updated;
   }
 
   /**

--- a/apps/server/src/sessions/store.ts
+++ b/apps/server/src/sessions/store.ts
@@ -195,6 +195,13 @@ export function markRunFailed(
   return updateRunRecord(id, updates);
 }
 
+export function markRunCancelled(id: string): SessionRunRecord | undefined {
+  return updateRunRecord(id, {
+    status: 'cancelled',
+    finishedAt: new Date().toISOString(),
+  });
+}
+
 export function listSessionRunRecords(sessionId: string): SessionRunRecord[] {
   return Array.from(runs.values())
     .filter((r) => r.sessionId === sessionId)

--- a/apps/server/src/tools/agents/invoke.test.ts
+++ b/apps/server/src/tools/agents/invoke.test.ts
@@ -435,6 +435,63 @@ describe('agents_invoke_await tool', () => {
     }
   }, 35000); // 35 second timeout for this test
 
+  // ── Cancellation (issue #376) ────────────────────────────────────────────────
+
+  it('bails out immediately when ctx.signal is already aborted', async () => {
+    const svc = makeSessionService({
+      dispatchAgent: vi.fn().mockResolvedValue({
+        ok: true,
+        sessionId: 'sess-abc',
+        done: Promise.resolve({ ok: true }),
+      }),
+      listRuns: vi.fn().mockResolvedValue([{ id: 'run-1', status: 'running' }]),
+    });
+    const tool = makeTool({ sessionSvc: svc });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await tool.execute(
+      { agentId: 'researcher', content: 'hello' },
+      { agentId: 'test-agent', signal: controller.signal },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Cancelled by user while waiting/);
+    }
+    // The dispatched sub-agent is NOT cancelled — dispatch still happened.
+    expect(svc.dispatchAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('wakes from the poll backoff and cancels when aborted mid-wait', async () => {
+    const svc = makeSessionService({
+      dispatchAgent: vi.fn().mockResolvedValue({
+        ok: true,
+        sessionId: 'sess-abc',
+        done: Promise.resolve({ ok: true }),
+      }),
+      listRuns: vi.fn().mockResolvedValue([{ id: 'run-1', status: 'running' }]),
+    });
+    const tool = makeTool({ sessionSvc: svc });
+    const controller = new AbortController();
+    // Abort partway through the first 2s backoff interval.
+    setTimeout(() => controller.abort(), 50);
+
+    const start = Date.now();
+    const result = await tool.execute(
+      { agentId: 'researcher', content: 'hello' },
+      { agentId: 'test-agent', signal: controller.signal },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Cancelled by user while waiting/);
+    }
+    // Must have woken well before the full 2s backoff interval elapsed.
+    expect(elapsed).toBeLessThan(1500);
+  }, 10000);
+
   // ── dispatchAgent error propagation ─────────────────────────────────────────
 
   it('propagates dispatchAgent errors', async () => {

--- a/apps/server/src/tools/agents/invoke.ts
+++ b/apps/server/src/tools/agents/invoke.ts
@@ -89,10 +89,22 @@ export function createAgentsInvokeTool(deps: AgentToolsDeps): BuiltinTool {
 }
 
 /**
- * Sleep helper for polling delays
+ * Sleep helper for polling delays. Resolves early if `signal` aborts, so a
+ * user "Stop" wakes the wait immediately instead of riding out the interval.
  */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 export function createAgentsInvokeAndWaitTool(
@@ -123,7 +135,7 @@ export function createAgentsInvokeAndWaitTool(
       required: ['agentId', 'content'],
     },
 
-    async execute(args, _ctx) {
+    async execute(args, ctx) {
       const agentId = args['agentId'];
       const content = args['content'];
       const sessionId =
@@ -151,6 +163,7 @@ export function createAgentsInvokeAndWaitTool(
         };
       }
 
+      const signal = ctx?.signal;
       const sessionService = deps.getSessionService();
 
       // Step 1: Dispatch the agent
@@ -177,6 +190,17 @@ export function createAgentsInvokeAndWaitTool(
 
       try {
         while (totalWaited < MAX_WAIT_MS) {
+          // User hit Stop — bail out of the local wait. The dispatched
+          // sub-agent keeps running in its own session (its lifecycle is owned
+          // by the sub-session, not this tool call) and stays inspectable via
+          // sessions_read.
+          if (signal?.aborted) {
+            return {
+              ok: false,
+              error: 'Cancelled by user while waiting for agent response',
+            };
+          }
+
           // Check runs status using listRuns (lightweight, no full messages)
           const runs = await sessionService.listRuns(resolvedId);
           const lastRun = runs[runs.length - 1] as
@@ -217,8 +241,8 @@ export function createAgentsInvokeAndWaitTool(
             // Status is 'running' or 'queued' - continue polling
           }
 
-          // Wait with backoff
-          await sleep(currentInterval);
+          // Wait with backoff (wakes immediately if the user cancels)
+          await sleep(currentInterval, signal);
           totalWaited += currentInterval;
 
           // Exponential backoff: 2s -> 3s -> 4.5s -> 6s (capped)

--- a/apps/server/src/websocket/handlers/session.test.ts
+++ b/apps/server/src/websocket/handlers/session.test.ts
@@ -582,7 +582,7 @@ describe('registerSessionHandlers', () => {
 
     registerSessionHandlers(mockRouter, handler);
 
-    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(8);
+    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(9);
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.create',
       expect.any(Function),
@@ -613,6 +613,10 @@ describe('registerSessionHandlers', () => {
     );
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.tool.cancel',
+      expect.any(Function),
+    );
+    expect(mockRouter.registerHandler).toHaveBeenCalledWith(
+      'session.run.cancel',
       expect.any(Function),
     );
   });

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -24,6 +24,7 @@ import {
   type SessionMessagesRequest,
   type SessionRunsRequest,
   type SessionToolCancelRequest,
+  type SessionRunCancelRequest,
   type SessionCreatedResponse,
   type SessionMessageResponse,
   type SessionMessagesResponse,
@@ -382,6 +383,20 @@ export class SessionHandler {
   ): Promise<void> {
     const { runId, toolCallId } = request.payload;
     this.sessionService.cancelTool(runId, toolCallId);
+  }
+
+  /**
+   * Handle session.run.cancel — the user hit "Stop agent". Aborts the whole
+   * run (provider stream + any running tool); the UI reacts to the resulting
+   * run.cancelled event, so no response is returned.
+   */
+  async handleRunCancel(
+    _connectionId: string,
+    request: SessionRunCancelRequest,
+    _context: HandlerContext,
+  ): Promise<void> {
+    const { runId } = request.payload;
+    this.sessionService.cancelRun(runId);
   }
 
   /**
@@ -927,6 +942,10 @@ export function registerSessionHandlers(
 
   router.registerHandler('session.tool.cancel', (connId, msg, ctx) =>
     handler.handleToolCancel(connId, msg as SessionToolCancelRequest, ctx),
+  );
+
+  router.registerHandler('session.run.cancel', (connId, msg, ctx) =>
+    handler.handleRunCancel(connId, msg as SessionRunCancelRequest, ctx),
   );
 }
 

--- a/apps/server/src/websocket/index.ts
+++ b/apps/server/src/websocket/index.ts
@@ -85,6 +85,7 @@ const MESSAGE_CAPABILITIES: Partial<Record<string, string[]>> = {
   'session.subscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.unsubscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.tool.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
+  'session.run.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
   'agent.list': [WS_CAPABILITIES.AGENTS_READ],
   'agent.get': [WS_CAPABILITIES.AGENTS_READ],
   'provider.list': [WS_CAPABILITIES.PROVIDERS_READ],

--- a/apps/server/src/websocket/integration/session-integration.test.ts
+++ b/apps/server/src/websocket/integration/session-integration.test.ts
@@ -660,12 +660,13 @@ describe('Session Integration Tests', () => {
       expect(messageRouter.hasHandler('session.messages')).toBe(true);
       expect(messageRouter.hasHandler('session.runs')).toBe(true);
       expect(messageRouter.hasHandler('session.tool.cancel')).toBe(true);
+      expect(messageRouter.hasHandler('session.run.cancel')).toBe(true);
     });
 
-    it('should have exactly 8 session handlers', () => {
+    it('should have exactly 9 session handlers', () => {
       const types = messageRouter.getHandlerTypes();
       const sessionHandlers = types.filter((t) => t.startsWith('session.'));
-      expect(sessionHandlers).toHaveLength(8);
+      expect(sessionHandlers).toHaveLength(9);
     });
   });
 

--- a/apps/server/src/websocket/streaming.ts
+++ b/apps/server/src/websocket/streaming.ts
@@ -13,6 +13,7 @@ import {
   type SessionStreamToolCall,
   type SessionStreamExecOutput,
   type SessionStreamToolCancelled,
+  type SessionStreamRunCancelled,
   type SessionStreamUsage,
   type SessionStreamEnd,
   type SessionStreamError,
@@ -33,6 +34,7 @@ export type SessionStreamEvent =
   | SessionStreamToolCall
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
+  | SessionStreamRunCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -119,6 +121,13 @@ export function mapRunEventToStreamEvent(
         runId: event.runId,
         toolCallId: event.data.toolCallId as string,
       }) as SessionStreamToolCancelled;
+    }
+
+    case 'run.cancelled': {
+      return createWSMessage('session.stream.run_cancelled', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+      }) as SessionStreamRunCancelled;
     }
 
     case 'run.completed': {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -243,6 +243,19 @@ function AppContent(props: AppContentProps) {
       );
     };
 
+    const handleRunCancelled = () => {
+      // User hit "Stop agent": tear down the streaming UI, drop any partial
+      // content, and refresh so the run shows its cancelled status (#376).
+      clearStreamWatchdog();
+      setIsStreaming(false);
+      setStreamingContent('');
+      setStreamingToolCalls([]);
+      setPendingUserMessage(undefined);
+      queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
+      queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
+      processQueue();
+    };
+
     const handleStreamEnd = () => {
       clearStreamWatchdog();
       setIsStreaming(false);
@@ -303,6 +316,10 @@ function AppContent(props: AppContentProps) {
       'session.stream.tool_cancelled',
       handleToolCancelled,
     );
+    const unsubRunCancelled = wsClient.on(
+      'session.stream.run_cancelled',
+      handleRunCancelled,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sessionId).catch((err: Error) => {
@@ -320,6 +337,7 @@ function AppContent(props: AppContentProps) {
       unsubChoices();
       unsubExecOutput();
       unsubToolCancelled();
+      unsubRunCancelled();
       setFocusChatInput(undefined); // Clear stale focus function
     });
   });
@@ -443,6 +461,16 @@ function AppContent(props: AppContentProps) {
     const rid = currentRunId();
     if (wsClient && sid && rid) {
       wsClient.cancelTool(sid, rid, toolCallId);
+    }
+  };
+
+  // User hit "Stop agent" — ask the server to cancel the whole run (#376).
+  const handleCancelRun = () => {
+    const wsClient = client();
+    const sid = selectedSessionId();
+    const rid = currentRunId();
+    if (wsClient && sid && rid) {
+      wsClient.cancelRun(sid, rid);
     }
   };
 
@@ -798,6 +826,7 @@ function AppContent(props: AppContentProps) {
                 isStreaming() ? streamingToolCalls() : undefined
               }
               onCancelTool={handleCancelTool}
+              onCancelRun={handleCancelRun}
               queuedMessages={messageQueue.items()}
               onEditQueued={messageQueue.edit}
               onRemoveQueued={messageQueue.remove}

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -178,5 +178,32 @@ describe('ChatView', () => {
       expect(screen.getByText('Cancelled by user')).toBeInTheDocument();
       expect(screen.queryByText('Stop')).not.toBeInTheDocument();
     });
+
+    it('shows a Stop agent button that invokes onCancelRun', () => {
+      const onCancelRun = vi.fn();
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          onCancelRun={onCancelRun}
+        />
+      ));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop agent' }));
+      expect(onCancelRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits the Stop agent button when onCancelRun is not provided', () => {
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+        />
+      ));
+      expect(
+        screen.queryByRole('button', { name: 'Stop agent' }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,5 +1,12 @@
 import { Show, For, createEffect } from 'solid-js';
-import { User, Bot, AlertCircle, Wrench, Server } from 'lucide-solid';
+import {
+  User,
+  Bot,
+  AlertCircle,
+  Wrench,
+  Server,
+  CircleStop,
+} from 'lucide-solid';
 import type { SessionMessage } from '../lib/api';
 import type { QueuedMessage } from '../lib/types';
 import { TypingIndicator } from './TypingIndicator';
@@ -31,6 +38,8 @@ type ChatViewProps = {
   onRemoveQueued?: (id: string) => void;
   /** Ask the server to cancel an in-flight tool call. */
   onCancelTool?: (toolCallId: string) => void;
+  /** Ask the server to cancel the whole in-flight run ("Stop agent"). */
+  onCancelRun?: () => void;
   /** Message ID to scroll to (e.g. from clicking a run) */
   scrollToMessageId?: string;
 };
@@ -236,6 +245,18 @@ export function ChatView(props: ChatViewProps) {
                         : 'Thinking...'}
                   </span>
                 </span>
+                {/* Stop agent — aborts the whole run (provider stream + tools) */}
+                <Show when={props.onCancelRun}>
+                  <button
+                    type="button"
+                    onClick={() => props.onCancelRun?.()}
+                    aria-label="Stop agent"
+                    class="ml-auto inline-flex items-center gap-1 rounded border border-red-200 dark:border-red-800 px-2 py-0.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                  >
+                    <CircleStop class="w-3.5 h-3.5" />
+                    Stop agent
+                  </button>
+                </Show>
               </div>
               <Show when={props.streamingContent}>
                 <div class="text-text-secondary mb-2">

--- a/packages/runtime/src/provider/index.ts
+++ b/packages/runtime/src/provider/index.ts
@@ -71,6 +71,12 @@ export type ModelRequest = {
   readonly stopSequences?: readonly string[];
   readonly stream?: boolean;
   readonly metadata?: Record<string, unknown>;
+  /**
+   * Optional caller-supplied abort signal (e.g. a user-initiated "Stop agent").
+   * Adapters combine it with their own request-timeout signal so aborting it
+   * cancels the in-flight provider fetch. Not serialized to the wire.
+   */
+  readonly signal?: AbortSignal;
 };
 
 /**

--- a/packages/sdk/src/websocket-client.ts
+++ b/packages/sdk/src/websocket-client.ts
@@ -517,6 +517,20 @@ export class WebSocketClient {
   }
 
   /**
+   * Cancel an in-flight run (user hit "Stop agent"). Fire-and-forget: the
+   * server aborts the run and the UI reacts to the resulting
+   * `session.stream.run_cancelled` event, so we don't await a response.
+   */
+  cancelRun(sessionId: string, runId: string): void {
+    void this.sendRequest('session.run.cancel', {
+      sessionId,
+      runId,
+    }).catch(() => {
+      /* best-effort — cancellation is confirmed via the stream event */
+    });
+  }
+
+  /**
    * Subscribe to session events
    */
   async subscribeToSession(

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -240,6 +240,15 @@ export type SessionToolCancelRequest = WSMessage<
   }
 >;
 
+/** Client → server: cancel an in-flight run (user hit "Stop agent"). */
+export type SessionRunCancelRequest = WSMessage<
+  'session.run.cancel',
+  {
+    sessionId: string;
+    runId: string;
+  }
+>;
+
 export type SessionMessagesRequest = WSMessage<
   'session.messages',
   {
@@ -529,6 +538,15 @@ export type SessionStreamToolCancelled = WSMessage<
   }
 >;
 
+/** The whole run was cancelled by the user ("Stop agent"). */
+export type SessionStreamRunCancelled = WSMessage<
+  'session.stream.run_cancelled',
+  {
+    sessionId: string;
+    runId: string;
+  }
+>;
+
 export type SessionRunChoicesEvent = WSMessage<
   'session.run.choices',
   ChoicesEvent
@@ -540,6 +558,7 @@ export type SessionStreamEvent =
   | SessionStreamToolCall
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
+  | SessionStreamRunCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -941,6 +960,7 @@ export type WSRequest =
   | SessionSubscribeRequest
   | SessionUnsubscribeRequest
   | SessionToolCancelRequest
+  | SessionRunCancelRequest
   | SessionMessagesRequest
   | SessionRunsRequest
   | AgentListRequest
@@ -1017,6 +1037,7 @@ const REQUEST_TYPES: Set<string> = new Set([
   'session.subscribe',
   'session.unsubscribe',
   'session.tool.cancel',
+  'session.run.cancel',
   'agent.list',
   'agent.get',
   'provider.list',
@@ -1050,6 +1071,7 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.tool_call',
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
+  'session.stream.run_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
@@ -1081,6 +1103,7 @@ const STREAM_EVENT_TYPES: Set<string> = new Set([
   'session.stream.tool_call',
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
+  'session.stream.run_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',


### PR DESCRIPTION
Closes #376. **Phase 2 of cancellation, stacked on #375** (base branch is `worktree-issue-375` — review/merge that first; the diff here is only the #376 delta).

Builds on the shared cancel infra from #375 (`BuiltinToolContext.signal`, the per-tool `AbortController` map, inbound `session.tool.cancel`).

## Two new abilities

**1. `agents_invoke_await` honors `ctx.signal`**
- The poll loop bails out on abort and the backoff `sleep` wakes immediately, returning `{ ok: false, error: 'Cancelled by user while waiting for agent response' }`.
- Cancelling only stops the **local wait** — the dispatched sub-agent keeps running in its own session (its lifecycle is owned by the sub-session) and stays inspectable via `sessions_read`.

**2. "Stop agent" aborts the in-flight turn**
- A run-level `AbortController` (keyed by the WS-level `runId`) cancels the provider stream and any tool running under the run. On abort the run is marked `cancelled`, `run.cancelled` is emitted, and **no final assistant message is persisted**.

## Changes

**Providers**
- `ModelRequest` gains an optional `signal`. `anthropic`/`gemini` `createAbortSignal` now **combine** the request-timeout signal with this external one; `openai-compatible` forwards it to the SDK's `create(params, { signal })`. It flows to the adapters through the existing invocation request spread — no signature churn.

**Session service**
- Tracks a run-level `AbortController` alongside the #375 per-tool map; `cancelRun()` aborts it, which also aborts in-flight tools (so a Stop-agent during `agents_invoke_await` wakes it too).
- Reuses the existing `cancelled` run status + repo `markCancelled`; adds an in-memory `markRunCancelled` fallback. **No migration.**

**WS / SDK**
- New inbound `session.run.cancel` (`SESSIONS_WRITE`) and outbound `run.cancelled` / `session.stream.run_cancelled`; SDK `cancelRun()` (fire-and-forget).

**Web**
- Top-level **Stop agent** button in the streaming block; on `run_cancelled` the UI tears down streaming, drops partial content, and refreshes so the run shows its cancelled status. The #375 per-tool Stop button is unchanged.

## Tests
- `agents_invoke_await`: already-aborted signal, and wake-from-backoff mid-wait (asserts it returns in <1.5s, not the full 2s interval).
- Anthropic adapter: external signal propagates to the fetch signal (live abort + already-aborted).
- `ChatView`: Stop-agent button invokes `onCancelRun`; omitted when no handler.
- Updated session handler counts (8 → 9).

All server (1913) and web (357) suites + typechecks + lint pass locally.

## Acceptance criteria
- [x] Stop during an `agents_invoke_await` wait wakes the loop (~50ms in test) and returns the cancel error.
- [x] Cancelling `agents_invoke_await` does not cancel the dispatched sub-agent.
- [x] Stop agent aborts the provider fetch and the run transitions to `cancelled`.
- [x] No final assistant message persisted after Stop agent.
- [x] The #375 per-tool Stop button still works.
- [x] Backward compat: tools that ignore `ctx.signal` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)