### PR TITLE
feat(web): live run-activity badge with elapsed time (#378)

### DIFF
--- a/apps/server/src/dispatch/events.test.ts
+++ b/apps/server/src/dispatch/events.test.ts
@@ -80,4 +80,52 @@ describe('RunEventEmitter', () => {
       expect(payload.choices).toEqual(['Yes', 'No']);
     });
   });
+
+  describe('emitActivity', () => {
+    it('publishes a run.activity event with phase, tool name, and elapsed', () => {
+      const listener = vi.fn();
+      emitter.subscribe('run-1', listener);
+
+      emitter.emitActivity({
+        runId: 'run-1',
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        phase: 'running_tool',
+        toolName: 'exec_run',
+        elapsedMs: 12000,
+      });
+
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]![0] as {
+        type: string;
+        runId: string;
+        data: { phase: string; toolName?: string; elapsedMs: number };
+      };
+      expect(event.type).toBe('run.activity');
+      expect(event.runId).toBe('run-1');
+      expect(event.data.phase).toBe('running_tool');
+      expect(event.data.toolName).toBe('exec_run');
+      expect(event.data.elapsedMs).toBe(12000);
+    });
+
+    it('omits toolName when not provided (thinking phase)', () => {
+      const listener = vi.fn();
+      emitter.subscribe('run-2', listener);
+
+      emitter.emitActivity({
+        runId: 'run-2',
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        phase: 'thinking',
+        elapsedMs: 500,
+      });
+
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]![0] as {
+        data: { phase: string; toolName?: string };
+      };
+      expect(event.data.phase).toBe('thinking');
+      expect(event.data.toolName).toBeUndefined();
+    });
+  });
 });

--- a/apps/server/src/dispatch/events.ts
+++ b/apps/server/src/dispatch/events.ts
@@ -12,6 +12,7 @@ export type RunEventType =
   | 'run.exec_output'
   | 'run.tool_cancelled'
   | 'run.cancelled'
+  | 'run.activity'
   | 'run.completed'
   | 'run.failed'
   | 'session.run.choices';
@@ -250,6 +251,32 @@ export class RunEventEmitter {
       agentId: params.agentId,
       timestamp: new Date().toISOString(),
       data: {},
+    });
+  }
+
+  /**
+   * Emit a run.activity heartbeat (server-driven liveness indicator). Lets the
+   * UI show "Thinking…" / "Running <tool>… 12s" between other events (#378).
+   */
+  emitActivity(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+    phase: 'thinking' | 'running_tool';
+    toolName?: string;
+    elapsedMs: number;
+  }): void {
+    this.emit({
+      type: 'run.activity',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {
+        phase: params.phase,
+        elapsedMs: params.elapsedMs,
+        ...(params.toolName !== undefined && { toolName: params.toolName }),
+      },
     });
   }
 

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -852,6 +852,36 @@ export class SessionMessageService {
       this.inflightRuns.set(input.runId, runController);
     }
 
+    // Server-driven activity heartbeat (issue #378): emit a `run.activity`
+    // event (at most 1/s) while the run is idle between other events, so the
+    // UI can show "Thinking…" / "Running <tool>… 12s". Emitted under the
+    // WS-level runId so it reaches the subscribed client; skipped for non-WS
+    // callers (no runId). `lastActivityAt` is bumped whenever we produce a
+    // real event, so a continuously-streaming run stays quiet.
+    const activityRunId = input.runId;
+    const runStartAt = Date.now();
+    let lastActivityAt = runStartAt;
+    let activityPhase: 'thinking' | 'running_tool' = 'thinking';
+    let activityToolName: string | undefined;
+    const heartbeat =
+      activityRunId && this.runEvents
+        ? setInterval(() => {
+            const now = Date.now();
+            // Already busy (event within the last 500ms) — stay quiet.
+            if (now - lastActivityAt < 500) return;
+            this.runEvents!.emitActivity({
+              runId: activityRunId,
+              sessionId: input.sessionId,
+              agentId,
+              phase: activityPhase,
+              elapsedMs: now - runStartAt,
+              ...(activityToolName !== undefined && {
+                toolName: activityToolName,
+              }),
+            });
+          }, 1000)
+        : undefined;
+
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
     const historyMessages: Message[] = history.map((m) => {
@@ -1031,6 +1061,11 @@ export class SessionMessageService {
           switch (value.type) {
             case 'stream.content_delta': {
               accumulatedContent += value.delta;
+              // Content is flowing — mark busy so the heartbeat stays quiet
+              // and the phase reads as thinking/streaming (#378).
+              lastActivityAt = Date.now();
+              activityPhase = 'thinking';
+              activityToolName = undefined;
               onStreamEvent({ type: 'delta', content: value.delta });
               break;
             }
@@ -1177,6 +1212,11 @@ export class SessionMessageService {
                 );
               }
 
+              // Reflect the running tool in the activity heartbeat (#378).
+              activityPhase = 'running_tool';
+              activityToolName = tc.name;
+              lastActivityAt = Date.now();
+
               const builtinResult = await builtinTool
                 .execute(tc.arguments, {
                   agentId,
@@ -1197,6 +1237,11 @@ export class SessionMessageService {
                 .finally(() => {
                   if (cancelKey) this.inflightTools.delete(cancelKey);
                 });
+
+              // Tool settled — back to thinking until the next tool runs (#378).
+              activityPhase = 'thinking';
+              activityToolName = undefined;
+              lastActivityAt = Date.now();
 
               // If the user cancelled this tool, tell the UI so it can mark the
               // block "Cancelled by user".
@@ -1462,6 +1507,7 @@ export class SessionMessageService {
         errorMsg,
       );
     } finally {
+      if (heartbeat) clearInterval(heartbeat);
       if (input.runId) this.inflightRuns.delete(input.runId);
     }
   }

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -736,6 +736,12 @@ export class SessionHandler {
             'Auto-rename session failed (non-fatal)',
           );
         });
+      } else if (result.error.code === 'cancelled') {
+        // User hit "Stop agent" — deliver a clean run.cancelled on the
+        // WS-level run channel the client is subscribed to (issue #376), not a
+        // generic stream error. (The service also marks the run cancelled and
+        // emits on its own run.id channel for any run-id subscribers.)
+        this.runEvents?.emitRunCancelled({ runId, sessionId, agentId });
       } else {
         // Emit failure
         this.runEvents?.emitFailed({

--- a/apps/server/src/websocket/streaming.test.ts
+++ b/apps/server/src/websocket/streaming.test.ts
@@ -12,6 +12,7 @@ import type {
   SessionStreamDelta,
   SessionStreamEnd,
   SessionStreamError,
+  SessionStreamActivity,
 } from '@openaidy/shared-types';
 
 // Mock logger
@@ -46,12 +47,10 @@ const createMockConnectionManager = () => ({
   updateHeartbeat: vi.fn(),
   checkStaleConnections: vi.fn().mockReturnValue([]),
   getLastHeartbeat: vi.fn(),
-  checkRateLimit: vi
-    .fn()
-    .mockReturnValue({
-      allowed: true,
-      info: { remaining: 10, reset: Date.now(), limit: 100 },
-    }),
+  checkRateLimit: vi.fn().mockReturnValue({
+    allowed: true,
+    info: { remaining: 10, reset: Date.now(), limit: 100 },
+  }),
   recordRequest: vi.fn(),
   resetRateLimit: vi.fn(),
   closeAll: vi.fn(),
@@ -191,6 +190,55 @@ describe('mapRunEventToStreamEvent', () => {
     expect(result?.type).toBe('session.stream.error');
     expect(result?.payload.error.code).toBe('unknown_error');
     expect(result?.payload.error.message).toBe('Unknown error');
+  });
+
+  it('should map run.activity event (with tool name)', () => {
+    const event: RunEvent = {
+      type: 'run.activity',
+      runId: 'run-123',
+      sessionId: 'session-456',
+      agentId: 'agent-789',
+      timestamp: '2024-01-01T00:00:12.000Z',
+      data: {
+        phase: 'running_tool',
+        toolName: 'exec_run',
+        elapsedMs: 12000,
+      },
+    };
+
+    const result = mapRunEventToStreamEvent(
+      event,
+    ) as SessionStreamActivity | null;
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('session.stream.activity');
+    expect(result?.payload.phase).toBe('running_tool');
+    expect(result?.payload.toolName).toBe('exec_run');
+    expect(result?.payload.elapsedMs).toBe(12000);
+  });
+
+  it('should map run.activity event (thinking, no tool name)', () => {
+    const event: RunEvent = {
+      type: 'run.activity',
+      runId: 'run-123',
+      sessionId: 'session-456',
+      agentId: 'agent-789',
+      timestamp: '2024-01-01T00:00:02.000Z',
+      data: {
+        phase: 'thinking',
+        elapsedMs: 2000,
+      },
+    };
+
+    const result = mapRunEventToStreamEvent(
+      event,
+    ) as SessionStreamActivity | null;
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('session.stream.activity');
+    expect(result?.payload.phase).toBe('thinking');
+    expect(result?.payload.toolName).toBeUndefined();
+    expect(result?.payload.elapsedMs).toBe(2000);
   });
 
   it('should return null for unknown event types', () => {

--- a/apps/server/src/websocket/streaming.ts
+++ b/apps/server/src/websocket/streaming.ts
@@ -14,6 +14,7 @@ import {
   type SessionStreamExecOutput,
   type SessionStreamToolCancelled,
   type SessionStreamRunCancelled,
+  type SessionStreamActivity,
   type SessionStreamUsage,
   type SessionStreamEnd,
   type SessionStreamError,
@@ -35,6 +36,7 @@ export type SessionStreamEvent =
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
   | SessionStreamRunCancelled
+  | SessionStreamActivity
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -128,6 +130,18 @@ export function mapRunEventToStreamEvent(
         sessionId: event.sessionId,
         runId: event.runId,
       }) as SessionStreamRunCancelled;
+    }
+
+    case 'run.activity': {
+      return createWSMessage('session.stream.activity', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        phase: event.data.phase as 'thinking' | 'running_tool',
+        elapsedMs: event.data.elapsedMs as number,
+        ...(event.data.toolName !== undefined && {
+          toolName: event.data.toolName as string,
+        }),
+      }) as SessionStreamActivity;
     }
 
     case 'run.completed': {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -120,6 +120,15 @@ function AppContent(props: AppContentProps) {
   const [currentRunId, setCurrentRunId] = createSignal<string | undefined>(
     undefined,
   );
+  // Server-driven activity heartbeat for the current run (#378).
+  const [runActivity, setRunActivity] = createSignal<
+    | {
+        phase: 'thinking' | 'running_tool' | 'cancelled' | 'failed';
+        toolName?: string;
+        elapsedMs: number;
+      }
+    | undefined
+  >(undefined);
   // Client-side queue of messages typed while the agent is responding.
   const messageQueue = useMessageQueue();
   const [pendingUserMessage, setPendingUserMessage] = createSignal<
@@ -161,6 +170,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       const sid = selectedSessionId();
       if (sid) {
@@ -183,6 +193,21 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(true);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity({ phase: 'thinking', elapsedMs: 0 });
+      armStreamWatchdog();
+    };
+
+    // Server-driven activity heartbeat — what the agent is doing between
+    // events, with a run-elapsed counter the badge ticks locally (#378).
+    const handleActivity = (event: {
+      payload: {
+        phase: 'thinking' | 'running_tool';
+        toolName?: string;
+        elapsedMs: number;
+      };
+    }) => {
+      const { phase, toolName, elapsedMs } = event.payload;
+      setRunActivity({ phase, elapsedMs, ...(toolName ? { toolName } : {}) });
       armStreamWatchdog();
     };
 
@@ -250,6 +275,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
       queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
@@ -261,6 +287,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       // Refresh messages to show the completed response
       queryClient.invalidateQueries({
@@ -283,6 +310,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
     };
 
@@ -320,6 +348,10 @@ function AppContent(props: AppContentProps) {
       'session.stream.run_cancelled',
       handleRunCancelled,
     );
+    const unsubActivity = wsClient.on(
+      'session.stream.activity',
+      handleActivity,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sessionId).catch((err: Error) => {
@@ -338,6 +370,7 @@ function AppContent(props: AppContentProps) {
       unsubExecOutput();
       unsubToolCancelled();
       unsubRunCancelled();
+      unsubActivity();
       setFocusChatInput(undefined); // Clear stale focus function
     });
   });
@@ -827,6 +860,7 @@ function AppContent(props: AppContentProps) {
               }
               onCancelTool={handleCancelTool}
               onCancelRun={handleCancelRun}
+              runActivity={isStreaming() ? runActivity() : undefined}
               queuedMessages={messageQueue.items()}
               onEditQueued={messageQueue.edit}
               onRemoveQueued={messageQueue.remove}

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -205,5 +205,21 @@ describe('ChatView', () => {
         screen.queryByRole('button', { name: 'Stop agent' }),
       ).not.toBeInTheDocument();
     });
+
+    it('renders the activity badge from runActivity', () => {
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          runActivity={{
+            phase: 'running_tool',
+            toolName: 'exec_run',
+            elapsedMs: 7000,
+          }}
+        />
+      ));
+      expect(screen.getByText('Running exec_run…')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -14,6 +14,8 @@ import { MessageContent } from './MessageContent';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock, ToolResultBlock } from './ToolBlocks';
 import { QueuedMessageCard } from './QueuedMessageCard';
+import { RunActivityBadge } from './RunActivityBadge';
+import type { RunActivityPhase } from './RunActivityBadge';
 
 type StreamingToolCall = {
   id: string;
@@ -40,6 +42,12 @@ type ChatViewProps = {
   onCancelTool?: (toolCallId: string) => void;
   /** Ask the server to cancel the whole in-flight run ("Stop agent"). */
   onCancelRun?: () => void;
+  /** Server-driven activity heartbeat for the in-flight run (#378). */
+  runActivity?: {
+    phase: RunActivityPhase;
+    toolName?: string;
+    elapsedMs: number;
+  };
   /** Message ID to scroll to (e.g. from clicking a run) */
   scrollToMessageId?: string;
 };
@@ -262,6 +270,16 @@ export function ChatView(props: ChatViewProps) {
                 <div class="text-text-secondary mb-2">
                   <MessageContent content={props.streamingContent!} />
                   <span class="inline-block w-2 h-4 bg-primary animate-pulse ml-0.5" />
+                </div>
+              </Show>
+              {/* Live activity heartbeat — what the agent is doing right now */}
+              <Show when={props.runActivity}>
+                <div class="mb-2">
+                  <RunActivityBadge
+                    phase={props.runActivity!.phase}
+                    toolName={props.runActivity!.toolName}
+                    elapsedMs={props.runActivity!.elapsedMs}
+                  />
                 </div>
               </Show>
               <Show when={(props.streamingToolCalls?.length ?? 0) > 0}>

--- a/apps/web/src/components/RunActivityBadge.test.tsx
+++ b/apps/web/src/components/RunActivityBadge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@solidjs/testing-library';
+import { RunActivityBadge } from './RunActivityBadge';
+
+vi.mock('lucide-solid', () => ({
+  Loader: () => <span data-testid="loader" />,
+  Ban: () => <span data-testid="ban" />,
+}));
+
+describe('RunActivityBadge', () => {
+  it('shows "Thinking…" with an elapsed counter', () => {
+    render(() => <RunActivityBadge phase="thinking" elapsedMs={3000} />);
+    expect(screen.getByText('Thinking…')).toBeInTheDocument();
+    expect(screen.getByText('3s')).toBeInTheDocument();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('shows the running tool name and elapsed time', () => {
+    render(() => (
+      <RunActivityBadge
+        phase="running_tool"
+        toolName="exec_run"
+        elapsedMs={12000}
+      />
+    ));
+    expect(screen.getByText('Running exec_run…')).toBeInTheDocument();
+    expect(screen.getByText('12s')).toBeInTheDocument();
+  });
+
+  it('shows a terminal "Cancelled" state with no counter or spinner', () => {
+    render(() => <RunActivityBadge phase="cancelled" elapsedMs={5000} />);
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    expect(screen.queryByText('5s')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ban')).toBeInTheDocument();
+  });
+
+  describe('local ticker', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('ticks the elapsed seconds locally without new events', () => {
+      render(() => <RunActivityBadge phase="thinking" elapsedMs={0} />);
+      expect(screen.getByText('0s')).toBeInTheDocument();
+      vi.advanceTimersByTime(2000);
+      expect(screen.getByText('2s')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/RunActivityBadge.tsx
+++ b/apps/web/src/components/RunActivityBadge.tsx
@@ -1,0 +1,80 @@
+import { createSignal, createEffect, onCleanup, Show } from 'solid-js';
+import { Loader, Ban } from 'lucide-solid';
+
+export type RunActivityPhase =
+  | 'thinking'
+  | 'running_tool'
+  | 'cancelled'
+  | 'failed';
+
+type RunActivityBadgeProps = {
+  /** What the agent is currently doing. */
+  phase: RunActivityPhase;
+  /** Tool name shown when `phase` is `running_tool`. */
+  toolName?: string;
+  /** Server-reported run elapsed time (ms); the badge ticks locally from here. */
+  elapsedMs: number;
+};
+
+/**
+ * Small read-only pill above the streaming message that surfaces what the
+ * agent is doing between events — "Thinking…" or "Running <tool>… 12s" — with
+ * a locally-ticking elapsed counter (issue #378). The server drives the phase
+ * via `session.stream.activity`; the seconds are interpolated client-side so
+ * the counter is smooth without flooding the WS.
+ */
+export function RunActivityBadge(props: RunActivityBadgeProps) {
+  const [displayMs, setDisplayMs] = createSignal(props.elapsedMs);
+
+  const isTerminal = () =>
+    props.phase === 'cancelled' || props.phase === 'failed';
+
+  // Re-anchor whenever the server sends a fresh elapsed value or the phase
+  // changes, then tick locally every 250ms. Terminal phases don't tick. The
+  // effect's onCleanup clears the prior interval, so nothing leaks.
+  createEffect(() => {
+    const serverMs = props.elapsedMs;
+    setDisplayMs(serverMs);
+    if (isTerminal()) return;
+    const anchor = Date.now() - serverMs;
+    const timer = setInterval(() => setDisplayMs(Date.now() - anchor), 250);
+    onCleanup(() => clearInterval(timer));
+  });
+
+  const seconds = () => Math.max(0, Math.floor(displayMs() / 1000));
+
+  const label = () => {
+    switch (props.phase) {
+      case 'running_tool':
+        return `Running ${props.toolName ?? 'tool'}…`;
+      case 'cancelled':
+        return 'Cancelled';
+      case 'failed':
+        return 'Failed';
+      default:
+        return 'Thinking…';
+    }
+  };
+
+  return (
+    <div
+      aria-live="polite"
+      class={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs ${
+        isTerminal()
+          ? 'border-red-200 dark:border-red-800 text-red-600 dark:text-red-400'
+          : 'border-gray-200 dark:border-gray-700 text-text-tertiary'
+      }`}
+    >
+      <Show
+        when={!isTerminal()}
+        fallback={<Ban class="w-3 h-3 flex-shrink-0" />}
+      >
+        <Loader class="w-3 h-3 flex-shrink-0 animate-spin" />
+      </Show>
+      <span>{label()}</span>
+      <Show when={!isTerminal()}>
+        <span class="tabular-nums opacity-70">{seconds()}s</span>
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/components/tasks/TaskExecutionView.tsx
+++ b/apps/web/src/components/tasks/TaskExecutionView.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../lib/api-tasks';
 import { useWebSocketContext } from '../../lib/ws-provider';
 import { submitMessageStreaming } from '../../lib/ws-api';
+import { RunActivityBadge } from '../RunActivityBadge';
 
 /**
  * Session message type
@@ -41,7 +42,7 @@ export type TaskExecutionViewProps = {
  */
 export function TaskExecutionView(props: TaskExecutionViewProps) {
   const { client, isConnected } = useWebSocketContext();
-  
+
   const [task, setTask] = createSignal<TaskWithDetails | null>(null);
   const [sessionId, setSessionId] = createSignal<string | null>(null);
   const [messages, setMessages] = createSignal<SessionMessage[]>([]);
@@ -49,23 +50,43 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
   const [inputValue, setInputValue] = createSignal('');
   const [isExecuting, setIsExecuting] = createSignal(false);
   const [isStreaming, setIsStreaming] = createSignal(false);
+  const [runActivity, setRunActivity] = createSignal<
+    | {
+        phase: 'thinking' | 'running_tool' | 'cancelled' | 'failed';
+        toolName?: string;
+        elapsedMs: number;
+      }
+    | undefined
+  >(undefined);
   const [error, setError] = createSignal<string | null>(null);
 
   // Subscribe to streaming events when we have a session and WebSocket is connected
   createEffect(() => {
     const sid = sessionId();
     const wsClient = client();
-    
+
     if (!sid || !wsClient || !isConnected()) return;
 
     // Subscribe to session stream events
     const handleStreamStart = () => {
       setIsStreaming(true);
       setStreamingContent('');
+      setRunActivity({ phase: 'thinking', elapsedMs: 0 });
     };
 
     const handleStreamDelta = (event: { payload: { content: string } }) => {
       setStreamingContent((prev) => prev + event.payload.content);
+    };
+
+    const handleActivity = (event: {
+      payload: {
+        phase: 'thinking' | 'running_tool';
+        toolName?: string;
+        elapsedMs: number;
+      };
+    }) => {
+      const { phase, toolName, elapsedMs } = event.payload;
+      setRunActivity({ phase, elapsedMs, ...(toolName ? { toolName } : {}) });
     };
 
     const handleStreamEnd = () => {
@@ -82,18 +103,26 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
       }
       setIsStreaming(false);
       setStreamingContent('');
+      setRunActivity(undefined);
     };
 
-    const handleStreamError = (event: { payload: { error: { message: string } } }) => {
+    const handleStreamError = (event: {
+      payload: { error: { message: string } };
+    }) => {
       setError(event.payload.error.message);
       setIsStreaming(false);
       setStreamingContent('');
+      setRunActivity(undefined);
     };
 
     const unsubStart = wsClient.on('session.stream.start', handleStreamStart);
     const unsubDelta = wsClient.on('session.stream.delta', handleStreamDelta);
     const unsubEnd = wsClient.on('session.stream.end', handleStreamEnd);
     const unsubError = wsClient.on('session.stream.error', handleStreamError);
+    const unsubActivity = wsClient.on(
+      'session.stream.activity',
+      handleActivity,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sid).catch((err) => {
@@ -105,6 +134,7 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
       unsubDelta();
       unsubEnd();
       unsubError();
+      unsubActivity();
     });
   });
 
@@ -148,7 +178,9 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
         setError(result.error.message);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start execution');
+      setError(
+        err instanceof Error ? err.message : 'Failed to start execution',
+      );
     } finally {
       setIsExecuting(false);
     }
@@ -223,11 +255,13 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
           </Show>
           {/* WebSocket connection status */}
           <Show when={sessionId()}>
-            <span class={`px-2 py-0.5 text-xs rounded ${
-              isConnected() 
-                ? 'bg-green-100 text-green-700' 
-                : 'bg-red-100 text-red-700'
-            }`}>
+            <span
+              class={`px-2 py-0.5 text-xs rounded ${
+                isConnected()
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-red-100 text-red-700'
+              }`}
+            >
               {isConnected() ? 'WS Connected' : 'WS Disconnected'}
             </span>
           </Show>
@@ -243,9 +277,7 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
 
       {/* Error state */}
       <Show when={error()}>
-        <div class="p-4 bg-red-50 text-red-600 text-sm">
-          {error()}
-        </div>
+        <div class="p-4 bg-red-50 text-red-600 text-sm">{error()}</div>
       </Show>
 
       {/* Execution prompt */}
@@ -289,11 +321,13 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
                   message.role === 'user'
                     ? 'bg-blue-50 ml-8'
                     : message.role === 'assistant'
-                    ? 'bg-gray-50 mr-8'
-                    : 'bg-yellow-50'
+                      ? 'bg-gray-50 mr-8'
+                      : 'bg-yellow-50'
                 }`}
               >
-                <div class="text-xs text-gray-500 mb-1 capitalize">{message.role}</div>
+                <div class="text-xs text-gray-500 mb-1 capitalize">
+                  {message.role}
+                </div>
                 <div class="text-sm text-gray-900 whitespace-pre-wrap">
                   {message.content}
                 </div>
@@ -307,19 +341,46 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
           {/* Streaming indicator with live content */}
           <Show when={isStreaming()}>
             <div class="p-3 bg-gray-50 rounded-lg mr-8">
-              <Show when={streamingContent()} fallback={
-                <div class="flex items-center gap-2 text-gray-500">
-                  <Loader2 class="w-4 h-4 animate-spin" />
-                  <span class="text-sm">Agent is typing...</span>
-                </div>
-              }>
+              <Show
+                when={streamingContent()}
+                fallback={
+                  <Show
+                    when={runActivity()}
+                    fallback={
+                      <div class="flex items-center gap-2 text-gray-500">
+                        <Loader2 class="w-4 h-4 animate-spin" />
+                        <span class="text-sm">Agent is typing...</span>
+                      </div>
+                    }
+                  >
+                    <RunActivityBadge
+                      phase={runActivity()!.phase}
+                      toolName={runActivity()!.toolName}
+                      elapsedMs={runActivity()!.elapsedMs}
+                    />
+                  </Show>
+                }
+              >
                 <div class="text-xs text-gray-500 mb-1">assistant</div>
                 <div class="text-sm text-gray-900 whitespace-pre-wrap">
                   {streamingContent()}
                 </div>
-                <div class="flex items-center gap-1 mt-1 text-xs text-gray-400">
-                  <Loader2 class="w-3 h-3 animate-spin" />
-                  <span>streaming...</span>
+                <div class="mt-1">
+                  <Show
+                    when={runActivity()}
+                    fallback={
+                      <div class="flex items-center gap-1 text-xs text-gray-400">
+                        <Loader2 class="w-3 h-3 animate-spin" />
+                        <span>streaming...</span>
+                      </div>
+                    }
+                  >
+                    <RunActivityBadge
+                      phase={runActivity()!.phase}
+                      toolName={runActivity()!.toolName}
+                      elapsedMs={runActivity()!.elapsedMs}
+                    />
+                  </Show>
                 </div>
               </Show>
             </div>

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -547,6 +547,22 @@ export type SessionStreamRunCancelled = WSMessage<
   }
 >;
 
+/**
+ * Server-driven liveness heartbeat so the UI can show what the agent is doing
+ * between other events ("Thinking…" / "Running <tool>… 12s"). At most one per
+ * second per run (#378).
+ */
+export type SessionStreamActivity = WSMessage<
+  'session.stream.activity',
+  {
+    sessionId: string;
+    runId: string;
+    phase: 'thinking' | 'running_tool';
+    toolName?: string;
+    elapsedMs: number;
+  }
+>;
+
 export type SessionRunChoicesEvent = WSMessage<
   'session.run.choices',
   ChoicesEvent
@@ -559,6 +575,7 @@ export type SessionStreamEvent =
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
   | SessionStreamRunCancelled
+  | SessionStreamActivity
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -1072,6 +1089,7 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
   'session.stream.run_cancelled',
+  'session.stream.activity',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
@@ -1104,6 +1122,7 @@ const STREAM_EVENT_TYPES: Set<string> = new Set([
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
   'session.stream.run_cancelled',
+  'session.stream.activity',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',


### PR DESCRIPTION
Closes #378. **Phase 3 of the cancel/streaming series, stacked on #375 → #376** (base branch is `worktree-issue-376`; the diff here is only the #378 delta). Merge #391 and #392 first.

Surfaces what the agent is doing **between events** so the user knows it's alive — and, combined with the Stop buttons from #375/#376, knows when to cancel.

## Server — activity heartbeat
- A 1s `setInterval` in the streaming loop emits a new `run.activity` event `{ phase, toolName?, elapsedMs }` **only when the run has been idle >500ms** since the last real event — so a run that's actively streaming content stays quiet (satisfies the "zero events while streaming" criterion). Phase tracks `thinking` vs `running_tool` (set around each builtin tool call).
- Emitted under the **WS-level `runId`** so it reaches the subscribed client, and the interval is **always cleared in the run's `finally`** — no leaked timers.
- New `RunEventType` `run.activity` + `emitActivity`, WS outbound `session.stream.activity`, shared-types plumbing. No inbound message (heartbeat is server-driven).

### Also fixes a #376 routing gap
While tracing which `runId` channel the client subscribes to, I found that a cancelled run resolved via `emitFailed` on the WS run channel — so the client never actually received `session.stream.run_cancelled` (it got a generic stream error instead). The handler now emits `run.cancelled` for a `cancelled` result. The service still marks the DB row cancelled and emits on its own `run.id` channel. This makes #376's Stop-agent deliver the clean "Cancelled" the UI expects.

## Web — RunActivityBadge
- New read-only pill: "Thinking…" / "Running exec_run… 12s" / terminal "Cancelled"/"Failed". The seconds **tick locally** every 250ms from the server-reported elapsed, re-anchored on each event, and the ticker tears down on terminal phases (no leaks).
- `ChatView` renders it between streaming content and the tool blocks; `App.tsx` holds run activity in state and clears it on end/error/cancel/watchdog; `TaskExecutionView` replaces its plain "streaming…" text with the badge.

## Tests
- `emitActivity` (with/without toolName), the `run.activity → session.stream.activity` mapper (both phases).
- `RunActivityBadge`: each phase, and the local ticker advancing 0s → 2s under fake timers.
- `ChatView`: badge renders from `runActivity`.
- All server (1044 in touched suites) + web (362) suites, typechecks, and lint pass locally.

## Acceptance criteria
- [x] "Thinking…" with a ticking counter in the gap before the first delta.
- [x] "Running exec_run… 12s" while a tool is in flight.
- [x] Flips back to "Thinking…" after a tool returns.
- [x] Badge stops updating on run termination (interval cleared in `finally`; ticker torn down on terminal phase).
- [x] No regression to streaming content / tool-call rendering.
- [x] ≤1 activity event per second per run, zero while streaming content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)