### PR TITLE
chore: land #376 + #378 into main (stacked PRs merged into intermediate branches)

### DIFF
--- a/apps/server/src/dispatch/events.test.ts
+++ b/apps/server/src/dispatch/events.test.ts
@@ -80,4 +80,52 @@ describe('RunEventEmitter', () => {
       expect(payload.choices).toEqual(['Yes', 'No']);
     });
   });
+
+  describe('emitActivity', () => {
+    it('publishes a run.activity event with phase, tool name, and elapsed', () => {
+      const listener = vi.fn();
+      emitter.subscribe('run-1', listener);
+
+      emitter.emitActivity({
+        runId: 'run-1',
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        phase: 'running_tool',
+        toolName: 'exec_run',
+        elapsedMs: 12000,
+      });
+
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]![0] as {
+        type: string;
+        runId: string;
+        data: { phase: string; toolName?: string; elapsedMs: number };
+      };
+      expect(event.type).toBe('run.activity');
+      expect(event.runId).toBe('run-1');
+      expect(event.data.phase).toBe('running_tool');
+      expect(event.data.toolName).toBe('exec_run');
+      expect(event.data.elapsedMs).toBe(12000);
+    });
+
+    it('omits toolName when not provided (thinking phase)', () => {
+      const listener = vi.fn();
+      emitter.subscribe('run-2', listener);
+
+      emitter.emitActivity({
+        runId: 'run-2',
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        phase: 'thinking',
+        elapsedMs: 500,
+      });
+
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]![0] as {
+        data: { phase: string; toolName?: string };
+      };
+      expect(event.data.phase).toBe('thinking');
+      expect(event.data.toolName).toBeUndefined();
+    });
+  });
 });

--- a/apps/server/src/dispatch/events.ts
+++ b/apps/server/src/dispatch/events.ts
@@ -11,6 +11,7 @@ export type RunEventType =
   | 'run.tool_call'
   | 'run.exec_output'
   | 'run.tool_cancelled'
+  | 'run.cancelled'
   | 'run.completed'
   | 'run.failed'
   | 'session.run.choices';
@@ -231,6 +232,24 @@ export class RunEventEmitter {
       data: {
         toolCallId: params.toolCallId,
       },
+    });
+  }
+
+  /**
+   * Emit a run.cancelled event (the whole run was aborted by the user).
+   */
+  emitRunCancelled(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+  }): void {
+    this.emit({
+      type: 'run.cancelled',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {},
     });
   }
 

--- a/apps/server/src/dispatch/events.ts
+++ b/apps/server/src/dispatch/events.ts
@@ -12,6 +12,7 @@ export type RunEventType =
   | 'run.exec_output'
   | 'run.tool_cancelled'
   | 'run.cancelled'
+  | 'run.activity'
   | 'run.completed'
   | 'run.failed'
   | 'session.run.choices';
@@ -250,6 +251,32 @@ export class RunEventEmitter {
       agentId: params.agentId,
       timestamp: new Date().toISOString(),
       data: {},
+    });
+  }
+
+  /**
+   * Emit a run.activity heartbeat (server-driven liveness indicator). Lets the
+   * UI show "Thinking…" / "Running <tool>… 12s" between other events (#378).
+   */
+  emitActivity(params: {
+    runId: string;
+    sessionId: string;
+    agentId: string;
+    phase: 'thinking' | 'running_tool';
+    toolName?: string;
+    elapsedMs: number;
+  }): void {
+    this.emit({
+      type: 'run.activity',
+      runId: params.runId,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      timestamp: new Date().toISOString(),
+      data: {
+        phase: params.phase,
+        elapsedMs: params.elapsedMs,
+        ...(params.toolName !== undefined && { toolName: params.toolName }),
+      },
     });
   }
 

--- a/apps/server/src/providers/infrastructure/anthropic/adapter.test.ts
+++ b/apps/server/src/providers/infrastructure/anthropic/adapter.test.ts
@@ -186,7 +186,10 @@ describe('AnthropicProvider', () => {
       });
 
       const provider = createAnthropicProvider({ apiKey: 'my-api-key' });
-      await provider.invoke({ model: 'claude-sonnet-4-20250514', messages: [{ role: 'user', content: 'Hi' }] });
+      await provider.invoke({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
@@ -195,7 +198,7 @@ describe('AnthropicProvider', () => {
             'x-api-key': 'my-api-key',
             'anthropic-version': expect.any(String),
           }),
-        })
+        }),
       );
     });
 
@@ -208,7 +211,9 @@ describe('AnthropicProvider', () => {
       const request: ModelRequest = {
         model: 'claude-sonnet-4-20250514',
         messages: [{ role: 'user', content: 'Hello' }],
-        tools: [{ name: 'test', description: 'Test', parameters: { type: 'object' } }],
+        tools: [
+          { name: 'test', description: 'Test', parameters: { type: 'object' } },
+        ],
       };
 
       const result = await provider.invoke(request);
@@ -229,8 +234,8 @@ describe('AnthropicProvider', () => {
             status: 429,
             statusText: 'Too Many Requests',
             headers: { 'Content-Type': 'application/json' },
-          }
-        )
+          },
+        ),
       );
 
       const provider = createAnthropicProvider({ apiKey: 'test-key' });
@@ -253,7 +258,12 @@ describe('AnthropicProvider', () => {
           type: 'message',
           role: 'assistant',
           content: [
-            { type: 'tool_use', id: 'toolu_1', name: 'get_weather', input: { city: 'Berlin' } },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'get_weather',
+              input: { city: 'Berlin' },
+            },
           ],
           model: 'claude-sonnet-4-20250514',
           stop_reason: 'tool_use',
@@ -298,6 +308,68 @@ describe('AnthropicProvider', () => {
       if (firstEvent && !firstEvent.ok) {
         expect(firstEvent.error.code).toBe('provider.capability_unsupported');
       }
+    });
+
+    it('aborts the fetch when the external request signal aborts (#376)', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+        headers: new Headers(),
+      });
+
+      const provider = createAnthropicProvider({ apiKey: 'test-key' });
+      const external = new AbortController();
+
+      const events = [];
+      for await (const event of provider.invokeStream({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hello' }],
+        signal: external.signal,
+      })) {
+        events.push(event);
+      }
+
+      // The signal handed to fetch is a combined signal, distinct from the
+      // external one, but aborting the external must propagate to it.
+      const passedSignal = mockFetch.mock.calls[0]?.[1]?.signal as AbortSignal;
+      expect(passedSignal).toBeInstanceOf(AbortSignal);
+      expect(passedSignal.aborted).toBe(false);
+      external.abort();
+      expect(passedSignal.aborted).toBe(true);
+    });
+
+    it('passes an already-aborted external signal through to fetch (#376)', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+        headers: new Headers(),
+      });
+
+      const provider = createAnthropicProvider({ apiKey: 'test-key' });
+      const external = new AbortController();
+      external.abort();
+
+      const events = [];
+      for await (const event of provider.invokeStream({
+        model: 'claude-sonnet-4-20250514',
+        messages: [{ role: 'user', content: 'Hello' }],
+        signal: external.signal,
+      })) {
+        events.push(event);
+      }
+
+      const passedSignal = mockFetch.mock.calls[0]?.[1]?.signal as AbortSignal;
+      expect(passedSignal.aborted).toBe(true);
     });
 
     it('should stream model output', async () => {
@@ -354,7 +426,10 @@ describe('Factory functions', () => {
   });
 
   it('createClaudeModelProvider should create provider with specific model', () => {
-    const provider = createClaudeModelProvider('test-key', 'claude-opus-4-20250514');
+    const provider = createClaudeModelProvider(
+      'test-key',
+      'claude-opus-4-20250514',
+    );
 
     expect(provider.descriptor.id).toBe('anthropic-claude-opus-4-20250514');
     expect(provider.descriptor.name).toBe('Anthropic claude-opus-4-20250514');

--- a/apps/server/src/providers/infrastructure/anthropic/adapter.ts
+++ b/apps/server/src/providers/infrastructure/anthropic/adapter.ts
@@ -54,7 +54,10 @@ const PROVIDER_NAME = 'Anthropic';
 /**
  * Common Anthropic models with their capabilities
  */
-const KNOWN_MODELS: Record<string, { name: string; capabilities: ProviderCapability[] }> = {
+const KNOWN_MODELS: Record<
+  string,
+  { name: string; capabilities: ProviderCapability[] }
+> = {
   'claude-opus-4-20250514': {
     name: 'Claude Opus 4',
     capabilities: ['text_generation', 'streaming', 'tool_calls', 'vision'],
@@ -146,12 +149,14 @@ export class AnthropicProvider implements ModelProvider {
   async listModels(): Promise<ProviderResult<readonly ModelDescriptor[]>> {
     // Anthropic doesn't have a list models endpoint
     // Return known models based on documentation
-    const models: ModelDescriptor[] = Object.entries(KNOWN_MODELS).map(([id, info]) => ({
-      id,
-      providerId: this.descriptor.id,
-      name: info.name,
-      capabilities: this.buildModelCapabilities(info.capabilities),
-    }));
+    const models: ModelDescriptor[] = Object.entries(KNOWN_MODELS).map(
+      ([id, info]) => ({
+        id,
+        providerId: this.descriptor.id,
+        name: info.name,
+        capabilities: this.buildModelCapabilities(info.capabilities),
+      }),
+    );
 
     // Add default model if not in known list
     if (!models.find((m) => m.id === this.config.defaultModel)) {
@@ -184,16 +189,22 @@ export class AnthropicProvider implements ModelProvider {
       id: modelId,
       providerId: this.descriptor.id,
       name: modelId,
-      capabilities: this.buildModelCapabilities(['text_generation', 'streaming']),
+      capabilities: this.buildModelCapabilities([
+        'text_generation',
+        'streaming',
+      ]),
     });
   }
 
   private buildModelCapabilities(
-    modelCaps: ProviderCapability[]
+    modelCaps: ProviderCapability[],
   ): ProviderCapability[] {
     const caps: ProviderCapability[] = ['text_generation'];
 
-    if (modelCaps.includes('streaming') && this.config.enableStreaming !== false) {
+    if (
+      modelCaps.includes('streaming') &&
+      this.config.enableStreaming !== false
+    ) {
       caps.push('streaming');
     }
     if (modelCaps.includes('tool_calls') && this.config.enableTools !== false) {
@@ -220,33 +231,40 @@ export class AnthropicProvider implements ModelProvider {
 
   async invoke(request: ModelRequest): Promise<ProviderResult<ModelResponse>> {
     // Check capabilities
-    if (request.tools && request.tools.length > 0 && !this.hasCapability('tool_calls')) {
+    if (
+      request.tools &&
+      request.tools.length > 0 &&
+      !this.hasCapability('tool_calls')
+    ) {
       return err(
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${this.descriptor.id}" does not support tool calls`,
-          { providerId: this.descriptor.id, modelId: request.model }
-        )
+          { providerId: this.descriptor.id, modelId: request.model },
+        ),
       );
     }
 
     try {
       // Build options, filtering out undefined values for exactOptionalPropertyTypes
-      const mapperOptions: { defaultMaxTokens?: number; defaultTemperature?: number } = {};
+      const mapperOptions: {
+        defaultMaxTokens?: number;
+        defaultTemperature?: number;
+      } = {};
       if (this.config.defaultMaxTokens !== undefined) {
         mapperOptions.defaultMaxTokens = this.config.defaultMaxTokens;
       }
       if (this.config.defaultTemperature !== undefined) {
         mapperOptions.defaultTemperature = this.config.defaultTemperature;
       }
-      
+
       const anthropicRequest = mapRequest(request, mapperOptions);
 
       const response = await this.fetch(`${this.config.baseUrl}/messages`, {
         method: 'POST',
         headers: this.getHeaders(),
         body: JSON.stringify(anthropicRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -261,14 +279,19 @@ export class AnthropicProvider implements ModelProvider {
           normalizeError(isAnthropicError(errorData) ? errorData : response, {
             providerId: this.descriptor.id,
             modelId: request.model,
-          })
+          }),
         );
       }
 
       const data = (await response.json()) as AnthropicMessagesResponse;
       return ok(mapResponse(data, this.descriptor.id));
     } catch (error) {
-      return err(normalizeError(error, { providerId: this.descriptor.id, modelId: request.model }));
+      return err(
+        normalizeError(error, {
+          providerId: this.descriptor.id,
+          modelId: request.model,
+        }),
+      );
     }
   }
 
@@ -276,15 +299,17 @@ export class AnthropicProvider implements ModelProvider {
   // Streaming Invocation
   // =====================
 
-  async *invokeStream(request: ModelRequest): AsyncIterable<ProviderResult<ModelStreamEvent>> {
+  async *invokeStream(
+    request: ModelRequest,
+  ): AsyncIterable<ProviderResult<ModelStreamEvent>> {
     // Check streaming capability
     if (!this.hasCapability('streaming')) {
       yield err(
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${this.descriptor.id}" does not support streaming`,
-          { providerId: this.descriptor.id, modelId: request.model }
-        )
+          { providerId: this.descriptor.id, modelId: request.model },
+        ),
       );
       return;
     }
@@ -299,21 +324,27 @@ export class AnthropicProvider implements ModelProvider {
 
     try {
       // Build options, filtering out undefined values for exactOptionalPropertyTypes
-      const mapperOptions: { defaultMaxTokens?: number; defaultTemperature?: number } = {};
+      const mapperOptions: {
+        defaultMaxTokens?: number;
+        defaultTemperature?: number;
+      } = {};
       if (this.config.defaultMaxTokens !== undefined) {
         mapperOptions.defaultMaxTokens = this.config.defaultMaxTokens;
       }
       if (this.config.defaultTemperature !== undefined) {
         mapperOptions.defaultTemperature = this.config.defaultTemperature;
       }
-      
-      const anthropicRequest = mapRequest({ ...request, stream: true }, mapperOptions);
+
+      const anthropicRequest = mapRequest(
+        { ...request, stream: true },
+        mapperOptions,
+      );
 
       const response = await this.fetch(`${this.config.baseUrl}/messages`, {
         method: 'POST',
         headers: { ...this.getHeaders(), Accept: 'text/event-stream' },
         body: JSON.stringify(anthropicRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -328,17 +359,21 @@ export class AnthropicProvider implements ModelProvider {
           normalizeError(isAnthropicError(errorData) ? errorData : response, {
             providerId: this.descriptor.id,
             modelId: request.model,
-          })
+          }),
         );
         return;
       }
 
       if (!response.body) {
         yield err(
-          createProviderError('provider.stream_error', 'Response body is null', {
-            providerId: this.descriptor.id,
-            modelId: request.model,
-          })
+          createProviderError(
+            'provider.stream_error',
+            'Response body is null',
+            {
+              providerId: this.descriptor.id,
+              modelId: request.model,
+            },
+          ),
         );
         return;
       }
@@ -399,7 +434,7 @@ export class AnthropicProvider implements ModelProvider {
                 event,
                 this.descriptor.id,
                 messageId,
-                model
+                model,
               )) {
                 yield ok(normalizedEvent);
               }
@@ -426,7 +461,12 @@ export class AnthropicProvider implements ModelProvider {
 
       // Note: finish reason tracking for tool calls could be added here if needed
     } catch (error) {
-      yield err(normalizeError(error, { providerId: this.descriptor.id, modelId: request.model }));
+      yield err(
+        normalizeError(error, {
+          providerId: this.descriptor.id,
+          modelId: request.model,
+        }),
+      );
       return;
     }
 
@@ -457,9 +497,27 @@ export class AnthropicProvider implements ModelProvider {
     return headers;
   }
 
-  private createAbortSignal(): AbortSignal {
+  private createAbortSignal(external?: AbortSignal): AbortSignal {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    if (external) {
+      if (external.aborted) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      } else {
+        external.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeoutId);
+            controller.abort();
+          },
+          { once: true },
+        );
+      }
+    }
     return controller.signal;
   }
 
@@ -475,7 +533,9 @@ export class AnthropicProvider implements ModelProvider {
 /**
  * Creates an Anthropic provider instance
  */
-export function createAnthropicProvider(config: AnthropicAdapterConfig): ModelProvider {
+export function createAnthropicProvider(
+  config: AnthropicAdapterConfig,
+): ModelProvider {
   return new AnthropicProvider(config);
 }
 
@@ -484,7 +544,7 @@ export function createAnthropicProvider(config: AnthropicAdapterConfig): ModelPr
  */
 export function createClaudeProvider(
   apiKey: string,
-  options?: Partial<AnthropicAdapterConfig>
+  options?: Partial<AnthropicAdapterConfig>,
 ): ModelProvider {
   return createAnthropicProvider({
     apiKey,
@@ -502,7 +562,7 @@ export function createClaudeProvider(
 export function createClaudeModelProvider(
   apiKey: string,
   model: string,
-  options?: Partial<AnthropicAdapterConfig>
+  options?: Partial<AnthropicAdapterConfig>,
 ): ModelProvider {
   return createAnthropicProvider({
     apiKey,

--- a/apps/server/src/providers/infrastructure/gemini/adapter.ts
+++ b/apps/server/src/providers/infrastructure/gemini/adapter.ts
@@ -471,7 +471,7 @@ export class GeminiProvider implements ModelProvider {
         method: 'POST',
         headers: this.getHeaders(),
         body: JSON.stringify(geminiRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -565,7 +565,7 @@ export class GeminiProvider implements ModelProvider {
         method: 'POST',
         headers: { ...this.getHeaders(), Accept: 'text/event-stream' },
         body: JSON.stringify(geminiRequest),
-        signal: this.createAbortSignal(),
+        signal: this.createAbortSignal(request.signal),
       });
 
       if (!response.ok) {
@@ -695,12 +695,27 @@ export class GeminiProvider implements ModelProvider {
     return headers;
   }
 
-  private createAbortSignal(): AbortSignal {
+  private createAbortSignal(external?: AbortSignal): AbortSignal {
     const controller = new AbortController();
-    setTimeout(
+    const timeoutId = setTimeout(
       () => controller.abort(),
       this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     );
+    if (external) {
+      if (external.aborted) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      } else {
+        external.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeoutId);
+            controller.abort();
+          },
+          { once: true },
+        );
+      }
+    }
     return controller.signal;
   }
 

--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.ts
@@ -374,7 +374,10 @@ export class OpenAICompatibleProvider implements ModelProvider {
       this.logger.info(
         `invoke: final requestParams = ${JSON.stringify({ ...requestParams, messages: '[...]' })}`,
       );
-      const response = await this.client.chat.completions.create(requestParams);
+      const response = await this.client.chat.completions.create(
+        requestParams,
+        request.signal ? { signal: request.signal } : {},
+      );
 
       return ok(
         this.mapResponse(response, modelId, toolMapping?.nameMap ?? new Map()),
@@ -444,7 +447,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
         requestParams.tools = tools;
       }
 
-      const stream = await this.client.chat.completions.create(requestParams);
+      // Forward the caller's abort signal (e.g. user "Stop agent") to the SDK
+      // so aborting it cancels the in-flight streaming request. The SDK applies
+      // its own per-request timeout (config.timeoutMs) alongside this.
+      const stream = await this.client.chat.completions.create(
+        requestParams,
+        request.signal ? { signal: request.signal } : {},
+      );
 
       let finishReason: 'stop' | 'length' | 'tool_calls' | 'content_filter' =
         'stop';

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -38,6 +38,7 @@ import {
   markRunRunning,
   markRunSucceeded,
   markRunFailed,
+  markRunCancelled,
   listSessionRunRecords,
   deleteSessionRecord,
 } from './store';
@@ -95,6 +96,11 @@ export class SessionMessageService {
   // (issue #375). Key: `${runId}:${toolCallId}`.
   private readonly inflightTools = new Map<string, AbortController>();
 
+  // In-flight run-level AbortControllers so a user "Stop agent" can abort the
+  // whole turn — the provider stream and any running tools (issue #376).
+  // Key: runId (the WS-level run id the client addresses).
+  private readonly inflightRuns = new Map<string, AbortController>();
+
   constructor(options: SessionMessageServiceOptions) {
     this.providers = options.providers;
     this.logger = options.logger;
@@ -129,6 +135,20 @@ export class SessionMessageService {
    */
   cancelTool(runId: string, toolCallId: string): boolean {
     const controller = this.inflightTools.get(`${runId}:${toolCallId}`);
+    if (!controller) return false;
+    controller.abort();
+    return true;
+  }
+
+  /**
+   * Cancel an in-flight run (user hit "Stop agent"). Aborts the run-level
+   * AbortSignal, which cancels the provider stream and any tool currently
+   * running under this run. The streaming loop marks the run `cancelled` and
+   * emits `run.cancelled` without persisting a final assistant message.
+   * Returns true if a matching in-flight run was found.
+   */
+  cancelRun(runId: string): boolean {
+    const controller = this.inflightRuns.get(runId);
     if (!controller) return false;
     controller.abort();
     return true;
@@ -824,6 +844,14 @@ export class SessionMessageService {
     // 4. Mark run as running
     await this.markRunRunning(run.id);
 
+    // Run-level AbortController: a user "Stop agent" aborts this, which cancels
+    // the provider stream and any tool running under this run (issue #376).
+    // Registered under the WS-level runId the client uses to address a cancel.
+    const runController = new AbortController();
+    if (input.runId) {
+      this.inflightRuns.set(input.runId, runController);
+    }
+
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
     const historyMessages: Message[] = history.map((m) => {
@@ -959,6 +987,8 @@ export class SessionMessageService {
           model: modelId,
           messages: loopMessages,
           ...(allTools.length > 0 && { tools: allTools, toolChoice: 'auto' }),
+          // Run-level cancel: aborting this signal cancels the provider fetch.
+          signal: runController.signal,
         };
 
         // Local accumulator for the tool calls the model
@@ -1136,6 +1166,16 @@ export class SessionMessageService {
                 : undefined;
               const controller = new AbortController();
               if (cancelKey) this.inflightTools.set(cancelKey, controller);
+              // A run-level "Stop agent" also aborts the tool in flight (#376).
+              if (runController.signal.aborted) {
+                controller.abort();
+              } else {
+                runController.signal.addEventListener(
+                  'abort',
+                  () => controller.abort(),
+                  { once: true },
+                );
+              }
 
               const builtinResult = await builtinTool
                 .execute(tc.arguments, {
@@ -1363,6 +1403,16 @@ export class SessionMessageService {
         break;
       }
 
+      // If the user hit "Stop agent", mark the run cancelled and bail without
+      // persisting a final assistant message (issue #376).
+      if (runController.signal.aborted) {
+        await this.markRunCancelled(run);
+        return {
+          ok: false,
+          error: { code: 'cancelled', message: 'Run cancelled by user' },
+        };
+      }
+
       // 7. Persist assistant message with accumulated content
       const assistantMessage = await this.appendMessage({
         sessionId: input.sessionId,
@@ -1394,6 +1444,15 @@ export class SessionMessageService {
 
       return { ok: true, userMessage, assistantMessage, run: updatedRun! };
     } catch (error) {
+      // A user "Stop agent" aborts the provider fetch, which surfaces here as
+      // an AbortError. Treat that as a cancellation, not a failure (issue #376).
+      if (runController.signal.aborted) {
+        await this.markRunCancelled(run);
+        return {
+          ok: false,
+          error: { code: 'cancelled', message: 'Run cancelled by user' },
+        };
+      }
       const errorMsg =
         error instanceof Error ? error.message : 'Streaming failed';
       return this.handleFailure(
@@ -1402,6 +1461,8 @@ export class SessionMessageService {
         'streaming_error',
         errorMsg,
       );
+    } finally {
+      if (input.runId) this.inflightRuns.delete(input.runId);
     }
   }
 
@@ -1608,6 +1669,25 @@ export class SessionMessageService {
       return this.runsRepo.markFailed(id, input);
     }
     return markRunFailed(id, input) ?? null;
+  }
+
+  /**
+   * Mark a run as cancelled (user hit "Stop agent") and emit run.cancelled.
+   */
+  private async markRunCancelled(
+    run: SessionRunRecord | SessionRun,
+  ): Promise<SessionRunRecord | SessionRun | null> {
+    const updated = this.runsRepo
+      ? await this.runsRepo.markCancelled(run.id)
+      : (markRunCancelled(run.id) ?? null);
+    if (this.runEvents && updated) {
+      this.runEvents.emitRunCancelled({
+        runId: run.id,
+        sessionId: run.sessionId,
+        agentId: run.agentId,
+      });
+    }
+    return updated;
   }
 
   /**

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -852,6 +852,36 @@ export class SessionMessageService {
       this.inflightRuns.set(input.runId, runController);
     }
 
+    // Server-driven activity heartbeat (issue #378): emit a `run.activity`
+    // event (at most 1/s) while the run is idle between other events, so the
+    // UI can show "Thinking…" / "Running <tool>… 12s". Emitted under the
+    // WS-level runId so it reaches the subscribed client; skipped for non-WS
+    // callers (no runId). `lastActivityAt` is bumped whenever we produce a
+    // real event, so a continuously-streaming run stays quiet.
+    const activityRunId = input.runId;
+    const runStartAt = Date.now();
+    let lastActivityAt = runStartAt;
+    let activityPhase: 'thinking' | 'running_tool' = 'thinking';
+    let activityToolName: string | undefined;
+    const heartbeat =
+      activityRunId && this.runEvents
+        ? setInterval(() => {
+            const now = Date.now();
+            // Already busy (event within the last 500ms) — stay quiet.
+            if (now - lastActivityAt < 500) return;
+            this.runEvents!.emitActivity({
+              runId: activityRunId,
+              sessionId: input.sessionId,
+              agentId,
+              phase: activityPhase,
+              elapsedMs: now - runStartAt,
+              ...(activityToolName !== undefined && {
+                toolName: activityToolName,
+              }),
+            });
+          }, 1000)
+        : undefined;
+
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
     const historyMessages: Message[] = history.map((m) => {
@@ -1031,6 +1061,11 @@ export class SessionMessageService {
           switch (value.type) {
             case 'stream.content_delta': {
               accumulatedContent += value.delta;
+              // Content is flowing — mark busy so the heartbeat stays quiet
+              // and the phase reads as thinking/streaming (#378).
+              lastActivityAt = Date.now();
+              activityPhase = 'thinking';
+              activityToolName = undefined;
               onStreamEvent({ type: 'delta', content: value.delta });
               break;
             }
@@ -1177,6 +1212,11 @@ export class SessionMessageService {
                 );
               }
 
+              // Reflect the running tool in the activity heartbeat (#378).
+              activityPhase = 'running_tool';
+              activityToolName = tc.name;
+              lastActivityAt = Date.now();
+
               const builtinResult = await builtinTool
                 .execute(tc.arguments, {
                   agentId,
@@ -1197,6 +1237,11 @@ export class SessionMessageService {
                 .finally(() => {
                   if (cancelKey) this.inflightTools.delete(cancelKey);
                 });
+
+              // Tool settled — back to thinking until the next tool runs (#378).
+              activityPhase = 'thinking';
+              activityToolName = undefined;
+              lastActivityAt = Date.now();
 
               // If the user cancelled this tool, tell the UI so it can mark the
               // block "Cancelled by user".
@@ -1462,6 +1507,7 @@ export class SessionMessageService {
         errorMsg,
       );
     } finally {
+      if (heartbeat) clearInterval(heartbeat);
       if (input.runId) this.inflightRuns.delete(input.runId);
     }
   }

--- a/apps/server/src/sessions/store.ts
+++ b/apps/server/src/sessions/store.ts
@@ -195,6 +195,13 @@ export function markRunFailed(
   return updateRunRecord(id, updates);
 }
 
+export function markRunCancelled(id: string): SessionRunRecord | undefined {
+  return updateRunRecord(id, {
+    status: 'cancelled',
+    finishedAt: new Date().toISOString(),
+  });
+}
+
 export function listSessionRunRecords(sessionId: string): SessionRunRecord[] {
   return Array.from(runs.values())
     .filter((r) => r.sessionId === sessionId)

--- a/apps/server/src/tools/agents/invoke.test.ts
+++ b/apps/server/src/tools/agents/invoke.test.ts
@@ -435,6 +435,63 @@ describe('agents_invoke_await tool', () => {
     }
   }, 35000); // 35 second timeout for this test
 
+  // ── Cancellation (issue #376) ────────────────────────────────────────────────
+
+  it('bails out immediately when ctx.signal is already aborted', async () => {
+    const svc = makeSessionService({
+      dispatchAgent: vi.fn().mockResolvedValue({
+        ok: true,
+        sessionId: 'sess-abc',
+        done: Promise.resolve({ ok: true }),
+      }),
+      listRuns: vi.fn().mockResolvedValue([{ id: 'run-1', status: 'running' }]),
+    });
+    const tool = makeTool({ sessionSvc: svc });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await tool.execute(
+      { agentId: 'researcher', content: 'hello' },
+      { agentId: 'test-agent', signal: controller.signal },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Cancelled by user while waiting/);
+    }
+    // The dispatched sub-agent is NOT cancelled — dispatch still happened.
+    expect(svc.dispatchAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('wakes from the poll backoff and cancels when aborted mid-wait', async () => {
+    const svc = makeSessionService({
+      dispatchAgent: vi.fn().mockResolvedValue({
+        ok: true,
+        sessionId: 'sess-abc',
+        done: Promise.resolve({ ok: true }),
+      }),
+      listRuns: vi.fn().mockResolvedValue([{ id: 'run-1', status: 'running' }]),
+    });
+    const tool = makeTool({ sessionSvc: svc });
+    const controller = new AbortController();
+    // Abort partway through the first 2s backoff interval.
+    setTimeout(() => controller.abort(), 50);
+
+    const start = Date.now();
+    const result = await tool.execute(
+      { agentId: 'researcher', content: 'hello' },
+      { agentId: 'test-agent', signal: controller.signal },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Cancelled by user while waiting/);
+    }
+    // Must have woken well before the full 2s backoff interval elapsed.
+    expect(elapsed).toBeLessThan(1500);
+  }, 10000);
+
   // ── dispatchAgent error propagation ─────────────────────────────────────────
 
   it('propagates dispatchAgent errors', async () => {

--- a/apps/server/src/tools/agents/invoke.ts
+++ b/apps/server/src/tools/agents/invoke.ts
@@ -89,10 +89,22 @@ export function createAgentsInvokeTool(deps: AgentToolsDeps): BuiltinTool {
 }
 
 /**
- * Sleep helper for polling delays
+ * Sleep helper for polling delays. Resolves early if `signal` aborts, so a
+ * user "Stop" wakes the wait immediately instead of riding out the interval.
  */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 export function createAgentsInvokeAndWaitTool(
@@ -123,7 +135,7 @@ export function createAgentsInvokeAndWaitTool(
       required: ['agentId', 'content'],
     },
 
-    async execute(args, _ctx) {
+    async execute(args, ctx) {
       const agentId = args['agentId'];
       const content = args['content'];
       const sessionId =
@@ -151,6 +163,7 @@ export function createAgentsInvokeAndWaitTool(
         };
       }
 
+      const signal = ctx?.signal;
       const sessionService = deps.getSessionService();
 
       // Step 1: Dispatch the agent
@@ -177,6 +190,17 @@ export function createAgentsInvokeAndWaitTool(
 
       try {
         while (totalWaited < MAX_WAIT_MS) {
+          // User hit Stop — bail out of the local wait. The dispatched
+          // sub-agent keeps running in its own session (its lifecycle is owned
+          // by the sub-session, not this tool call) and stays inspectable via
+          // sessions_read.
+          if (signal?.aborted) {
+            return {
+              ok: false,
+              error: 'Cancelled by user while waiting for agent response',
+            };
+          }
+
           // Check runs status using listRuns (lightweight, no full messages)
           const runs = await sessionService.listRuns(resolvedId);
           const lastRun = runs[runs.length - 1] as
@@ -217,8 +241,8 @@ export function createAgentsInvokeAndWaitTool(
             // Status is 'running' or 'queued' - continue polling
           }
 
-          // Wait with backoff
-          await sleep(currentInterval);
+          // Wait with backoff (wakes immediately if the user cancels)
+          await sleep(currentInterval, signal);
           totalWaited += currentInterval;
 
           // Exponential backoff: 2s -> 3s -> 4.5s -> 6s (capped)

--- a/apps/server/src/websocket/handlers/session.test.ts
+++ b/apps/server/src/websocket/handlers/session.test.ts
@@ -582,7 +582,7 @@ describe('registerSessionHandlers', () => {
 
     registerSessionHandlers(mockRouter, handler);
 
-    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(8);
+    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(9);
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.create',
       expect.any(Function),
@@ -613,6 +613,10 @@ describe('registerSessionHandlers', () => {
     );
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.tool.cancel',
+      expect.any(Function),
+    );
+    expect(mockRouter.registerHandler).toHaveBeenCalledWith(
+      'session.run.cancel',
       expect.any(Function),
     );
   });

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -24,6 +24,7 @@ import {
   type SessionMessagesRequest,
   type SessionRunsRequest,
   type SessionToolCancelRequest,
+  type SessionRunCancelRequest,
   type SessionCreatedResponse,
   type SessionMessageResponse,
   type SessionMessagesResponse,
@@ -382,6 +383,20 @@ export class SessionHandler {
   ): Promise<void> {
     const { runId, toolCallId } = request.payload;
     this.sessionService.cancelTool(runId, toolCallId);
+  }
+
+  /**
+   * Handle session.run.cancel — the user hit "Stop agent". Aborts the whole
+   * run (provider stream + any running tool); the UI reacts to the resulting
+   * run.cancelled event, so no response is returned.
+   */
+  async handleRunCancel(
+    _connectionId: string,
+    request: SessionRunCancelRequest,
+    _context: HandlerContext,
+  ): Promise<void> {
+    const { runId } = request.payload;
+    this.sessionService.cancelRun(runId);
   }
 
   /**
@@ -927,6 +942,10 @@ export function registerSessionHandlers(
 
   router.registerHandler('session.tool.cancel', (connId, msg, ctx) =>
     handler.handleToolCancel(connId, msg as SessionToolCancelRequest, ctx),
+  );
+
+  router.registerHandler('session.run.cancel', (connId, msg, ctx) =>
+    handler.handleRunCancel(connId, msg as SessionRunCancelRequest, ctx),
   );
 }
 

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -736,6 +736,12 @@ export class SessionHandler {
             'Auto-rename session failed (non-fatal)',
           );
         });
+      } else if (result.error.code === 'cancelled') {
+        // User hit "Stop agent" — deliver a clean run.cancelled on the
+        // WS-level run channel the client is subscribed to (issue #376), not a
+        // generic stream error. (The service also marks the run cancelled and
+        // emits on its own run.id channel for any run-id subscribers.)
+        this.runEvents?.emitRunCancelled({ runId, sessionId, agentId });
       } else {
         // Emit failure
         this.runEvents?.emitFailed({

--- a/apps/server/src/websocket/index.ts
+++ b/apps/server/src/websocket/index.ts
@@ -85,6 +85,7 @@ const MESSAGE_CAPABILITIES: Partial<Record<string, string[]>> = {
   'session.subscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.unsubscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.tool.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
+  'session.run.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
   'agent.list': [WS_CAPABILITIES.AGENTS_READ],
   'agent.get': [WS_CAPABILITIES.AGENTS_READ],
   'provider.list': [WS_CAPABILITIES.PROVIDERS_READ],

--- a/apps/server/src/websocket/integration/session-integration.test.ts
+++ b/apps/server/src/websocket/integration/session-integration.test.ts
@@ -660,12 +660,13 @@ describe('Session Integration Tests', () => {
       expect(messageRouter.hasHandler('session.messages')).toBe(true);
       expect(messageRouter.hasHandler('session.runs')).toBe(true);
       expect(messageRouter.hasHandler('session.tool.cancel')).toBe(true);
+      expect(messageRouter.hasHandler('session.run.cancel')).toBe(true);
     });
 
-    it('should have exactly 8 session handlers', () => {
+    it('should have exactly 9 session handlers', () => {
       const types = messageRouter.getHandlerTypes();
       const sessionHandlers = types.filter((t) => t.startsWith('session.'));
-      expect(sessionHandlers).toHaveLength(8);
+      expect(sessionHandlers).toHaveLength(9);
     });
   });
 

--- a/apps/server/src/websocket/streaming.test.ts
+++ b/apps/server/src/websocket/streaming.test.ts
@@ -12,6 +12,7 @@ import type {
   SessionStreamDelta,
   SessionStreamEnd,
   SessionStreamError,
+  SessionStreamActivity,
 } from '@openaidy/shared-types';
 
 // Mock logger
@@ -46,12 +47,10 @@ const createMockConnectionManager = () => ({
   updateHeartbeat: vi.fn(),
   checkStaleConnections: vi.fn().mockReturnValue([]),
   getLastHeartbeat: vi.fn(),
-  checkRateLimit: vi
-    .fn()
-    .mockReturnValue({
-      allowed: true,
-      info: { remaining: 10, reset: Date.now(), limit: 100 },
-    }),
+  checkRateLimit: vi.fn().mockReturnValue({
+    allowed: true,
+    info: { remaining: 10, reset: Date.now(), limit: 100 },
+  }),
   recordRequest: vi.fn(),
   resetRateLimit: vi.fn(),
   closeAll: vi.fn(),
@@ -191,6 +190,55 @@ describe('mapRunEventToStreamEvent', () => {
     expect(result?.type).toBe('session.stream.error');
     expect(result?.payload.error.code).toBe('unknown_error');
     expect(result?.payload.error.message).toBe('Unknown error');
+  });
+
+  it('should map run.activity event (with tool name)', () => {
+    const event: RunEvent = {
+      type: 'run.activity',
+      runId: 'run-123',
+      sessionId: 'session-456',
+      agentId: 'agent-789',
+      timestamp: '2024-01-01T00:00:12.000Z',
+      data: {
+        phase: 'running_tool',
+        toolName: 'exec_run',
+        elapsedMs: 12000,
+      },
+    };
+
+    const result = mapRunEventToStreamEvent(
+      event,
+    ) as SessionStreamActivity | null;
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('session.stream.activity');
+    expect(result?.payload.phase).toBe('running_tool');
+    expect(result?.payload.toolName).toBe('exec_run');
+    expect(result?.payload.elapsedMs).toBe(12000);
+  });
+
+  it('should map run.activity event (thinking, no tool name)', () => {
+    const event: RunEvent = {
+      type: 'run.activity',
+      runId: 'run-123',
+      sessionId: 'session-456',
+      agentId: 'agent-789',
+      timestamp: '2024-01-01T00:00:02.000Z',
+      data: {
+        phase: 'thinking',
+        elapsedMs: 2000,
+      },
+    };
+
+    const result = mapRunEventToStreamEvent(
+      event,
+    ) as SessionStreamActivity | null;
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('session.stream.activity');
+    expect(result?.payload.phase).toBe('thinking');
+    expect(result?.payload.toolName).toBeUndefined();
+    expect(result?.payload.elapsedMs).toBe(2000);
   });
 
   it('should return null for unknown event types', () => {

--- a/apps/server/src/websocket/streaming.ts
+++ b/apps/server/src/websocket/streaming.ts
@@ -13,6 +13,7 @@ import {
   type SessionStreamToolCall,
   type SessionStreamExecOutput,
   type SessionStreamToolCancelled,
+  type SessionStreamRunCancelled,
   type SessionStreamUsage,
   type SessionStreamEnd,
   type SessionStreamError,
@@ -33,6 +34,7 @@ export type SessionStreamEvent =
   | SessionStreamToolCall
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
+  | SessionStreamRunCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -119,6 +121,13 @@ export function mapRunEventToStreamEvent(
         runId: event.runId,
         toolCallId: event.data.toolCallId as string,
       }) as SessionStreamToolCancelled;
+    }
+
+    case 'run.cancelled': {
+      return createWSMessage('session.stream.run_cancelled', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+      }) as SessionStreamRunCancelled;
     }
 
     case 'run.completed': {

--- a/apps/server/src/websocket/streaming.ts
+++ b/apps/server/src/websocket/streaming.ts
@@ -14,6 +14,7 @@ import {
   type SessionStreamExecOutput,
   type SessionStreamToolCancelled,
   type SessionStreamRunCancelled,
+  type SessionStreamActivity,
   type SessionStreamUsage,
   type SessionStreamEnd,
   type SessionStreamError,
@@ -35,6 +36,7 @@ export type SessionStreamEvent =
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
   | SessionStreamRunCancelled
+  | SessionStreamActivity
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -128,6 +130,18 @@ export function mapRunEventToStreamEvent(
         sessionId: event.sessionId,
         runId: event.runId,
       }) as SessionStreamRunCancelled;
+    }
+
+    case 'run.activity': {
+      return createWSMessage('session.stream.activity', {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        phase: event.data.phase as 'thinking' | 'running_tool',
+        elapsedMs: event.data.elapsedMs as number,
+        ...(event.data.toolName !== undefined && {
+          toolName: event.data.toolName as string,
+        }),
+      }) as SessionStreamActivity;
     }
 
     case 'run.completed': {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -243,6 +243,19 @@ function AppContent(props: AppContentProps) {
       );
     };
 
+    const handleRunCancelled = () => {
+      // User hit "Stop agent": tear down the streaming UI, drop any partial
+      // content, and refresh so the run shows its cancelled status (#376).
+      clearStreamWatchdog();
+      setIsStreaming(false);
+      setStreamingContent('');
+      setStreamingToolCalls([]);
+      setPendingUserMessage(undefined);
+      queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
+      queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
+      processQueue();
+    };
+
     const handleStreamEnd = () => {
       clearStreamWatchdog();
       setIsStreaming(false);
@@ -303,6 +316,10 @@ function AppContent(props: AppContentProps) {
       'session.stream.tool_cancelled',
       handleToolCancelled,
     );
+    const unsubRunCancelled = wsClient.on(
+      'session.stream.run_cancelled',
+      handleRunCancelled,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sessionId).catch((err: Error) => {
@@ -320,6 +337,7 @@ function AppContent(props: AppContentProps) {
       unsubChoices();
       unsubExecOutput();
       unsubToolCancelled();
+      unsubRunCancelled();
       setFocusChatInput(undefined); // Clear stale focus function
     });
   });
@@ -443,6 +461,16 @@ function AppContent(props: AppContentProps) {
     const rid = currentRunId();
     if (wsClient && sid && rid) {
       wsClient.cancelTool(sid, rid, toolCallId);
+    }
+  };
+
+  // User hit "Stop agent" — ask the server to cancel the whole run (#376).
+  const handleCancelRun = () => {
+    const wsClient = client();
+    const sid = selectedSessionId();
+    const rid = currentRunId();
+    if (wsClient && sid && rid) {
+      wsClient.cancelRun(sid, rid);
     }
   };
 
@@ -798,6 +826,7 @@ function AppContent(props: AppContentProps) {
                 isStreaming() ? streamingToolCalls() : undefined
               }
               onCancelTool={handleCancelTool}
+              onCancelRun={handleCancelRun}
               queuedMessages={messageQueue.items()}
               onEditQueued={messageQueue.edit}
               onRemoveQueued={messageQueue.remove}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -120,6 +120,15 @@ function AppContent(props: AppContentProps) {
   const [currentRunId, setCurrentRunId] = createSignal<string | undefined>(
     undefined,
   );
+  // Server-driven activity heartbeat for the current run (#378).
+  const [runActivity, setRunActivity] = createSignal<
+    | {
+        phase: 'thinking' | 'running_tool' | 'cancelled' | 'failed';
+        toolName?: string;
+        elapsedMs: number;
+      }
+    | undefined
+  >(undefined);
   // Client-side queue of messages typed while the agent is responding.
   const messageQueue = useMessageQueue();
   const [pendingUserMessage, setPendingUserMessage] = createSignal<
@@ -161,6 +170,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       const sid = selectedSessionId();
       if (sid) {
@@ -183,6 +193,21 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(true);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity({ phase: 'thinking', elapsedMs: 0 });
+      armStreamWatchdog();
+    };
+
+    // Server-driven activity heartbeat — what the agent is doing between
+    // events, with a run-elapsed counter the badge ticks locally (#378).
+    const handleActivity = (event: {
+      payload: {
+        phase: 'thinking' | 'running_tool';
+        toolName?: string;
+        elapsedMs: number;
+      };
+    }) => {
+      const { phase, toolName, elapsedMs } = event.payload;
+      setRunActivity({ phase, elapsedMs, ...(toolName ? { toolName } : {}) });
       armStreamWatchdog();
     };
 
@@ -250,6 +275,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
       queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
@@ -261,6 +287,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
       // Refresh messages to show the completed response
       queryClient.invalidateQueries({
@@ -283,6 +310,7 @@ function AppContent(props: AppContentProps) {
       setIsStreaming(false);
       setStreamingContent('');
       setStreamingToolCalls([]);
+      setRunActivity(undefined);
       setPendingUserMessage(undefined);
     };
 
@@ -320,6 +348,10 @@ function AppContent(props: AppContentProps) {
       'session.stream.run_cancelled',
       handleRunCancelled,
     );
+    const unsubActivity = wsClient.on(
+      'session.stream.activity',
+      handleActivity,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sessionId).catch((err: Error) => {
@@ -338,6 +370,7 @@ function AppContent(props: AppContentProps) {
       unsubExecOutput();
       unsubToolCancelled();
       unsubRunCancelled();
+      unsubActivity();
       setFocusChatInput(undefined); // Clear stale focus function
     });
   });
@@ -827,6 +860,7 @@ function AppContent(props: AppContentProps) {
               }
               onCancelTool={handleCancelTool}
               onCancelRun={handleCancelRun}
+              runActivity={isStreaming() ? runActivity() : undefined}
               queuedMessages={messageQueue.items()}
               onEditQueued={messageQueue.edit}
               onRemoveQueued={messageQueue.remove}

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -205,5 +205,21 @@ describe('ChatView', () => {
         screen.queryByRole('button', { name: 'Stop agent' }),
       ).not.toBeInTheDocument();
     });
+
+    it('renders the activity badge from runActivity', () => {
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          runActivity={{
+            phase: 'running_tool',
+            toolName: 'exec_run',
+            elapsedMs: 7000,
+          }}
+        />
+      ));
+      expect(screen.getByText('Running exec_run…')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -178,5 +178,32 @@ describe('ChatView', () => {
       expect(screen.getByText('Cancelled by user')).toBeInTheDocument();
       expect(screen.queryByText('Stop')).not.toBeInTheDocument();
     });
+
+    it('shows a Stop agent button that invokes onCancelRun', () => {
+      const onCancelRun = vi.fn();
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+          onCancelRun={onCancelRun}
+        />
+      ));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop agent' }));
+      expect(onCancelRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits the Stop agent button when onCancelRun is not provided', () => {
+      render(() => (
+        <ChatView
+          messages={mockMessages}
+          isLoading={false}
+          isStreaming={true}
+        />
+      ));
+      expect(
+        screen.queryByRole('button', { name: 'Stop agent' }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -14,6 +14,8 @@ import { MessageContent } from './MessageContent';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock, ToolResultBlock } from './ToolBlocks';
 import { QueuedMessageCard } from './QueuedMessageCard';
+import { RunActivityBadge } from './RunActivityBadge';
+import type { RunActivityPhase } from './RunActivityBadge';
 
 type StreamingToolCall = {
   id: string;
@@ -40,6 +42,12 @@ type ChatViewProps = {
   onCancelTool?: (toolCallId: string) => void;
   /** Ask the server to cancel the whole in-flight run ("Stop agent"). */
   onCancelRun?: () => void;
+  /** Server-driven activity heartbeat for the in-flight run (#378). */
+  runActivity?: {
+    phase: RunActivityPhase;
+    toolName?: string;
+    elapsedMs: number;
+  };
   /** Message ID to scroll to (e.g. from clicking a run) */
   scrollToMessageId?: string;
 };
@@ -262,6 +270,16 @@ export function ChatView(props: ChatViewProps) {
                 <div class="text-text-secondary mb-2">
                   <MessageContent content={props.streamingContent!} />
                   <span class="inline-block w-2 h-4 bg-primary animate-pulse ml-0.5" />
+                </div>
+              </Show>
+              {/* Live activity heartbeat — what the agent is doing right now */}
+              <Show when={props.runActivity}>
+                <div class="mb-2">
+                  <RunActivityBadge
+                    phase={props.runActivity!.phase}
+                    toolName={props.runActivity!.toolName}
+                    elapsedMs={props.runActivity!.elapsedMs}
+                  />
                 </div>
               </Show>
               <Show when={(props.streamingToolCalls?.length ?? 0) > 0}>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,5 +1,12 @@
 import { Show, For, createEffect } from 'solid-js';
-import { User, Bot, AlertCircle, Wrench, Server } from 'lucide-solid';
+import {
+  User,
+  Bot,
+  AlertCircle,
+  Wrench,
+  Server,
+  CircleStop,
+} from 'lucide-solid';
 import type { SessionMessage } from '../lib/api';
 import type { QueuedMessage } from '../lib/types';
 import { TypingIndicator } from './TypingIndicator';
@@ -31,6 +38,8 @@ type ChatViewProps = {
   onRemoveQueued?: (id: string) => void;
   /** Ask the server to cancel an in-flight tool call. */
   onCancelTool?: (toolCallId: string) => void;
+  /** Ask the server to cancel the whole in-flight run ("Stop agent"). */
+  onCancelRun?: () => void;
   /** Message ID to scroll to (e.g. from clicking a run) */
   scrollToMessageId?: string;
 };
@@ -236,6 +245,18 @@ export function ChatView(props: ChatViewProps) {
                         : 'Thinking...'}
                   </span>
                 </span>
+                {/* Stop agent — aborts the whole run (provider stream + tools) */}
+                <Show when={props.onCancelRun}>
+                  <button
+                    type="button"
+                    onClick={() => props.onCancelRun?.()}
+                    aria-label="Stop agent"
+                    class="ml-auto inline-flex items-center gap-1 rounded border border-red-200 dark:border-red-800 px-2 py-0.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                  >
+                    <CircleStop class="w-3.5 h-3.5" />
+                    Stop agent
+                  </button>
+                </Show>
               </div>
               <Show when={props.streamingContent}>
                 <div class="text-text-secondary mb-2">

--- a/apps/web/src/components/RunActivityBadge.test.tsx
+++ b/apps/web/src/components/RunActivityBadge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@solidjs/testing-library';
+import { RunActivityBadge } from './RunActivityBadge';
+
+vi.mock('lucide-solid', () => ({
+  Loader: () => <span data-testid="loader" />,
+  Ban: () => <span data-testid="ban" />,
+}));
+
+describe('RunActivityBadge', () => {
+  it('shows "Thinking…" with an elapsed counter', () => {
+    render(() => <RunActivityBadge phase="thinking" elapsedMs={3000} />);
+    expect(screen.getByText('Thinking…')).toBeInTheDocument();
+    expect(screen.getByText('3s')).toBeInTheDocument();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('shows the running tool name and elapsed time', () => {
+    render(() => (
+      <RunActivityBadge
+        phase="running_tool"
+        toolName="exec_run"
+        elapsedMs={12000}
+      />
+    ));
+    expect(screen.getByText('Running exec_run…')).toBeInTheDocument();
+    expect(screen.getByText('12s')).toBeInTheDocument();
+  });
+
+  it('shows a terminal "Cancelled" state with no counter or spinner', () => {
+    render(() => <RunActivityBadge phase="cancelled" elapsedMs={5000} />);
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    expect(screen.queryByText('5s')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ban')).toBeInTheDocument();
+  });
+
+  describe('local ticker', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('ticks the elapsed seconds locally without new events', () => {
+      render(() => <RunActivityBadge phase="thinking" elapsedMs={0} />);
+      expect(screen.getByText('0s')).toBeInTheDocument();
+      vi.advanceTimersByTime(2000);
+      expect(screen.getByText('2s')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/RunActivityBadge.tsx
+++ b/apps/web/src/components/RunActivityBadge.tsx
@@ -1,0 +1,80 @@
+import { createSignal, createEffect, onCleanup, Show } from 'solid-js';
+import { Loader, Ban } from 'lucide-solid';
+
+export type RunActivityPhase =
+  | 'thinking'
+  | 'running_tool'
+  | 'cancelled'
+  | 'failed';
+
+type RunActivityBadgeProps = {
+  /** What the agent is currently doing. */
+  phase: RunActivityPhase;
+  /** Tool name shown when `phase` is `running_tool`. */
+  toolName?: string;
+  /** Server-reported run elapsed time (ms); the badge ticks locally from here. */
+  elapsedMs: number;
+};
+
+/**
+ * Small read-only pill above the streaming message that surfaces what the
+ * agent is doing between events — "Thinking…" or "Running <tool>… 12s" — with
+ * a locally-ticking elapsed counter (issue #378). The server drives the phase
+ * via `session.stream.activity`; the seconds are interpolated client-side so
+ * the counter is smooth without flooding the WS.
+ */
+export function RunActivityBadge(props: RunActivityBadgeProps) {
+  const [displayMs, setDisplayMs] = createSignal(props.elapsedMs);
+
+  const isTerminal = () =>
+    props.phase === 'cancelled' || props.phase === 'failed';
+
+  // Re-anchor whenever the server sends a fresh elapsed value or the phase
+  // changes, then tick locally every 250ms. Terminal phases don't tick. The
+  // effect's onCleanup clears the prior interval, so nothing leaks.
+  createEffect(() => {
+    const serverMs = props.elapsedMs;
+    setDisplayMs(serverMs);
+    if (isTerminal()) return;
+    const anchor = Date.now() - serverMs;
+    const timer = setInterval(() => setDisplayMs(Date.now() - anchor), 250);
+    onCleanup(() => clearInterval(timer));
+  });
+
+  const seconds = () => Math.max(0, Math.floor(displayMs() / 1000));
+
+  const label = () => {
+    switch (props.phase) {
+      case 'running_tool':
+        return `Running ${props.toolName ?? 'tool'}…`;
+      case 'cancelled':
+        return 'Cancelled';
+      case 'failed':
+        return 'Failed';
+      default:
+        return 'Thinking…';
+    }
+  };
+
+  return (
+    <div
+      aria-live="polite"
+      class={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs ${
+        isTerminal()
+          ? 'border-red-200 dark:border-red-800 text-red-600 dark:text-red-400'
+          : 'border-gray-200 dark:border-gray-700 text-text-tertiary'
+      }`}
+    >
+      <Show
+        when={!isTerminal()}
+        fallback={<Ban class="w-3 h-3 flex-shrink-0" />}
+      >
+        <Loader class="w-3 h-3 flex-shrink-0 animate-spin" />
+      </Show>
+      <span>{label()}</span>
+      <Show when={!isTerminal()}>
+        <span class="tabular-nums opacity-70">{seconds()}s</span>
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/components/tasks/TaskExecutionView.tsx
+++ b/apps/web/src/components/tasks/TaskExecutionView.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../lib/api-tasks';
 import { useWebSocketContext } from '../../lib/ws-provider';
 import { submitMessageStreaming } from '../../lib/ws-api';
+import { RunActivityBadge } from '../RunActivityBadge';
 
 /**
  * Session message type
@@ -41,7 +42,7 @@ export type TaskExecutionViewProps = {
  */
 export function TaskExecutionView(props: TaskExecutionViewProps) {
   const { client, isConnected } = useWebSocketContext();
-  
+
   const [task, setTask] = createSignal<TaskWithDetails | null>(null);
   const [sessionId, setSessionId] = createSignal<string | null>(null);
   const [messages, setMessages] = createSignal<SessionMessage[]>([]);
@@ -49,23 +50,43 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
   const [inputValue, setInputValue] = createSignal('');
   const [isExecuting, setIsExecuting] = createSignal(false);
   const [isStreaming, setIsStreaming] = createSignal(false);
+  const [runActivity, setRunActivity] = createSignal<
+    | {
+        phase: 'thinking' | 'running_tool' | 'cancelled' | 'failed';
+        toolName?: string;
+        elapsedMs: number;
+      }
+    | undefined
+  >(undefined);
   const [error, setError] = createSignal<string | null>(null);
 
   // Subscribe to streaming events when we have a session and WebSocket is connected
   createEffect(() => {
     const sid = sessionId();
     const wsClient = client();
-    
+
     if (!sid || !wsClient || !isConnected()) return;
 
     // Subscribe to session stream events
     const handleStreamStart = () => {
       setIsStreaming(true);
       setStreamingContent('');
+      setRunActivity({ phase: 'thinking', elapsedMs: 0 });
     };
 
     const handleStreamDelta = (event: { payload: { content: string } }) => {
       setStreamingContent((prev) => prev + event.payload.content);
+    };
+
+    const handleActivity = (event: {
+      payload: {
+        phase: 'thinking' | 'running_tool';
+        toolName?: string;
+        elapsedMs: number;
+      };
+    }) => {
+      const { phase, toolName, elapsedMs } = event.payload;
+      setRunActivity({ phase, elapsedMs, ...(toolName ? { toolName } : {}) });
     };
 
     const handleStreamEnd = () => {
@@ -82,18 +103,26 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
       }
       setIsStreaming(false);
       setStreamingContent('');
+      setRunActivity(undefined);
     };
 
-    const handleStreamError = (event: { payload: { error: { message: string } } }) => {
+    const handleStreamError = (event: {
+      payload: { error: { message: string } };
+    }) => {
       setError(event.payload.error.message);
       setIsStreaming(false);
       setStreamingContent('');
+      setRunActivity(undefined);
     };
 
     const unsubStart = wsClient.on('session.stream.start', handleStreamStart);
     const unsubDelta = wsClient.on('session.stream.delta', handleStreamDelta);
     const unsubEnd = wsClient.on('session.stream.end', handleStreamEnd);
     const unsubError = wsClient.on('session.stream.error', handleStreamError);
+    const unsubActivity = wsClient.on(
+      'session.stream.activity',
+      handleActivity,
+    );
 
     // Subscribe to the session
     wsClient.subscribeToSession(sid).catch((err) => {
@@ -105,6 +134,7 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
       unsubDelta();
       unsubEnd();
       unsubError();
+      unsubActivity();
     });
   });
 
@@ -148,7 +178,9 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
         setError(result.error.message);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start execution');
+      setError(
+        err instanceof Error ? err.message : 'Failed to start execution',
+      );
     } finally {
       setIsExecuting(false);
     }
@@ -223,11 +255,13 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
           </Show>
           {/* WebSocket connection status */}
           <Show when={sessionId()}>
-            <span class={`px-2 py-0.5 text-xs rounded ${
-              isConnected() 
-                ? 'bg-green-100 text-green-700' 
-                : 'bg-red-100 text-red-700'
-            }`}>
+            <span
+              class={`px-2 py-0.5 text-xs rounded ${
+                isConnected()
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-red-100 text-red-700'
+              }`}
+            >
               {isConnected() ? 'WS Connected' : 'WS Disconnected'}
             </span>
           </Show>
@@ -243,9 +277,7 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
 
       {/* Error state */}
       <Show when={error()}>
-        <div class="p-4 bg-red-50 text-red-600 text-sm">
-          {error()}
-        </div>
+        <div class="p-4 bg-red-50 text-red-600 text-sm">{error()}</div>
       </Show>
 
       {/* Execution prompt */}
@@ -289,11 +321,13 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
                   message.role === 'user'
                     ? 'bg-blue-50 ml-8'
                     : message.role === 'assistant'
-                    ? 'bg-gray-50 mr-8'
-                    : 'bg-yellow-50'
+                      ? 'bg-gray-50 mr-8'
+                      : 'bg-yellow-50'
                 }`}
               >
-                <div class="text-xs text-gray-500 mb-1 capitalize">{message.role}</div>
+                <div class="text-xs text-gray-500 mb-1 capitalize">
+                  {message.role}
+                </div>
                 <div class="text-sm text-gray-900 whitespace-pre-wrap">
                   {message.content}
                 </div>
@@ -307,19 +341,46 @@ export function TaskExecutionView(props: TaskExecutionViewProps) {
           {/* Streaming indicator with live content */}
           <Show when={isStreaming()}>
             <div class="p-3 bg-gray-50 rounded-lg mr-8">
-              <Show when={streamingContent()} fallback={
-                <div class="flex items-center gap-2 text-gray-500">
-                  <Loader2 class="w-4 h-4 animate-spin" />
-                  <span class="text-sm">Agent is typing...</span>
-                </div>
-              }>
+              <Show
+                when={streamingContent()}
+                fallback={
+                  <Show
+                    when={runActivity()}
+                    fallback={
+                      <div class="flex items-center gap-2 text-gray-500">
+                        <Loader2 class="w-4 h-4 animate-spin" />
+                        <span class="text-sm">Agent is typing...</span>
+                      </div>
+                    }
+                  >
+                    <RunActivityBadge
+                      phase={runActivity()!.phase}
+                      toolName={runActivity()!.toolName}
+                      elapsedMs={runActivity()!.elapsedMs}
+                    />
+                  </Show>
+                }
+              >
                 <div class="text-xs text-gray-500 mb-1">assistant</div>
                 <div class="text-sm text-gray-900 whitespace-pre-wrap">
                   {streamingContent()}
                 </div>
-                <div class="flex items-center gap-1 mt-1 text-xs text-gray-400">
-                  <Loader2 class="w-3 h-3 animate-spin" />
-                  <span>streaming...</span>
+                <div class="mt-1">
+                  <Show
+                    when={runActivity()}
+                    fallback={
+                      <div class="flex items-center gap-1 text-xs text-gray-400">
+                        <Loader2 class="w-3 h-3 animate-spin" />
+                        <span>streaming...</span>
+                      </div>
+                    }
+                  >
+                    <RunActivityBadge
+                      phase={runActivity()!.phase}
+                      toolName={runActivity()!.toolName}
+                      elapsedMs={runActivity()!.elapsedMs}
+                    />
+                  </Show>
                 </div>
               </Show>
             </div>

--- a/packages/runtime/src/provider/index.ts
+++ b/packages/runtime/src/provider/index.ts
@@ -71,6 +71,12 @@ export type ModelRequest = {
   readonly stopSequences?: readonly string[];
   readonly stream?: boolean;
   readonly metadata?: Record<string, unknown>;
+  /**
+   * Optional caller-supplied abort signal (e.g. a user-initiated "Stop agent").
+   * Adapters combine it with their own request-timeout signal so aborting it
+   * cancels the in-flight provider fetch. Not serialized to the wire.
+   */
+  readonly signal?: AbortSignal;
 };
 
 /**

--- a/packages/sdk/src/websocket-client.ts
+++ b/packages/sdk/src/websocket-client.ts
@@ -517,6 +517,20 @@ export class WebSocketClient {
   }
 
   /**
+   * Cancel an in-flight run (user hit "Stop agent"). Fire-and-forget: the
+   * server aborts the run and the UI reacts to the resulting
+   * `session.stream.run_cancelled` event, so we don't await a response.
+   */
+  cancelRun(sessionId: string, runId: string): void {
+    void this.sendRequest('session.run.cancel', {
+      sessionId,
+      runId,
+    }).catch(() => {
+      /* best-effort — cancellation is confirmed via the stream event */
+    });
+  }
+
+  /**
    * Subscribe to session events
    */
   async subscribeToSession(

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -547,6 +547,22 @@ export type SessionStreamRunCancelled = WSMessage<
   }
 >;
 
+/**
+ * Server-driven liveness heartbeat so the UI can show what the agent is doing
+ * between other events ("Thinking…" / "Running <tool>… 12s"). At most one per
+ * second per run (#378).
+ */
+export type SessionStreamActivity = WSMessage<
+  'session.stream.activity',
+  {
+    sessionId: string;
+    runId: string;
+    phase: 'thinking' | 'running_tool';
+    toolName?: string;
+    elapsedMs: number;
+  }
+>;
+
 export type SessionRunChoicesEvent = WSMessage<
   'session.run.choices',
   ChoicesEvent
@@ -559,6 +575,7 @@ export type SessionStreamEvent =
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
   | SessionStreamRunCancelled
+  | SessionStreamActivity
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -1072,6 +1089,7 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
   'session.stream.run_cancelled',
+  'session.stream.activity',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
@@ -1104,6 +1122,7 @@ const STREAM_EVENT_TYPES: Set<string> = new Set([
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
   'session.stream.run_cancelled',
+  'session.stream.activity',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -240,6 +240,15 @@ export type SessionToolCancelRequest = WSMessage<
   }
 >;
 
+/** Client → server: cancel an in-flight run (user hit "Stop agent"). */
+export type SessionRunCancelRequest = WSMessage<
+  'session.run.cancel',
+  {
+    sessionId: string;
+    runId: string;
+  }
+>;
+
 export type SessionMessagesRequest = WSMessage<
   'session.messages',
   {
@@ -529,6 +538,15 @@ export type SessionStreamToolCancelled = WSMessage<
   }
 >;
 
+/** The whole run was cancelled by the user ("Stop agent"). */
+export type SessionStreamRunCancelled = WSMessage<
+  'session.stream.run_cancelled',
+  {
+    sessionId: string;
+    runId: string;
+  }
+>;
+
 export type SessionRunChoicesEvent = WSMessage<
   'session.run.choices',
   ChoicesEvent
@@ -540,6 +558,7 @@ export type SessionStreamEvent =
   | SessionStreamToolCall
   | SessionStreamExecOutput
   | SessionStreamToolCancelled
+  | SessionStreamRunCancelled
   | SessionStreamUsage
   | SessionStreamEnd
   | SessionStreamError
@@ -941,6 +960,7 @@ export type WSRequest =
   | SessionSubscribeRequest
   | SessionUnsubscribeRequest
   | SessionToolCancelRequest
+  | SessionRunCancelRequest
   | SessionMessagesRequest
   | SessionRunsRequest
   | AgentListRequest
@@ -1017,6 +1037,7 @@ const REQUEST_TYPES: Set<string> = new Set([
   'session.subscribe',
   'session.unsubscribe',
   'session.tool.cancel',
+  'session.run.cancel',
   'agent.list',
   'agent.get',
   'provider.list',
@@ -1050,6 +1071,7 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.tool_call',
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
+  'session.stream.run_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
@@ -1081,6 +1103,7 @@ const STREAM_EVENT_TYPES: Set<string> = new Set([
   'session.stream.tool_call',
   'session.stream.exec_output',
   'session.stream.tool_cancelled',
+  'session.stream.run_cancelled',
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',


### PR DESCRIPTION
## Why

The stacked PRs #392 (#376) and #393 (#378) were merged into their **intermediate base branches** (`worktree-issue-375` / `worktree-issue-376`) rather than cascading up to `main`. Only #391 (#375) reached `main`, so:

- #375 code is in `main` (issue auto-closed ✓)
- **#376 and #378 code never reached `main`**, and their issues stayed open.

This PR brings both into `main` in one shot. The merge-base is the #375 tip (already in `main`), so the diff below is exactly the #376 + #378 delta — no revert of `main`'s newer features (AboutTab, restart, etc.), and `git merge-tree` reports zero conflicts.

## Contents

**#376 — cancel `agents_invoke_await` + Stop-agent**
- `agents_invoke_await` honors `ctx.signal`; run-level `AbortController` + `cancelRun` cancels the provider stream and in-flight tools; `session.run.cancel` / `run.cancelled` wiring; adapters combine an external abort signal; run marked `cancelled` with no final assistant message.

**#378 — live run-activity badge**
- Server-driven `run.activity` heartbeat (≤1/s, quiet while streaming); `RunActivityBadge` with a local elapsed ticker; wired into `ChatView`, `App.tsx`, `TaskExecutionView`. Also corrects #376's cancel routing so the client receives `session.stream.run_cancelled` on the WS run channel.

Closes #376
Closes #378

All server + web suites, typechecks, and lint pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)