### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Release **v0.3.1** — ships #375, #376, and #378 to `@openaidy/app`.

- **#375** — `exec_run` streams stdout/stderr live + a per-tool Stop button.
- **#376** — cancel `agents_invoke_await` + a Stop-agent button that aborts the whole turn (provider stream + in-flight tools).
- **#378** — live run-activity badge (server-driven heartbeat + elapsed time) so the user can see the agent is alive between events.

Single-line version bump. Merging this, then pushing the `v0.3.1` tag, triggers the release workflow (gate → npm publish → GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)