### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `@openaidy/app` to 0.3.2.
- Ships #396 and #397, plus the mid-branch reconnect/streaming, session-pagination, sessions-filter, and horizontal-scroll fixes landed directly on `main`.

## What's included
- fix(web): keep chat auto-scroll inside the chat container (#396)
- feat(web): sort sessions by last activity, auto-select most recent (#397)
- fix(server): return most recent messages instead of oldest for sessions past the pagination window
- fix(web): reconcile stuck streaming state on reconnect and tab visibility
- feat(web): filter sessions page to chat-only by default, with pill toggles for tasks/subtasks/addons
- fix(web): stop long unbroken titles/text from causing horizontal scroll

## Test plan
- [x] CI gate (lint/build/test) passes on this PR
- [x] Merging triggers `v0.3.2` tag push → release workflow publishes to npm and creates the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)