### PR TITLE
feat(providers): add OpenCode Zen as a ready provider (free tier)

### DIFF
--- a/apps/web/src/components/providers/DialogConnectProvider.tsx
+++ b/apps/web/src/components/providers/DialogConnectProvider.tsx
@@ -260,7 +260,8 @@ export function DialogConnectProvider(props: DialogConnectProviderProps) {
                 <Show
                   when={
                     props.provider!.id !== 'opencode-go' &&
-                    props.provider!.id !== 'opencode-go-anthropic'
+                    props.provider!.id !== 'opencode-go-anthropic' &&
+                    props.provider!.id !== 'opencode-zen'
                   }
                 >
                   <label class="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50">

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -34,3 +34,4 @@ export { OpenAIProfile } from './openai/index';
 export { OpenRouterProfile } from './openrouter/index';
 export { OpenCodeGoProfile } from './opencode-go/index';
 export { OpenCodeGoAnthropicProfile } from './opencode-go-anthropic/index';
+export { OpenCodeZenProfile } from './opencode-zen/index';

--- a/packages/providers/src/opencode-zen/index.ts
+++ b/packages/providers/src/opencode-zen/index.ts
@@ -1,0 +1,49 @@
+/**
+ * OpenCode Zen Provider Profile — free tier models.
+ *
+ * Backed by OpenCode Zen's free-tier catalog. The user signs up at
+ * opencode.ai/zen, adds billing (required to get an API key), and
+ * receives a long-lived API key. No OAuth / device code — the API key
+ * is the auth boundary.
+ *
+ * Endpoint: https://opencode.ai/zen/v1/chat/completions
+ * (OpenAI-compatible — no format translation needed.)
+ *
+ * Only free-tier models are included here (mimo-v2.5-free,
+ * north-mini-code-free, nemotron-3-ultra-free, deepseek-v4-flash-free).
+ * The full Zen catalog (GPT-5, Claude, Gemini, DeepSeek V4 Pro, etc.)
+ * requires a paid plan and is available through OpenCode Go instead.
+ *
+ * Reads `id`, `name`, `baseUrl`, and the model list from
+ * `PROVIDER_PRESETS` — the single source of truth.
+ */
+
+import { PROVIDER_PRESETS } from '@openaidy/shared-types';
+import { ProviderProfile } from '../types';
+
+const PRESET = PROVIDER_PRESETS.find((p) => p.id === 'opencode-zen');
+if (!PRESET) {
+  throw new Error(
+    "PROVIDER_PRESETS is missing the 'opencode-zen' entry — keep shared-types and providers in sync.",
+  );
+}
+
+export class OpenCodeZenProfile extends ProviderProfile {
+  constructor() {
+    super(
+      ProviderProfile.fromPreset(PRESET!, {
+        signupUrl: 'https://opencode.ai/zen',
+        aliases: ['opencode-zen', 'openai-zen'],
+      }),
+    );
+  }
+
+  /**
+   * OpenCode Zen is API-key-only. No OAuth or device code flow is
+   * exposed by the Zen gateway. Restrict to api_key so the UI never
+   * surfaces OAuth for this provider.
+   */
+  getAvailableAuthMethods(): import('@openaidy/shared-types').AuthMethod[] {
+    return [{ type: 'api_key', label: 'API Key' }];
+  }
+}

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -23,6 +23,7 @@ import { OpenAIProfile } from './openai/index';
 import { OpenRouterProfile } from './openrouter/index';
 import { OpenCodeGoProfile } from './opencode-go/index';
 import { OpenCodeGoAnthropicProfile } from './opencode-go-anthropic/index';
+import { OpenCodeZenProfile } from './opencode-zen/index';
 
 const builtInProfiles: ProviderProfile[] = [
   new AnthropicProfile(),
@@ -34,6 +35,7 @@ const builtInProfiles: ProviderProfile[] = [
   new OpenRouterProfile(),
   new OpenCodeGoProfile(),
   new OpenCodeGoAnthropicProfile(),
+  new OpenCodeZenProfile(),
 ];
 
 export class ProviderRegistry {

--- a/packages/shared-types/src/providers-preset.ts
+++ b/packages/shared-types/src/providers-preset.ts
@@ -11,6 +11,7 @@ export type ProviderPresetId =
   | 'minimax'
   | 'opencode-go'
   | 'opencode-go-anthropic'
+  | 'opencode-zen'
   | 'ollama'
   | 'lmstudio';
 
@@ -325,6 +326,38 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     ],
   },
   {
+    id: 'opencode-zen',
+    name: 'OpenCode Zen',
+    vendorFamily: 'openai-compatible',
+    baseUrl: 'https://opencode.ai/zen/v1',
+    websiteUrl: 'https://opencode.ai/zen',
+    documentationUrl: 'https://opencode.ai/docs/zen',
+    recommendedModel: 'mimo-v2.5-free',
+    icon: 'bi-stars',
+    models: [
+      {
+        id: 'mimo-v2.5-free',
+        name: 'MiMo V2.5 Free',
+        description: 'Free tier — high-volume open model',
+      },
+      {
+        id: 'north-mini-code-free',
+        name: 'North Mini Code Free',
+        description: 'Free tier — coding-specialized open model',
+      },
+      {
+        id: 'nemotron-3-ultra-free',
+        name: 'Nemotron 3 Ultra Free',
+        description: 'Free tier — NVIDIA open coding model',
+      },
+      {
+        id: 'deepseek-v4-flash-free',
+        name: 'DeepSeek V4 Flash Free',
+        description: 'Free tier — fast and affordable reasoning',
+      },
+    ],
+  },
+  {
     id: 'ollama',
     name: 'Ollama',
     vendorFamily: 'openai-compatible',
@@ -378,6 +411,52 @@ export const OPENCODE_GO_ANTHROPIC_MODEL_IDS: ReadonlySet<string> = new Set([
   'qwen3.7-plus',
   'qwen3.6-plus',
 ]);
+
+/**
+ * OpenCode Zen — free tier models served via OpenAI-compatible endpoint.
+ *
+ * Docs: https://opencode.ai/docs/zen
+ * Endpoint: https://opencode.ai/zen/v1/chat/completions
+ *
+ * Auth: Bearer API key (sign up at opencode.ai/zen, add billing, get key).
+ * No OAuth. Free to use — no per-request charges for the free-tier models.
+ *
+ * Only the free-tier models are included here. The full Zen catalog
+ * (GPT-5, Claude, Gemini, DeepSeek V4 Pro, etc.) requires a paid plan
+ * and is available via OpenCode Go (`opencode-go`) instead.
+ */
+export const OPENCODE_ZEN_PRESET: ProviderPreset = {
+  id: 'opencode-zen',
+  name: 'OpenCode Zen',
+  vendorFamily: 'openai-compatible',
+  baseUrl: 'https://opencode.ai/zen/v1',
+  websiteUrl: 'https://opencode.ai/zen',
+  documentationUrl: 'https://opencode.ai/docs/zen',
+  recommendedModel: 'mimo-v2.5-free',
+  icon: 'bi-stars',
+  models: [
+    {
+      id: 'mimo-v2.5-free',
+      name: 'MiMo V2.5 Free',
+      description: 'Free tier — high-volume open model',
+    },
+    {
+      id: 'north-mini-code-free',
+      name: 'North Mini Code Free',
+      description: 'Free tier — coding-specialized open model',
+    },
+    {
+      id: 'nemotron-3-ultra-free',
+      name: 'Nemotron 3 Ultra Free',
+      description: 'Free tier — NVIDIA open coding model',
+    },
+    {
+      id: 'deepseek-v4-flash-free',
+      name: 'DeepSeek V4 Flash Free',
+      description: 'Free tier — fast and affordable reasoning',
+    },
+  ],
+};
 
 /**
  * Hidden preset for the Anthropic-compatible subset of OpenCode


### PR DESCRIPTION
## Summary

Add OpenCode Zen as a "Ready Provider" in OpenAidy with its 4 free-tier models:

- `mimo-v2.5-free` — MiMo V2.5 Free
- `north-mini-code-free` — North Mini Code Free
- `nemotron-3-ultra-free` — Nemotron 3 Ultra Free
- `deepseek-v4-flash-free` — DeepSeek V4 Flash Free

### Changes

| File | Change |
|------|--------|
| `packages/shared-types/src/providers-preset.ts` | Add `'opencode-zen'` to `ProviderPresetId` type + entry in `PROVIDER_PRESETS` with 4 free models |
| `packages/providers/src/opencode-zen/index.ts` | New `OpenCodeZenProfile` class — reads from `PROVIDER_PRESETS`, `api_key` auth only, aliases: `opencode-zen`, `openai-zen` |
| `packages/providers/src/index.ts` | Export `OpenCodeZenProfile` |
| `packages/providers/src/registry.ts` | Register `OpenCodeZenProfile` in `builtInProfiles` |
| `apps/web/src/components/providers/DialogConnectProvider.tsx` | Exclude `opencode-zen` from OAuth option — Zen gateway is API-key-only, OAuth not supported |

### Auth

API key only — no OAuth. User signs up at [opencode.ai/zen](https://opencode.ai/zen), adds billing, copies API key, connects via the Providers tab. No per-request charges for the free-tier models.