### PR TITLE
fix(sessions): persist synthetic tool result for INTERRUPT_CHOICES

### DIFF
--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -1275,6 +1275,42 @@ export class SessionMessageService {
                         choicesCount: (parsed.choices as string[]).length,
                       },
                     }).catch(() => {});
+                    // Persist a synthetic tool result message so the conversation
+                    // history stays well-formed for the next turn. OpenAI-
+                    // compatible APIs (MiniMax, OpenAI, DeepSeek, etc.) require
+                    // every assistant message with `tool_calls` to be followed
+                    // by a matching `role: 'tool'` message — without it, the
+                    // next request errors with "tool call result does not
+                    // follow tool call" the moment the user replies.
+                    // The user-facing semantics are: present_choices paused the
+                    // loop and surfaced the choices to the UI; the "result"
+                    // here is just a marker that the tool is waiting on user
+                    // input. The user's next message will arrive as a regular
+                    // `role: 'user'` turn that resumes the conversation.
+                    await this.appendMessage({
+                      sessionId: input.sessionId,
+                      runId: run.id,
+                      role: 'tool',
+                      content: JSON.stringify({
+                        _type: 'INTERRUPT_CHOICES',
+                        status: 'awaiting_user_choice',
+                        question: parsed.question ?? null,
+                        choices: parsed.choices,
+                      }),
+                      toolCallId: tc.id,
+                      metadata: {
+                        toolName: tc.name,
+                        interrupt: 'awaiting_user_choice',
+                      },
+                    }).catch((err: unknown) => {
+                      // Non-fatal: if persisting fails the next turn will
+                      // surface the provider error, which is the same outcome
+                      // we had before this fix.
+                      this.logger?.warn(
+                        { err, sessionId: input.sessionId, toolCallId: tc.id },
+                        'Failed to persist synthetic INTERRUPT_CHOICES tool result',
+                      );
+                    });
                     return {
                       ok: true,
                       userMessage,


### PR DESCRIPTION
## Bug

When an agent calls `present_choices` and the user answers, the next turn fails with `HTTP 400 invalid params, tool call result does not follow tool call (2013)` from the provider (e.g. MiniMax M2.7, OpenAI, DeepSeek, Groq, etc.).

### Root cause

When `present_choices` returns the `INTERRUPT_CHOICES` sentinel, the agentic loop emits a `session.run.choices` event, marks the run as suspended (waiting on user input), and returns early — **without persisting a `role: 'tool'` message** for the tool result.

The assistant message with `tool_calls` IS persisted (with `toolCalls` metadata), so the conversation history in the DB ends up looking like:

```
user:      "Lets do the onboarding"
assistant: "Let's get you set up..."  + tool_calls: [present_choices]
                                       ← NO matching tool result here
user:      "Your mission is to serve doing middle heavy tasks..."
```

OpenAI-compatible APIs require every assistant message with `tool_calls` to be followed by a matching `role: 'tool'` message with the corresponding `tool_call_id`. Without it, the provider rejects the next request and the turn fails.

### Repro (from local DB, session `DSPXH-wev_F_7NFLSLrLE`)

```
[INFO] [minimax] invokeStream: model=MiniMax-M2.7 baseURL=https://api.minimax.io/v1
[ERROR][minimax] Provider API error: HTTP 400 400 invalid params,
  tool call result does not follow tool call (2013) (code=undefined)
```

DB shows the failed run (`dxFxPc9ORN3t7yNwGhvOF`, `error_code=provider.api_error`) immediately after the assistant message with the `present_choices` tool call and the user's reply.

## Fix

Before the early return for `INTERRUPT_CHOICES`, append a synthetic `role: 'tool'` message mirroring the sentinel so the conversation stays well-formed.

```ts
await this.appendMessage({
  sessionId: input.sessionId,
  runId: run.id,
  role: 'tool',
  content: JSON.stringify({
    _type: 'INTERRUPT_CHOICES',
    status: 'awaiting_user_choice',
    question: parsed.question ?? null,
    choices: parsed.choices,
  }),
  toolCallId: tc.id,
  metadata: {
    toolName: tc.name,
    interrupt: 'awaiting_user_choice',
  },
});
```

The content marks the result as `awaiting_user_choice` and re-states the question and choices for context. The user's next message arrives as a regular `role: 'user'` turn that resumes the conversation normally.

Persist failure is non-fatal (logged as a warning) — if the DB write fails the next turn will surface the provider error, which is the same outcome we had before this fix.

## Testing

- Full server suite: **3087 passed | 30 skipped | 3 todo** (147 files)
- Targeted: `session-streaming.test.ts`, `streaming.test.ts`, `e2e.test.ts`, `present-choices.test.ts`, `sessions/service.test.ts` — all green
- Server typecheck: clean