### PR TITLE
feat: multimodal image/audio attachments in chat

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -27,6 +27,8 @@ import { authRoutes } from './routes/auth';
 import { accessTokenRoutes } from './routes/access-tokens';
 import { createAccessTokenService } from './access-tokens/service';
 import { sessionRoutes } from './routes/sessions';
+import { attachmentRoutes } from './routes/attachments';
+import { createAttachmentService } from './attachments/service';
 import { configRoutes } from './routes/config';
 import { providerRoutes } from './routes/providers';
 import { agentRoutes } from './routes/agents';
@@ -309,6 +311,15 @@ export async function buildApp() {
   // Create run event emitter for SSE streaming (needed by sessionService)
   const runEvents = new RunEventEmitter();
 
+  // Attachment storage (image/audio chat media) — requires the DB for
+  // metadata rows; bytes go under OPENAIDY_HOME/attachments.
+  const attachmentService = dbAdapter
+    ? createAttachmentService({
+        repository: dbAdapter.repositories.messageAttachments,
+        baseDir: path.join(env.OPENAIDY_HOME, 'attachments'),
+      })
+    : undefined;
+
   sessionService = new SessionMessageService({
     providers: providerServices,
     logger: log as unknown as FastifyBaseLogger,
@@ -321,6 +332,7 @@ export async function buildApp() {
     getDefaultAgentId: () => configService.getConfig().defaults.agentId,
     runEvents,
     workspaceBaseDir: env.WORKSPACE_BASE_DIR,
+    ...(attachmentService ? { attachments: attachmentService } : {}),
     repositories: dbAdapter
       ? {
           sessions: dbAdapter.repositories.sessions,
@@ -482,6 +494,15 @@ export async function buildApp() {
         sessionService: services.sessions,
         authMiddleware,
       });
+
+      // Attachment upload/serving (requires DB-backed attachment storage)
+      if (attachmentService) {
+        await api.register(attachmentRoutes, {
+          attachmentService,
+          sessionService: services.sessions,
+          authMiddleware,
+        });
+      }
 
       // Pass shared services to provider routes. provider routes may
       // optionally use the DB (for OAuth state + provider credentials);

--- a/apps/server/src/attachments/service.ts
+++ b/apps/server/src/attachments/service.ts
@@ -1,0 +1,244 @@
+/**
+ * Attachment service
+ *
+ * Stores and serves image/audio media attached to session messages.
+ * Bytes live on local disk under a dedicated attachments directory
+ * (`<baseDir>/<sessionId>/<id>.<ext>`); only metadata goes to the DB
+ * (`message_attachments` table). Tool-produced media (e.g. screenshots
+ * persisted into an agent workspace) is registered here too, pointing at
+ * its existing on-disk location.
+ */
+
+import { mkdir, writeFile, readFile, stat, unlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { nanoid } from 'nanoid';
+import type {
+  MessageAttachmentsStore,
+  MessageAttachment,
+  AttachmentKind,
+} from '@openaidy/db';
+
+/** Max upload size (decoded bytes). */
+export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/** Allowed mime types by kind. */
+const ALLOWED_MIME_TYPES: Record<AttachmentKind, readonly string[]> = {
+  image: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+  audio: [
+    'audio/wav',
+    'audio/x-wav',
+    'audio/mpeg',
+    'audio/mp3',
+    'audio/mp4',
+    'audio/ogg',
+    'audio/webm',
+    'audio/flac',
+    'audio/aac',
+  ],
+};
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/mp4': 'm4a',
+  'audio/ogg': 'ogg',
+  'audio/webm': 'webm',
+  'audio/flac': 'flac',
+  'audio/aac': 'aac',
+};
+
+/** Derive the attachment kind from a mime type, or null if unsupported. */
+export function kindForMimeType(mimeType: string): AttachmentKind | null {
+  if (ALLOWED_MIME_TYPES.image.includes(mimeType)) return 'image';
+  if (ALLOWED_MIME_TYPES.audio.includes(mimeType)) return 'audio';
+  return null;
+}
+
+export class AttachmentError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'UNSUPPORTED_MIME_TYPE'
+      | 'FILE_TOO_LARGE'
+      | 'NOT_FOUND'
+      | 'WRITE_FAILED'
+      | 'READ_FAILED',
+  ) {
+    super(message);
+    this.name = 'AttachmentError';
+  }
+}
+
+export type AttachmentServiceOptions = {
+  repository: MessageAttachmentsStore;
+  /** Directory upload bytes are written into (created on demand). */
+  baseDir: string;
+};
+
+export class AttachmentService {
+  private readonly repo: MessageAttachmentsStore;
+  private readonly baseDir: string;
+
+  constructor(options: AttachmentServiceOptions) {
+    this.repo = options.repository;
+    this.baseDir = resolve(options.baseDir);
+  }
+
+  /**
+   * Store an uploaded file: validates mime type and size, writes the bytes
+   * under the attachments directory, and creates an unlinked metadata row
+   * (linked to the user message at submit time).
+   */
+  async saveUpload(input: {
+    sessionId: string;
+    mimeType: string;
+    /** Base64-encoded bytes (no data: URI prefix). */
+    data: string;
+    name?: string;
+  }): Promise<MessageAttachment> {
+    const kind = kindForMimeType(input.mimeType);
+    if (!kind) {
+      throw new AttachmentError(
+        `Unsupported attachment mime type: ${input.mimeType}`,
+        'UNSUPPORTED_MIME_TYPE',
+      );
+    }
+
+    const buffer = Buffer.from(input.data, 'base64');
+    if (buffer.length === 0) {
+      throw new AttachmentError('Attachment is empty', 'WRITE_FAILED');
+    }
+    if (buffer.length > MAX_ATTACHMENT_BYTES) {
+      throw new AttachmentError(
+        `Attachment exceeds the ${Math.floor(MAX_ATTACHMENT_BYTES / (1024 * 1024))}MB limit`,
+        'FILE_TOO_LARGE',
+      );
+    }
+
+    const id = nanoid();
+    const ext = EXT_BY_MIME[input.mimeType] ?? 'bin';
+    const dir = join(this.baseDir, input.sessionId);
+    const storagePath = join(dir, `${id}.${ext}`);
+
+    try {
+      await mkdir(dir, { recursive: true });
+      await writeFile(storagePath, buffer);
+    } catch (error) {
+      throw new AttachmentError(
+        `Failed to store attachment: ${error instanceof Error ? error.message : String(error)}`,
+        'WRITE_FAILED',
+      );
+    }
+
+    return this.repo.create({
+      sessionId: input.sessionId,
+      kind,
+      source: 'user_upload',
+      ...(input.name ? { name: input.name } : {}),
+      mimeType: input.mimeType,
+      sizeBytes: buffer.length,
+      storagePath,
+    });
+  }
+
+  /**
+   * Register media that already exists on disk (e.g. a screenshot a tool
+   * persisted into an agent workspace) as an attachment on a message.
+   */
+  async registerToolOutput(input: {
+    sessionId: string;
+    messageId: string;
+    mimeType: string;
+    storagePath: string;
+    name?: string;
+  }): Promise<MessageAttachment | null> {
+    const kind = kindForMimeType(input.mimeType);
+    if (!kind) return null;
+
+    let sizeBytes = 0;
+    try {
+      sizeBytes = (await stat(input.storagePath)).size;
+    } catch {
+      return null; // file vanished — nothing to register
+    }
+
+    return this.repo.create({
+      sessionId: input.sessionId,
+      messageId: input.messageId,
+      kind,
+      source: 'tool_output',
+      ...(input.name ? { name: input.name } : {}),
+      mimeType: input.mimeType,
+      sizeBytes,
+      storagePath: input.storagePath,
+    });
+  }
+
+  /** Link pending uploads to the persisted user message. */
+  async linkToMessage(
+    attachmentIds: string[],
+    sessionId: string,
+    messageId: string,
+  ): Promise<MessageAttachment[]> {
+    return this.repo.linkToMessage({ attachmentIds, sessionId, messageId });
+  }
+
+  /** All linked attachments for a session, grouped by message id. */
+  async listBySessionGrouped(
+    sessionId: string,
+  ): Promise<Map<string, MessageAttachment[]>> {
+    const rows = await this.repo.listBySession(sessionId);
+    const grouped = new Map<string, MessageAttachment[]>();
+    for (const row of rows) {
+      if (!row.messageId) continue;
+      const list = grouped.get(row.messageId) ?? [];
+      list.push(row);
+      grouped.set(row.messageId, list);
+    }
+    return grouped;
+  }
+
+  async findById(id: string): Promise<MessageAttachment | null> {
+    return this.repo.findById(id);
+  }
+
+  /** Read an attachment's bytes for serving or provider payloads. */
+  async readBytes(
+    attachment: MessageAttachment,
+  ): Promise<{ buffer: Buffer; mimeType: string }> {
+    try {
+      const buffer = await readFile(attachment.storagePath);
+      return { buffer, mimeType: attachment.mimeType };
+    } catch (error) {
+      throw new AttachmentError(
+        `Failed to read attachment ${attachment.id}: ${error instanceof Error ? error.message : String(error)}`,
+        'READ_FAILED',
+      );
+    }
+  }
+
+  /** Delete an attachment row and its stored bytes (uploads only). */
+  async delete(id: string): Promise<boolean> {
+    const attachment = await this.repo.findById(id);
+    if (!attachment) return false;
+    const deleted = await this.repo.delete(id);
+    // Only remove bytes we own (uploads live under baseDir; tool output
+    // points into an agent workspace the workspace service owns).
+    if (deleted && attachment.storagePath.startsWith(this.baseDir)) {
+      await unlink(attachment.storagePath).catch(() => {});
+    }
+    return deleted;
+  }
+}
+
+export function createAttachmentService(
+  options: AttachmentServiceOptions,
+): AttachmentService {
+  return new AttachmentService(options);
+}

--- a/apps/server/src/mcp/screenshot-capture.ts
+++ b/apps/server/src/mcp/screenshot-capture.ts
@@ -29,6 +29,27 @@ import type { McpToolResult, McpTextContent } from './client';
 /** Workspace-relative folder screenshots are saved into. */
 export const SCREENSHOT_WORKSPACE_DIR = 'screenshots';
 
+/**
+ * Workspace-relative folder for inline images returned by non-screenshot
+ * MCP tools (e.g. image generation) — persisted by the same mechanism.
+ */
+export const MEDIA_WORKSPACE_DIR = 'media';
+
+/**
+ * Extract inline image content items from an MCP tool result. Returns an
+ * empty array when the result carries none — used to decide whether the
+ * persistence step should run at all.
+ */
+export function extractInlineImages(
+  result: McpToolResult | undefined,
+): Array<{ type: 'image'; data: string; mimeType?: string }> {
+  const content = Array.isArray(result?.content) ? result.content : [];
+  return content.filter(
+    (c): c is { type: 'image'; data: string; mimeType?: string } =>
+      c?.type === 'image' && typeof (c as { data?: unknown }).data === 'string',
+  );
+}
+
 /** Minimal logger shape — matches the subset of FastifyBaseLogger we use. */
 type Logger = { warn: (obj: unknown, msg?: string) => void };
 
@@ -118,11 +139,22 @@ export function buildScreenshotFilename(options: {
   return `${stem}${suffix}.${ext}`;
 }
 
+export type PersistedImage = {
+  /** Workspace-relative path (e.g. `screenshots/x.png`). */
+  relativePath: string;
+  /** Absolute on-disk path of the written file. */
+  absolutePath: string;
+  /** Mime type of the image bytes (defaults to image/png when unreported). */
+  mimeType: string;
+};
+
 export type PersistScreenshotResult = {
   /** The tool result, augmented with a text note of where images were saved. */
   result: McpToolResult;
   /** Workspace-relative paths of saved screenshots (e.g. `screenshots/x.png`). */
   savedPaths: string[];
+  /** Full details of each saved image, for attachment registration. */
+  saved: PersistedImage[];
   /** Absolute path of the first saved screenshot, for tool-result metadata. */
   absolutePath?: string;
 };
@@ -141,27 +173,30 @@ export async function persistScreenshotImages(params: {
   agentId: string;
   requestedFilename?: string | undefined;
   logger?: Logger | undefined;
+  /**
+   * Workspace-relative folder to save into. Defaults to the screenshots
+   * folder; non-screenshot tool media goes to {@link MEDIA_WORKSPACE_DIR}.
+   */
+  targetDir?: string;
   /** Injectable clock for deterministic tests. Defaults to `Date.now()`. */
   now?: () => number;
 }): Promise<PersistScreenshotResult> {
   const { result, workspace, agentId, requestedFilename, logger } = params;
+  const targetDir = params.targetDir ?? SCREENSHOT_WORKSPACE_DIR;
   const nowMs = (params.now ?? (() => Date.now()))();
 
-  const content = Array.isArray(result.content) ? result.content : [];
-  const images = content.filter(
-    (c): c is { type: 'image'; data: string; mimeType?: string } =>
-      c?.type === 'image' && typeof (c as { data?: unknown }).data === 'string',
-  );
+  const images = extractInlineImages(result);
 
   if (images.length === 0) {
     logger?.warn(
       { agentId },
       'Screenshot tool returned no inline image content to persist',
     );
-    return { result, savedPaths: [] };
+    return { result, savedPaths: [], saved: [] };
   }
 
   const savedPaths: string[] = [];
+  const saved: PersistedImage[] = [];
   let firstAbsolutePath: string | undefined;
 
   for (let i = 0; i < images.length; i++) {
@@ -172,7 +207,7 @@ export async function persistScreenshotImages(params: {
       index: i,
       now: nowMs,
     });
-    const relativePath = `${SCREENSHOT_WORKSPACE_DIR}/${filename}`;
+    const relativePath = `${targetDir}/${filename}`;
     const buffer = Buffer.from(image.data, 'base64');
     const absolutePath = await workspace.writeBinaryFile(
       agentId,
@@ -180,23 +215,29 @@ export async function persistScreenshotImages(params: {
       buffer,
     );
     savedPaths.push(relativePath);
+    saved.push({
+      relativePath,
+      absolutePath,
+      mimeType: image.mimeType ?? 'image/png',
+    });
     if (i === 0) firstAbsolutePath = absolutePath;
   }
 
   const note: McpTextContent = {
     type: 'text',
-    text: `Screenshot saved to workspace: ${savedPaths.join(', ')}`,
+    text: `${targetDir === SCREENSHOT_WORKSPACE_DIR ? 'Screenshot' : 'Image'} saved to workspace: ${savedPaths.join(', ')}`,
   };
 
   const augmented: McpToolResult = {
     ...result,
-    content: [...content, note],
+    content: [...(Array.isArray(result.content) ? result.content : []), note],
     ...(firstAbsolutePath ? { absolutePath: firstAbsolutePath } : {}),
   } as McpToolResult & { absolutePath?: string };
 
   return {
     result: augmented,
     savedPaths,
+    saved,
     ...(firstAbsolutePath ? { absolutePath: firstAbsolutePath } : {}),
   };
 }

--- a/apps/server/src/providers/infrastructure/anthropic/request-mapper.ts
+++ b/apps/server/src/providers/infrastructure/anthropic/request-mapper.ts
@@ -26,11 +26,40 @@ export function mapMessage(message: Message): AnthropicMessage | null {
       // Return null to indicate it should be extracted separately
       return null;
 
-    case 'user':
+    case 'user': {
+      // Attachments become content blocks: text plus base64 image blocks.
+      // Anthropic has no audio input type, so audio attachments degrade to
+      // a text note (the capability check upstream avoids this path for
+      // audio-capable flows).
+      if (message.attachments && message.attachments.length > 0) {
+        const blocks: AnthropicContentBlock[] = [];
+        if (message.content) {
+          blocks.push({ type: 'text', text: message.content });
+        }
+        for (const attachment of message.attachments) {
+          if (attachment.kind === 'image') {
+            blocks.push({
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: attachment.mimeType,
+                data: attachment.data,
+              },
+            });
+          } else {
+            blocks.push({
+              type: 'text',
+              text: `[Audio attachment${attachment.name ? ` "${attachment.name}"` : ''} (${attachment.mimeType}) — this model cannot process audio input natively.]`,
+            });
+          }
+        }
+        return { role: 'user', content: blocks };
+      }
       return {
         role: 'user',
         content: message.content,
       };
+    }
 
     case 'assistant': {
       const blocks: AnthropicContentBlock[] = [];
@@ -67,7 +96,9 @@ export function mapMessage(message: Message): AnthropicMessage | null {
             type: 'tool_result',
             tool_use_id: message.toolCallId,
             content: message.content,
-            ...(message.isError !== undefined ? { is_error: message.isError } : {}),
+            ...(message.isError !== undefined
+              ? { is_error: message.isError }
+              : {}),
           },
         ],
       };
@@ -98,7 +129,9 @@ export function mapMessages(messages: readonly Message[]): AnthropicMessage[] {
 /**
  * Extracts system instruction from messages
  */
-export function extractSystemInstruction(messages: readonly Message[]): string | undefined {
+export function extractSystemInstruction(
+  messages: readonly Message[],
+): string | undefined {
   const systemMessages = messages.filter((msg) => msg.role === 'system');
   if (systemMessages.length === 0) return undefined;
   return systemMessages.map((msg) => msg.content).join('\n\n');
@@ -122,7 +155,9 @@ export function mapTool(tool: ToolDefinition): AnthropicToolDefinition {
 /**
  * Maps all tools to Anthropic format
  */
-export function mapTools(tools: readonly ToolDefinition[]): AnthropicToolDefinition[] {
+export function mapTools(
+  tools: readonly ToolDefinition[],
+): AnthropicToolDefinition[] {
   return tools.map(mapTool);
 }
 
@@ -130,7 +165,7 @@ export function mapTools(tools: readonly ToolDefinition[]): AnthropicToolDefinit
  * Maps tool choice to Anthropic format
  */
 export function mapToolChoice(
-  toolChoice?: 'auto' | 'required' | 'none'
+  toolChoice?: 'auto' | 'required' | 'none',
 ): { type: 'auto' } | { type: 'any' } | undefined {
   if (!toolChoice) return undefined;
 
@@ -160,7 +195,7 @@ export function mapRequest(
     defaultMaxTokens?: number;
     defaultTemperature?: number;
     systemInstruction?: string;
-  }
+  },
 ): AnthropicMessagesRequest {
   // Extract system instruction from messages or use provided one
   const systemFromMessages = extractSystemInstruction(request.messages);

--- a/apps/server/src/providers/infrastructure/gemini/request-mapper.ts
+++ b/apps/server/src/providers/infrastructure/gemini/request-mapper.ts
@@ -55,11 +55,29 @@ export function mapMessage(message: Message): GeminiContent {
         parts: [{ text: message.content }],
       };
 
-    case 'user':
+    case 'user': {
+      // Attachments become inlineData parts (Gemini accepts both image and
+      // audio bytes inline as base64).
+      if (message.attachments && message.attachments.length > 0) {
+        const parts: GeminiPart[] = [];
+        if (message.content) {
+          parts.push({ text: message.content });
+        }
+        for (const attachment of message.attachments) {
+          parts.push({
+            inlineData: {
+              mimeType: attachment.mimeType,
+              data: attachment.data,
+            },
+          });
+        }
+        return { role: 'user', parts };
+      }
       return {
         role: 'user',
         parts: [{ text: message.content }],
       };
+    }
 
     case 'assistant': {
       const parts: GeminiPart[] = [];

--- a/apps/server/src/providers/infrastructure/openai-compatible/request-mapper.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/request-mapper.ts
@@ -8,8 +8,18 @@ import type { Message, ModelRequest, ToolDefinition } from '@openaidy/runtime';
 import type {
   OpenAIMessage,
   OpenAIChatCompletionRequest,
+  OpenAIContentPart,
   OpenAIToolDefinition,
 } from './types';
+
+/**
+ * Maps an audio mime type to the bare format string the OpenAI
+ * `input_audio` part expects (e.g. 'audio/wav' → 'wav').
+ */
+function audioFormatFromMime(mimeType: string): string {
+  const subtype = mimeType.split('/')[1] ?? mimeType;
+  return subtype === 'mpeg' ? 'mp3' : subtype;
+}
 
 // =====================
 // Message Mapping
@@ -26,11 +36,39 @@ export function mapMessage(message: Message): OpenAIMessage {
         content: message.content,
       };
 
-    case 'user':
+    case 'user': {
+      // Attachments become multi-part content: text plus provider-specific
+      // image/audio parts (bytes inline as base64).
+      if (message.attachments && message.attachments.length > 0) {
+        const parts: OpenAIContentPart[] = [];
+        if (message.content) {
+          parts.push({ type: 'text', text: message.content });
+        }
+        for (const attachment of message.attachments) {
+          if (attachment.kind === 'image') {
+            parts.push({
+              type: 'image_url',
+              image_url: {
+                url: `data:${attachment.mimeType};base64,${attachment.data}`,
+              },
+            });
+          } else {
+            parts.push({
+              type: 'input_audio',
+              input_audio: {
+                data: attachment.data,
+                format: audioFormatFromMime(attachment.mimeType),
+              },
+            });
+          }
+        }
+        return { role: 'user', content: parts };
+      }
       return {
         role: 'user',
         content: message.content,
       };
+    }
 
     case 'assistant': {
       const openAIMsg: OpenAIMessage = {
@@ -96,7 +134,9 @@ export function mapTool(tool: ToolDefinition): OpenAIToolDefinition {
 /**
  * Maps all tools to OpenAI format
  */
-export function mapTools(tools: readonly ToolDefinition[]): OpenAIToolDefinition[] {
+export function mapTools(
+  tools: readonly ToolDefinition[],
+): OpenAIToolDefinition[] {
   return tools.map(mapTool);
 }
 
@@ -104,7 +144,7 @@ export function mapTools(tools: readonly ToolDefinition[]): OpenAIToolDefinition
  * Maps tool choice to OpenAI format
  */
 export function mapToolChoice(
-  toolChoice?: 'auto' | 'required' | 'none'
+  toolChoice?: 'auto' | 'required' | 'none',
 ): 'auto' | 'required' | 'none' | undefined {
   return toolChoice;
 }

--- a/apps/server/src/providers/infrastructure/openai-compatible/types.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/types.ts
@@ -22,9 +22,38 @@ export type OpenAITextContentPart = {
 };
 
 /**
+ * OpenAI message content part (image, as a data: or https: URL)
+ */
+export type OpenAIImageContentPart = {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+};
+
+/**
+ * OpenAI message content part (audio input)
+ */
+export type OpenAIAudioContentPart = {
+  type: 'input_audio';
+  input_audio: {
+    data: string;
+    format: string;
+  };
+};
+
+/**
+ * OpenAI message content part union
+ */
+export type OpenAIContentPart =
+  | OpenAITextContentPart
+  | OpenAIImageContentPart
+  | OpenAIAudioContentPart;
+
+/**
  * OpenAI message content (can be string or array of parts)
  */
-export type OpenAIMessageContent = string | OpenAITextContentPart[];
+export type OpenAIMessageContent = string | OpenAIContentPart[];
 
 /**
  * OpenAI tool call

--- a/apps/server/src/routes/attachments.ts
+++ b/apps/server/src/routes/attachments.ts
@@ -1,0 +1,131 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import { requireAuth } from '../middleware/require-auth';
+import {
+  AttachmentError,
+  MAX_ATTACHMENT_BYTES,
+  type AttachmentService,
+} from '../attachments/service';
+import type { SessionMessageService } from '../sessions/service';
+
+const uploadAttachmentSchema = z.object({
+  mimeType: z.string().min(1),
+  /** Base64-encoded bytes (no data: URI prefix) */
+  data: z.string().min(1),
+  name: z.string().max(255).optional(),
+});
+
+/**
+ * Base64 expands bytes by ~4/3; allow the JSON envelope on top of the
+ * decoded-size limit enforced by the service.
+ */
+const UPLOAD_BODY_LIMIT = Math.ceil(MAX_ATTACHMENT_BYTES * 1.4) + 64 * 1024;
+
+export type AttachmentRoutesOptions = {
+  attachmentService: AttachmentService;
+  sessionService: SessionMessageService;
+  authMiddleware: AuthMiddleware;
+};
+
+export const attachmentRoutes: FastifyPluginAsync<
+  AttachmentRoutesOptions
+> = async (app, options) => {
+  const { attachmentService, sessionService, authMiddleware } = options;
+
+  app.addHook(
+    'preHandler',
+    requireAuth({ authMiddleware, requiredScope: 'sessions.list' }),
+  );
+
+  /**
+   * POST /sessions/:sessionId/attachments
+   * Upload an image/audio file for a pending message. The attachment is
+   * stored unlinked; submitting a message with its id links it.
+   */
+  app.post(
+    '/sessions/:sessionId/attachments',
+    { bodyLimit: UPLOAD_BODY_LIMIT },
+    async (request, reply) => {
+      const { sessionId } = request.params as { sessionId: string };
+
+      const session = await sessionService.getSession(sessionId);
+      if (!session) {
+        reply.code(404);
+        return { error: 'Session not found', sessionId };
+      }
+
+      let body;
+      try {
+        body = uploadAttachmentSchema.parse(request.body);
+      } catch (error) {
+        reply.code(400);
+        return {
+          error: 'validation.invalid_request',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        };
+      }
+
+      try {
+        const attachment = await attachmentService.saveUpload({
+          sessionId,
+          mimeType: body.mimeType,
+          data: body.data,
+          ...(body.name ? { name: body.name } : {}),
+        });
+        reply.code(201);
+        return {
+          id: attachment.id,
+          sessionId: attachment.sessionId,
+          kind: attachment.kind,
+          source: attachment.source,
+          name: attachment.name,
+          mimeType: attachment.mimeType,
+          sizeBytes: attachment.sizeBytes,
+          createdAt: attachment.createdAt,
+        };
+      } catch (error) {
+        if (error instanceof AttachmentError) {
+          reply.code(
+            error.code === 'FILE_TOO_LARGE'
+              ? 413
+              : error.code === 'UNSUPPORTED_MIME_TYPE'
+                ? 415
+                : 500,
+          );
+          return { error: error.code, message: error.message };
+        }
+        throw error;
+      }
+    },
+  );
+
+  /**
+   * GET /attachments/:attachmentId/raw
+   * Serve an attachment's raw bytes with its media type. Fetched by the
+   * client through the authenticated fetch wrapper, so an <img src> points
+   * at an object URL, not here (same pattern as /workspace/:agentId/raw/*).
+   */
+  app.get('/attachments/:attachmentId/raw', async (request, reply) => {
+    const { attachmentId } = request.params as { attachmentId: string };
+
+    const attachment = await attachmentService.findById(attachmentId);
+    if (!attachment) {
+      reply.code(404);
+      return { error: 'Attachment not found', attachmentId };
+    }
+
+    try {
+      const { buffer, mimeType } =
+        await attachmentService.readBytes(attachment);
+      reply.header('Content-Type', mimeType);
+      reply.header('Content-Length', buffer.length);
+      reply.header('Cache-Control', 'private, max-age=3600');
+      return reply.send(buffer);
+    } catch {
+      reply.code(404);
+      return { error: 'Attachment bytes not found', attachmentId };
+    }
+  });
+};

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -8,13 +8,19 @@ const createSessionSchema = z.object({
   title: z.string().min(1),
 });
 
-const submitMessageSchema = z.object({
-  role: z.enum(['user', 'system']),
-  content: z.string().min(1),
-  agentId: z.string().optional(),
-  providerId: z.string().optional(),
-  modelId: z.string().optional(),
-});
+const submitMessageSchema = z
+  .object({
+    role: z.enum(['user', 'system']),
+    content: z.string(),
+    agentId: z.string().optional(),
+    providerId: z.string().optional(),
+    modelId: z.string().optional(),
+    attachmentIds: z.array(z.string()).max(10).optional(),
+  })
+  .refine((body) => body.content.length > 0 || body.attachmentIds?.length, {
+    message: 'content is required unless attachments are provided',
+    path: ['content'],
+  });
 
 /**
  * Session routes options
@@ -168,6 +174,9 @@ export const sessionRoutes: FastifyPluginAsync<SessionRoutesOptions> = async (
       ...(body.agentId !== undefined && { agentId: body.agentId }),
       ...(body.providerId !== undefined && { providerId: body.providerId }),
       ...(body.modelId !== undefined && { modelId: body.modelId }),
+      ...(body.attachmentIds !== undefined && {
+        attachmentIds: body.attachmentIds,
+      }),
     };
 
     const result = await sessionService.submitMessageStreaming({

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -7,15 +7,21 @@ import {
   isScreenshotTool,
   stripScreenshotFilename,
   persistScreenshotImages,
+  extractInlineImages,
+  MEDIA_WORKSPACE_DIR,
+  type PersistedImage,
 } from '../mcp/screenshot-capture';
 import type { BuiltinToolRegistry } from '../tools';
+import type { AttachmentService } from '../attachments/service';
 import type {
   ToolDefinition,
   Message,
+  MessageAttachment as RuntimeMessageAttachment,
   ModelRequest,
   ModelResponse,
   ToolCallRequest,
 } from '@openaidy/runtime';
+import type { MessageAttachment as DbMessageAttachment } from '@openaidy/db';
 import {
   type SessionsStore,
   type SessionMessagesStore,
@@ -88,6 +94,7 @@ export class SessionMessageService {
   private readonly personalityService: AgentPersonalityService | undefined;
   private readonly runEvents: RunEventEmitter | undefined;
   private readonly workspaceBaseDir: string | undefined;
+  private readonly attachments: AttachmentService | undefined;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -113,6 +120,7 @@ export class SessionMessageService {
     this.personalityService = options.personality;
     this.runEvents = options.runEvents;
     this.workspaceBaseDir = options.workspaceBaseDir;
+    this.attachments = options.attachments;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -420,13 +428,24 @@ export class SessionMessageService {
   }
 
   /**
-   * List messages for a session
+   * List messages for a session.
+   *
+   * When attachment storage is configured, each message additionally
+   * carries an `attachments` array (metadata only — no bytes) so both the
+   * UI and the model-request builder know what media belongs to it.
    */
   async listMessages(
     sessionId: string,
   ): Promise<SessionMessageRecord[] | SessionMessage[]> {
     if (this.messagesRepo) {
-      return this.messagesRepo.listBySession(sessionId);
+      const messages = await this.messagesRepo.listBySession(sessionId);
+      if (!this.attachments) return messages;
+      const grouped = await this.attachments.listBySessionGrouped(sessionId);
+      if (grouped.size === 0) return messages;
+      return messages.map((m) => {
+        const atts = grouped.get(m.id);
+        return atts ? { ...m, attachments: atts } : m;
+      }) as SessionMessage[];
     }
     return listSessionMessageRecords(sessionId);
   }
@@ -779,6 +798,27 @@ export class SessionMessageService {
       content: input.content,
     });
 
+    // Link any pending uploads to the persisted user message so they show
+    // up in the transcript and flow into the model request below.
+    if (input.attachmentIds?.length && this.attachments) {
+      try {
+        await this.attachments.linkToMessage(
+          input.attachmentIds,
+          input.sessionId,
+          userMessage.id,
+        );
+      } catch (e) {
+        this.logger?.warn(
+          {
+            sessionId: input.sessionId,
+            attachmentIds: input.attachmentIds,
+            error: e instanceof Error ? e.message : String(e),
+          },
+          'Failed to link attachments to message',
+        );
+      }
+    }
+
     // 3. Create run record
     // Track how many more messages may include the (discretion-based) ONBOARDING
     // guidance. Starts at 2 (first message + first user response); decremented
@@ -883,9 +923,28 @@ export class SessionMessageService {
           }, 1000)
         : undefined;
 
+    // Model media capabilities — decide whether image/audio attachments are
+    // embedded natively as provider content blocks or degraded to a
+    // file-path note (so the model can reach for a vision-capable tool).
+    // Unknown capabilities are treated as capable (optimistic): a provider
+    // that can't handle the block will surface its own error.
+    let modelSupportsVision = true;
+    let modelSupportsAudio = true;
+    if (this.attachments && providerEntry) {
+      const modelResult = await providerEntry.provider
+        .getModel(modelId)
+        .catch(() => null);
+      if (modelResult?.ok && modelResult.value.capabilities.length > 0) {
+        modelSupportsVision = modelResult.value.capabilities.includes('vision');
+        modelSupportsAudio =
+          modelResult.value.capabilities.includes('audio_input');
+      }
+    }
+
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
-    const historyMessages: Message[] = history.map((m) => {
+    const historyMessages: Message[] = [];
+    for (const m of history) {
       const msgRole = (m as { role: string }).role;
       const msgContent = (m as { content: string }).content;
       const msgToolCallId = (m as { toolCallId?: string }).toolCallId;
@@ -893,11 +952,12 @@ export class SessionMessageService {
         .metadata;
 
       if (msgRole === 'tool') {
-        return {
+        historyMessages.push({
           role: 'tool' as const,
           content: msgContent,
           toolCallId: msgToolCallId ?? '',
-        };
+        });
+        continue;
       }
       if (msgRole === 'assistant') {
         // The DB row's `metadata.toolCalls` is an untyped JSON blob;
@@ -909,20 +969,70 @@ export class SessionMessageService {
           | readonly ToolCallRequest[]
           | undefined;
         const msgReasoningContent = m.reasoningContent ?? undefined;
-        return {
+        historyMessages.push({
           role: 'assistant' as const,
           content: msgContent,
           ...(storedToolCalls?.length ? { toolCalls: storedToolCalls } : {}),
           ...(msgReasoningContent
             ? { reasoningContent: msgReasoningContent }
             : {}),
-        } as Message;
+        } as Message);
+        continue;
       }
-      return {
+
+      // User messages may carry attachments (linked above / in prior turns).
+      const msgAttachments = (m as { attachments?: DbMessageAttachment[] })
+        .attachments;
+      if (msgRole === 'user' && msgAttachments?.length && this.attachments) {
+        const inline: RuntimeMessageAttachment[] = [];
+        const degradedNotes: string[] = [];
+        for (const att of msgAttachments) {
+          if (att.kind !== 'image' && att.kind !== 'audio') continue;
+          const supported =
+            att.kind === 'image' ? modelSupportsVision : modelSupportsAudio;
+          if (!supported) {
+            degradedNotes.push(
+              `[Attached ${att.kind}${att.name ? ` "${att.name}"` : ''} (${att.mimeType}) is saved at ${att.storagePath} — this model cannot process it natively; use an available tool to analyze the file.]`,
+            );
+            continue;
+          }
+          try {
+            const { buffer } = await this.attachments.readBytes(att);
+            inline.push({
+              kind: att.kind,
+              mimeType: att.mimeType,
+              data: buffer.toString('base64'),
+              ...(att.name ? { name: att.name } : {}),
+            });
+          } catch (e) {
+            this.logger?.warn(
+              {
+                attachmentId: att.id,
+                error: e instanceof Error ? e.message : String(e),
+              },
+              'Failed to read attachment bytes for model request',
+            );
+            degradedNotes.push(
+              `[Attachment ${att.name ?? att.id} could not be read.]`,
+            );
+          }
+        }
+        const contentWithNotes = degradedNotes.length
+          ? [msgContent, ...degradedNotes].filter(Boolean).join('\n')
+          : msgContent;
+        historyMessages.push({
+          role: 'user' as const,
+          content: contentWithNotes,
+          ...(inline.length ? { attachments: inline } : {}),
+        } as Message);
+        continue;
+      }
+
+      historyMessages.push({
         role: msgRole as 'system' | 'user',
         content: msgContent,
-      } as Message;
-    });
+      } as Message);
+    }
 
     // 5. Build tool definitions (needed for system prompt and invocation)
     const mcpTools = this.buildMcpTools(agentId);
@@ -1186,6 +1296,9 @@ export class SessionMessageService {
             let toolContent: string | undefined;
             let toolIsError = false;
             let absolutePathFromTool: string | undefined;
+            // Inline images a tool returned and we persisted to disk —
+            // registered as attachments on the tool result message below.
+            let persistedImages: PersistedImage[] = [];
 
             // Route to builtin (native) tool only if it exists in the registry
             // AND is still enabled for this agent (tools list may have changed mid-session).
@@ -1335,13 +1448,17 @@ export class SessionMessageService {
                   };
                 });
 
-              // Persist any inline screenshot image into the agent workspace.
-              // Best-effort: a failure here must not fail the tool call.
+              // Persist any inline image the tool returned into the agent
+              // workspace — screenshots keep their dedicated folder, other
+              // tool media goes to `media/`. The saved files are registered
+              // as attachments on the tool result message below so they
+              // render inline in chat. Best-effort: a failure here must not
+              // fail the tool call.
               if (
-                captureScreenshot &&
                 this.workspace &&
                 mcpResult &&
-                !toolIsError
+                !toolIsError &&
+                extractInlineImages(mcpResult as McpToolResult).length > 0
               ) {
                 try {
                   const persisted = await persistScreenshotImages({
@@ -1349,9 +1466,13 @@ export class SessionMessageService {
                     workspace: this.workspace,
                     agentId,
                     requestedFilename,
+                    ...(captureScreenshot
+                      ? {}
+                      : { targetDir: MEDIA_WORKSPACE_DIR }),
                     logger: this.logger,
                   });
                   mcpResult = persisted.result;
+                  persistedImages = persisted.saved;
                 } catch (e) {
                   this.logger?.warn(
                     {
@@ -1359,7 +1480,7 @@ export class SessionMessageService {
                       tool: mcpToolName,
                       error: e instanceof Error ? e.message : String(e),
                     },
-                    'Failed to persist screenshot to workspace',
+                    'Failed to persist tool image to workspace',
                   );
                 }
               }
@@ -1405,7 +1526,7 @@ export class SessionMessageService {
                 toolMetadata.absolutePath = absolutePathFromTool;
               }
               // Persist tool result message
-              await this.appendMessage({
+              const toolMessage = await this.appendMessage({
                 sessionId: input.sessionId,
                 runId: run.id,
                 role: 'tool',
@@ -1414,6 +1535,33 @@ export class SessionMessageService {
                 ...(toolIsError ? { isError: true } : {}),
                 metadata: toolMetadata,
               });
+
+              // Register tool-produced images as attachments on the tool
+              // result message so the chat renders them inline (instead of
+              // only leaving a workspace-path breadcrumb).
+              if (persistedImages.length > 0 && this.attachments) {
+                for (const img of persistedImages) {
+                  await this.attachments
+                    .registerToolOutput({
+                      sessionId: input.sessionId,
+                      messageId: toolMessage.id,
+                      mimeType: img.mimeType,
+                      storagePath: img.absolutePath,
+                      name:
+                        img.relativePath.split('/').pop() ?? img.relativePath,
+                    })
+                    .catch((e: unknown) => {
+                      this.logger?.warn(
+                        {
+                          messageId: toolMessage.id,
+                          path: img.absolutePath,
+                          error: e instanceof Error ? e.message : String(e),
+                        },
+                        'Failed to register tool image attachment',
+                      );
+                    });
+                }
+              }
 
               loopMessages.push({
                 role: 'tool',

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -11,6 +11,11 @@ export type SubmitMessageInput = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
+  /**
+   * Ids of previously-uploaded (pending) attachments to link to this
+   * message. The bytes were stored via POST /sessions/:id/attachments.
+   */
+  attachmentIds?: string[];
 };
 
 /**
@@ -113,6 +118,8 @@ export type SessionMessageServiceOptions = {
   runEvents?: RunEventEmitter;
   /** Base directory for agent workspaces (for loading agent workspace skills) */
   workspaceBaseDir?: string;
+  /** Attachment storage for image/audio chat media (requires DB) */
+  attachments?: import('../attachments/service').AttachmentService;
   repositories?:
     | {
         sessions: SessionsStore;

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -293,6 +293,18 @@ export class SessionHandler {
           messages: paginated.map((msg) => {
             const reasoningContent = (msg as { reasoningContent?: string })
               .reasoningContent;
+            const attachments = (
+              msg as {
+                attachments?: Array<{
+                  id: string;
+                  kind: string;
+                  source: string;
+                  name: string | null;
+                  mimeType: string;
+                  sizeBytes: number;
+                }>;
+              }
+            ).attachments;
             return {
               id: msg.id,
               sessionId: msg.sessionId,
@@ -302,6 +314,18 @@ export class SessionHandler {
               createdAt: new Date(msg.createdAt).toISOString(),
               metadata: msg.metadata as Record<string, unknown> | undefined,
               ...(reasoningContent ? { reasoningContent } : {}),
+              ...(attachments?.length
+                ? {
+                    attachments: attachments.map((a) => ({
+                      id: a.id,
+                      kind: a.kind as 'image' | 'audio',
+                      source: a.source as 'user_upload' | 'tool_output',
+                      name: a.name,
+                      mimeType: a.mimeType,
+                      sizeBytes: a.sizeBytes,
+                    })),
+                  }
+                : {}),
             };
           }),
           total: messages.length,
@@ -440,6 +464,9 @@ export class SessionHandler {
         ...(resolvedAgentId != null && { agentId: resolvedAgentId }),
         ...(resolvedProviderId != null && { providerId: resolvedProviderId }),
         ...(resolvedModelId != null && { modelId: resolvedModelId }),
+        ...(request.payload.attachmentIds?.length && {
+          attachmentIds: request.payload.attachmentIds,
+        }),
         onStreamEvent: () => {},
       });
 
@@ -629,6 +656,9 @@ export class SessionHandler {
         runId,
         ...(providerId != null && { providerId }),
         ...(modelId != null && { modelId }),
+        ...(request.payload.attachmentIds?.length && {
+          attachmentIds: request.payload.attachmentIds,
+        }),
         onStreamEvent: (event) => {
           switch (event.type) {
             case 'delta':

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -45,7 +45,12 @@ import { createRouter } from './lib/router';
 import { useMessageQueue } from './lib/use-message-queue';
 import { LoginScreen } from './components/LoginScreen';
 import { resolveToken, clearToken } from './lib/auth-token';
-import { listAddons, deleteSession, type AddonRecord } from './lib/api';
+import {
+  listAddons,
+  deleteSession,
+  uploadAttachment,
+  type AddonRecord,
+} from './lib/api';
 import type { ChoicesEvent } from '@openaidy/shared-types';
 import { ChoicesCard } from './components/ChoicesCard';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
@@ -497,16 +502,41 @@ function AppContent(props: AppContentProps) {
 
   // Queue-aware entry point used by the composer and the choices card.
   // While a run is in flight the message is queued; otherwise it is sent now.
-  const handleSubmit = async (content: string, agentId?: string) => {
-    if (!selectedSessionId()) {
+  // Files are uploaded immediately (they don't need the run to be idle) and
+  // travel as attachment ids from then on.
+  const handleSubmit = async (
+    content: string,
+    agentId?: string,
+    files?: File[],
+  ) => {
+    const sessionId = selectedSessionId();
+    if (!sessionId) {
       setSubmitError('No session selected');
       return;
     }
+
+    let attachmentIds: string[] | undefined;
+    if (files?.length) {
+      try {
+        const uploaded = await Promise.all(
+          files.map((file) => uploadAttachment(sessionId, file)),
+        );
+        attachmentIds = uploaded.map((a) => a.id);
+      } catch (err) {
+        setSubmitError(
+          err instanceof Error ? err.message : 'Failed to upload attachment',
+        );
+        throw err instanceof Error
+          ? err
+          : new Error('Failed to upload attachment');
+      }
+    }
+
     if (isStreaming()) {
-      messageQueue.enqueue(content, agentId);
+      messageQueue.enqueue(content, agentId, attachmentIds);
       return;
     }
-    await sendMessage(content, agentId);
+    await sendMessage(content, agentId, attachmentIds);
   };
 
   // User hit Stop on an in-flight tool call — ask the server to cancel it.
@@ -536,7 +566,7 @@ function AppContent(props: AppContentProps) {
     if (isStreaming() || currentChoices()) return;
     const next = messageQueue.dequeue();
     if (next) {
-      void sendMessage(next.content, next.agentId);
+      void sendMessage(next.content, next.agentId, next.attachmentIds);
     }
   };
 
@@ -563,7 +593,11 @@ function AppContent(props: AppContentProps) {
   };
 
   // Actually dispatch a message and begin a streaming run.
-  const sendMessage = async (content: string, agentId?: string) => {
+  const sendMessage = async (
+    content: string,
+    agentId?: string,
+    attachmentIds?: string[],
+  ) => {
     const sessionId = selectedSessionId();
     if (!sessionId) {
       setSubmitError('No session selected');
@@ -608,6 +642,7 @@ function AppContent(props: AppContentProps) {
         agentId,
         providerId,
         modelId,
+        ...(attachmentIds?.length ? { attachmentIds } : {}),
       });
 
       if (!result.ok) {

--- a/apps/web/src/components/AttachmentList.tsx
+++ b/apps/web/src/components/AttachmentList.tsx
@@ -1,0 +1,105 @@
+/**
+ * AttachmentList
+ *
+ * Renders a message's image/audio attachments. Bytes are served by the
+ * authenticated raw endpoint, so each item fetches through the auth-aware
+ * wrapper and renders from an object URL (same pattern as the workspace
+ * file preview) — a bare <img src="/api/..."> would miss the Bearer token.
+ */
+
+import { createSignal, onCleanup, onMount, Show, For } from 'solid-js';
+import { FileWarning, Music } from 'lucide-solid';
+import {
+  fetchAttachmentObjectUrl,
+  type SessionMessageAttachment,
+} from '../lib/api';
+
+function AttachmentItem(props: { attachment: SessionMessageAttachment }) {
+  const [url, setUrl] = createSignal<string>();
+  const [failed, setFailed] = createSignal(false);
+
+  onMount(async () => {
+    try {
+      setUrl(await fetchAttachmentObjectUrl(props.attachment.id));
+    } catch {
+      setFailed(true);
+    }
+  });
+
+  onCleanup(() => {
+    const u = url();
+    if (u) URL.revokeObjectURL(u);
+  });
+
+  const label = () =>
+    props.attachment.name ?? `${props.attachment.kind} attachment`;
+
+  return (
+    <Show
+      when={!failed()}
+      fallback={
+        <div class="flex items-center gap-1.5 rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1.5 text-xs text-text-tertiary">
+          <FileWarning class="w-4 h-4" />
+          <span>{label()} (unavailable)</span>
+        </div>
+      }
+    >
+      <Show
+        when={props.attachment.kind === 'image'}
+        fallback={
+          <div class="flex items-center gap-2">
+            <Music class="w-4 h-4 text-text-tertiary flex-shrink-0" />
+            <Show
+              when={url()}
+              fallback={
+                <span class="text-xs text-text-tertiary">
+                  Loading {label()}…
+                </span>
+              }
+            >
+              <audio
+                controls
+                src={url()}
+                class="h-9 max-w-full"
+                title={label()}
+              />
+            </Show>
+          </div>
+        }
+      >
+        <Show
+          when={url()}
+          fallback={
+            <div class="w-32 h-24 rounded-lg bg-gray-100 dark:bg-gray-700 animate-pulse" />
+          }
+        >
+          <a
+            href={url()}
+            target="_blank"
+            rel="noopener"
+            title={label()}
+            class="block"
+          >
+            <img
+              src={url()}
+              alt={label()}
+              class="max-h-64 max-w-full rounded-lg border border-gray-200 dark:border-gray-700 object-contain"
+            />
+          </a>
+        </Show>
+      </Show>
+    </Show>
+  );
+}
+
+export function AttachmentList(props: {
+  attachments: SessionMessageAttachment[];
+}) {
+  return (
+    <div class="flex flex-wrap gap-2 mt-2" aria-label="Attachments">
+      <For each={props.attachments}>
+        {(attachment) => <AttachmentItem attachment={attachment} />}
+      </For>
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatComposer.test.tsx
+++ b/apps/web/src/components/ChatComposer.test.tsx
@@ -10,6 +10,8 @@ vi.mock('lucide-solid', () => ({
   ChevronDown: () => <span data-testid="chevron-down" />,
   Bot: () => <span data-testid="bot" />,
   X: () => <span data-testid="x" />,
+  Paperclip: () => <span data-testid="paperclip" />,
+  Music: () => <span data-testid="music" />,
 }));
 
 /** Force ChatComposer's `isMobile()` on by stubbing matchMedia. */

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1,10 +1,10 @@
-import { createSignal, onCleanup, onMount, Show } from 'solid-js';
-import { Send, ListPlus } from 'lucide-solid';
+import { createSignal, For, onCleanup, onMount, Show } from 'solid-js';
+import { Send, ListPlus, Paperclip, X, Music } from 'lucide-solid';
 import { AgentPicker } from './AgentPicker';
 import type { Agent } from '../lib/api';
 
 type ChatComposerProps = {
-  onSend: (content: string, agentId?: string) => Promise<void>;
+  onSend: (content: string, agentId?: string, files?: File[]) => Promise<void>;
   /** Hard-disable the composer (e.g. no session / disconnected). */
   disabled?: boolean;
   /**
@@ -20,15 +20,25 @@ type ChatComposerProps = {
   onInputReady?: (focus: () => void) => void;
 };
 
+/** Mime prefixes accepted as chat attachments. */
+const ACCEPTED_MIME_PREFIXES = ['image/', 'audio/'];
+
+function isAcceptedFile(file: File): boolean {
+  return ACCEPTED_MIME_PREFIXES.some((p) => file.type.startsWith(p));
+}
+
 export function ChatComposer(props: ChatComposerProps) {
   const [input, setInput] = createSignal('');
   const [isSending, setIsSending] = createSignal(false);
+  const [pendingFiles, setPendingFiles] = createSignal<File[]>([]);
+  const [isDragOver, setIsDragOver] = createSignal(false);
   // Below Tailwind's `md` (768px) we use the mobile layout: the agent picker
   // moves to a chip above the input, and the send button is merged into the
   // input pill — reclaiming horizontal room for typing. Defaults to desktop
   // when matchMedia is unavailable (e.g. jsdom under test).
   const [isMobile, setIsMobile] = createSignal(false);
   let textareaRef: HTMLTextAreaElement | undefined;
+  let fileInputRef: HTMLInputElement | undefined;
 
   // Queue mode: usable composer, but submitting enqueues for later send.
   const isQueueing = () => !!props.isStreaming && !props.disabled;
@@ -52,15 +62,63 @@ export function ChatComposer(props: ChatComposerProps) {
     });
   });
 
+  const addFiles = (files: Iterable<File>) => {
+    const accepted = [...files].filter(isAcceptedFile);
+    if (accepted.length === 0) return;
+    setPendingFiles((prev) => [...prev, ...accepted]);
+  };
+
+  const removeFile = (index: number) => {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleFileInputChange = (e: Event) => {
+    const inputEl = e.currentTarget as HTMLInputElement;
+    if (inputEl.files) addFiles(inputEl.files);
+    inputEl.value = '';
+  };
+
+  const handlePaste = (e: ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    const files: File[] = [];
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile();
+        if (file && isAcceptedFile(file)) files.push(file);
+      }
+    }
+    if (files.length > 0) {
+      e.preventDefault();
+      addFiles(files);
+    }
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    if (e.dataTransfer?.files) addFiles(e.dataTransfer.files);
+  };
+
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
     const content = input().trim();
-    if (!content || props.disabled || isSending()) return;
+    const files = pendingFiles();
+    if ((!content && files.length === 0) || props.disabled || isSending())
+      return;
 
     setIsSending(true);
     try {
-      await props.onSend(content, props.selectedAgentId);
+      await props.onSend(
+        content,
+        props.selectedAgentId,
+        files.length > 0 ? files : undefined,
+      );
       setInput('');
+      setPendingFiles([]);
+    } catch {
+      // Send/upload failed (the parent surfaces the error) — keep the input
+      // and pending files so the user can retry.
     } finally {
       setIsSending(false);
     }
@@ -83,7 +141,10 @@ export function ChatComposer(props: ChatComposerProps) {
   };
 
   const inputDisabled = () => props.disabled || isSending();
-  const sendDisabled = () => props.disabled || isSending() || !input().trim();
+  const sendDisabled = () =>
+    props.disabled ||
+    isSending() ||
+    (!input().trim() && pendingFiles().length === 0);
   const sendAriaLabel = () => (isQueueing() ? 'Queue message' : 'Send message');
   const sendTitle = () =>
     isQueueing()
@@ -104,15 +165,84 @@ export function ChatComposer(props: ChatComposerProps) {
     </Show>
   );
 
+  const attachButton = (extraClass: string) => (
+    <button
+      type="button"
+      onClick={() => fileInputRef?.click()}
+      disabled={inputDisabled()}
+      aria-label="Attach image or audio"
+      title="Attach image or audio"
+      class={`flex-shrink-0 flex items-center justify-center rounded-lg text-text-tertiary hover:text-text-primary hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${extraClass}`}
+    >
+      <Paperclip class="w-4 h-4" />
+    </button>
+  );
+
+  // Pending attachment chips (image thumbnails / audio labels), shown above
+  // the input until the message is sent.
+  const attachmentChips = () => (
+    <Show when={pendingFiles().length > 0}>
+      <div class="flex flex-wrap gap-2 mb-2" aria-label="Pending attachments">
+        <For each={pendingFiles()}>
+          {(file, index) => (
+            <div class="flex items-center gap-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 pl-1.5 pr-1 py-1 text-xs text-text-secondary max-w-48">
+              <Show
+                when={file.type.startsWith('image/')}
+                fallback={<Music class="w-4 h-4 flex-shrink-0" />}
+              >
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={file.name}
+                  class="w-6 h-6 rounded object-cover flex-shrink-0"
+                  onLoad={(e) => URL.revokeObjectURL(e.currentTarget.src)}
+                />
+              </Show>
+              <span class="truncate">{file.name}</span>
+              <button
+                type="button"
+                onClick={() => removeFile(index())}
+                aria-label={`Remove ${file.name}`}
+                class="flex-shrink-0 rounded p-0.5 hover:bg-gray-200 dark:hover:bg-gray-600"
+              >
+                <X class="w-3 h-3" />
+              </button>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+
   return (
     <form
       onSubmit={handleSubmit}
-      class="border-t border-gray-200 dark:border-gray-700 px-3 py-2 md:p-4"
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDragOver(true);
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={handleDrop}
+      class={`border-t border-gray-200 dark:border-gray-700 px-3 py-2 md:p-4 ${
+        isDragOver() ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+      }`}
     >
+      <input
+        ref={(el) => {
+          fileInputRef = el;
+        }}
+        type="file"
+        accept="image/*,audio/*"
+        multiple
+        class="hidden"
+        onChange={handleFileInputChange}
+      />
+
+      {attachmentChips()}
+
       <Show
         when={isMobile()}
         fallback={
-          /* ── Desktop / tablet (≥ md): [picker] [input] [send] ── */
+          /* ── Desktop / tablet (≥ md): [picker] [attach] [input] [send] ── */
           <div class="flex items-center gap-3">
             <AgentPicker
               agents={props.agents}
@@ -121,12 +251,15 @@ export function ChatComposer(props: ChatComposerProps) {
               disabled={inputDisabled()}
             />
 
+            {attachButton('w-10 h-10')}
+
             <div class="flex-1">
               <textarea
                 ref={setRef}
                 value={input()}
                 onInput={(e) => setInput(e.currentTarget.value)}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 disabled={inputDisabled()}
                 placeholder={placeholder()}
                 rows={1}
@@ -146,10 +279,10 @@ export function ChatComposer(props: ChatComposerProps) {
           </div>
         }
       >
-        {/* ── Mobile (< md): one compact row — agent icon, input, send — in a
-            single pill, so the chat scrollback keeps the vertical space. The
-            agent is icon-only (its name shows in the picker sheet), and the
-            keyboard hint below is hidden. ── */}
+        {/* ── Mobile (< md): one compact row — agent icon, attach, input, send —
+            in a single pill, so the chat scrollback keeps the vertical space.
+            The agent is icon-only (its name shows in the picker sheet), and
+            the keyboard hint below is hidden. ── */}
         <div class="flex items-end gap-1.5 rounded-2xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-1.5 py-1 focus-within:ring-2 focus-within:ring-primary focus-within:border-transparent">
           <AgentPicker
             variant="icon"
@@ -158,11 +291,13 @@ export function ChatComposer(props: ChatComposerProps) {
             onSelect={props.onAgentSelect}
             disabled={inputDisabled()}
           />
+          {attachButton('w-8 h-8 rounded-full')}
           <textarea
             ref={setRef}
             value={input()}
             onInput={(e) => setInput(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             disabled={inputDisabled()}
             placeholder={placeholder()}
             rows={1}
@@ -184,7 +319,7 @@ export function ChatComposer(props: ChatComposerProps) {
       <p class="mt-2 text-xs text-text-tertiary hidden md:block">
         <Show
           when={isQueueing()}
-          fallback="Press Enter to send, Shift+Enter for new line"
+          fallback="Press Enter to send, Shift+Enter for new line — paste or drop images/audio to attach"
         >
           Agent is responding — Enter queues your message, sent when it finishes
         </Show>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -13,6 +13,7 @@ import { TypingIndicator } from './TypingIndicator';
 import { MessageContent } from './MessageContent';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock, ToolResultBlock } from './ToolBlocks';
+import { AttachmentList } from './AttachmentList';
 import { QueuedMessageCard } from './QueuedMessageCard';
 import { RunActivityBadge } from './RunActivityBadge';
 import type { RunActivityPhase } from './RunActivityBadge';
@@ -234,6 +235,9 @@ export function ChatView(props: ChatViewProps) {
                       content={message.content}
                       isMcp={isMcpTool(message)}
                     />
+                  </Show>
+                  <Show when={message.attachments?.length}>
+                    <AttachmentList attachments={message.attachments!} />
                   </Show>
                 </div>
               </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,7 @@ export type {
   Session,
   MessageRole,
   SessionMessage,
+  SessionMessageAttachment,
   RunStatus,
   AgentWorkspacePermission,
   AgentWorkspace,
@@ -483,6 +484,71 @@ export async function submitMessage(
     },
   );
   return response.json();
+}
+
+/**
+ * Upload an image/audio file as a pending attachment for a session.
+ * Returns the attachment metadata; pass its id in `attachmentIds` when
+ * submitting the message.
+ */
+export async function uploadAttachment(
+  sessionId: string,
+  file: File,
+): Promise<import('./types').SessionMessageAttachment> {
+  const data = await fileToBase64(file);
+  const response = await apiFetch(
+    `${API_BASE}/api/sessions/${sessionId}/attachments`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mimeType: file.type,
+        name: file.name,
+        data,
+      }),
+    },
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      message?: string;
+      error?: string;
+    };
+    throw new Error(
+      body.message ?? body.error ?? `Upload failed (${response.status})`,
+    );
+  }
+  return response.json();
+}
+
+/** Read a File's bytes as a bare base64 string (no data: URI prefix). */
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Fetch an attachment's raw bytes (authenticated) and return an object URL
+ * suitable for <img src> / <audio src>. Callers must revoke the URL when
+ * done (URL.revokeObjectURL).
+ */
+export async function fetchAttachmentObjectUrl(
+  attachmentId: string,
+): Promise<string> {
+  const response = await apiFetch(
+    `${API_BASE}/api/attachments/${attachmentId}/raw`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to load attachment (${response.status})`);
+  }
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
 }
 
 /**

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -53,10 +53,24 @@ import type {
 } from '@openaidy/shared-types';
 
 /**
+ * Attachment metadata on a session message. Bytes are fetched separately
+ * via GET /api/attachments/:id/raw (through the authenticated fetch).
+ */
+export type SessionMessageAttachment = {
+  id: string;
+  kind: 'image' | 'audio';
+  source: 'user_upload' | 'tool_output';
+  name?: string | null;
+  mimeType: string;
+  sizeBytes: number;
+};
+
+/**
  * Session message — extends shared type with UI-only reasoning content field
  */
 export type SessionMessage = SharedSessionMessage & {
   reasoningContent?: string;
+  attachments?: SessionMessageAttachment[];
 };
 
 /**
@@ -178,6 +192,8 @@ export type QueuedMessage = {
   content: string;
   /** Agent selected at enqueue time, sent with the message. */
   agentId?: string;
+  /** Attachments uploaded at enqueue time, linked when the message sends. */
+  attachmentIds?: string[];
 };
 
 /**
@@ -189,6 +205,8 @@ export type SubmitMessageInput = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
+  /** Ids of previously-uploaded attachments to link to this message */
+  attachmentIds?: string[];
 };
 
 /**

--- a/apps/web/src/lib/use-message-queue.ts
+++ b/apps/web/src/lib/use-message-queue.ts
@@ -20,7 +20,11 @@ export interface UseMessageQueueReturn {
   /** True when no messages are queued. */
   isEmpty: Accessor<boolean>;
   /** Append a message to the end of the queue and return the created item. */
-  enqueue: (content: string, agentId?: string) => QueuedMessage;
+  enqueue: (
+    content: string,
+    agentId?: string,
+    attachmentIds?: string[],
+  ) => QueuedMessage;
   /** Replace the content of a queued message by id (no-op if not found). */
   edit: (id: string, content: string) => void;
   /** Remove a queued message by id (no-op if not found). */
@@ -40,12 +44,17 @@ export function useMessageQueue(): UseMessageQueueReturn {
   const [items, setItems] = createSignal<QueuedMessage[]>([]);
   let counter = 0;
 
-  const enqueue = (content: string, agentId?: string): QueuedMessage => {
+  const enqueue = (
+    content: string,
+    agentId?: string,
+    attachmentIds?: string[],
+  ): QueuedMessage => {
     counter += 1;
     const item: QueuedMessage = {
       id: `queued-${Date.now()}-${counter}`,
       content,
       ...(agentId ? { agentId } : {}),
+      ...(attachmentIds?.length ? { attachmentIds } : {}),
     };
     setItems((prev) => [...prev, item]);
     return item;

--- a/apps/web/src/lib/ws-api.ts
+++ b/apps/web/src/lib/ws-api.ts
@@ -127,6 +127,7 @@ export async function listMessages(
             createdAt: string;
             metadata?: Record<string, unknown>;
             reasoningContent?: string;
+            attachments?: SessionMessage['attachments'];
           }) => ({
             id: msg.id,
             sessionId: msg.sessionId,
@@ -137,6 +138,9 @@ export async function listMessages(
             metadata: msg.metadata,
             ...(msg.reasoningContent
               ? { reasoningContent: msg.reasoningContent }
+              : {}),
+            ...(msg.attachments?.length
+              ? { attachments: msg.attachments }
               : {}),
           }),
         ),
@@ -157,6 +161,9 @@ export async function submitMessage(
         agentId: input.agentId,
         providerId: input.providerId,
         modelId: input.modelId,
+        ...(input.attachmentIds?.length
+          ? { attachmentIds: input.attachmentIds }
+          : {}),
       });
 
       if (response.type !== 'session.message') {
@@ -228,6 +235,9 @@ export async function submitMessageStreaming(
         agentId: input.agentId,
         providerId: input.providerId,
         modelId: input.modelId,
+        ...(input.attachmentIds?.length
+          ? { attachmentIds: input.attachmentIds }
+          : {}),
       });
 
       if (

--- a/packages/db/drizzle/0012_message_attachments.sql
+++ b/packages/db/drizzle/0012_message_attachments.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- Migration: 0012_message_attachments
+-- Description: Metadata table for image/audio attachments on
+--              session messages. Bytes live on local disk at
+--              storage_path; message_id is null until the
+--              attachment is linked to a persisted message.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS message_attachments (
+  id           TEXT PRIMARY KEY,
+  session_id   TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  message_id   TEXT REFERENCES session_messages(id) ON DELETE CASCADE,
+  kind         TEXT NOT NULL,                          -- 'image' | 'audio'
+  source       TEXT NOT NULL DEFAULT 'user_upload',    -- 'user_upload' | 'tool_output'
+  name         TEXT,
+  mime_type    TEXT NOT NULL,
+  size_bytes   INTEGER NOT NULL,
+  storage_path TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS message_attachments_message_id_idx ON message_attachments(message_id);
+CREATE INDEX IF NOT EXISTS message_attachments_session_id_idx ON message_attachments(session_id);

--- a/packages/db/src/adapter.ts
+++ b/packages/db/src/adapter.ts
@@ -8,6 +8,7 @@ import {
 } from './repositories/pairing';
 import { createSessionsRepository } from './repositories/sessions';
 import { createSessionMessagesRepository } from './repositories/session-messages';
+import { createMessageAttachmentsRepository } from './repositories/message-attachments';
 import { createSessionRunsRepository } from './repositories/session-runs';
 import { createAccessTokensRepository } from './repositories/access-tokens';
 import { createTasksRepository } from './repositories/tasks';
@@ -31,6 +32,7 @@ export async function createDatabaseAdapter(
     sessions: createSessionsRepository(client),
     sessionMessages: createSessionMessagesRepository(client),
     sessionRuns: createSessionRunsRepository(client),
+    messageAttachments: createMessageAttachmentsRepository(client),
     jobs: createJobsRepository(client),
     jobRuns: createJobRunsRepository(client),
     pairingRequests: createPairingRequestsRepository(client),

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -97,6 +97,22 @@ function initializeSqliteSchema(sqlite: InstanceType<typeof Database>) {
       FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS message_attachments (
+      id           TEXT PRIMARY KEY,
+      session_id   TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      message_id   TEXT REFERENCES session_messages(id) ON DELETE CASCADE,
+      kind         TEXT NOT NULL,
+      source       TEXT NOT NULL DEFAULT 'user_upload',
+      name         TEXT,
+      mime_type    TEXT NOT NULL,
+      size_bytes   INTEGER NOT NULL,
+      storage_path TEXT NOT NULL,
+      created_at   TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX IF NOT EXISTS message_attachments_message_id_idx ON message_attachments(message_id);
+    CREATE INDEX IF NOT EXISTS message_attachments_session_id_idx ON message_attachments(session_id);
+
     CREATE TABLE IF NOT EXISTS scheduled_jobs (
       id TEXT PRIMARY KEY NOT NULL,
       type TEXT NOT NULL,
@@ -666,10 +682,15 @@ export async function createDatabaseClient(
     resolve(drizzleDir, '0010_add_running_status.sql'),
     'utf-8',
   );
+  const messageAttachmentsMigrationSql = readFileSync(
+    resolve(drizzleDir, '0012_message_attachments.sql'),
+    'utf-8',
+  );
   const client = await pool.connect();
   try {
     await client.query(migrationSql);
     await client.query(runningStatusMigrationSql);
+    await client.query(messageAttachmentsMigrationSql);
   } finally {
     client.release();
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,6 +10,7 @@ export * from './schema/deliverables';
 export * from './schema/addons';
 export * from './repositories/sessions';
 export * from './repositories/session-messages';
+export * from './repositories/message-attachments';
 export * from './repositories/session-runs';
 export * from './repositories/jobs';
 export * from './repositories/job-runs';

--- a/packages/db/src/repositories/message-attachments.ts
+++ b/packages/db/src/repositories/message-attachments.ts
@@ -1,0 +1,116 @@
+import { eq, and, isNull, inArray } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import type { DatabaseClient } from '../client';
+import * as schema from '../schema/sessions';
+
+type Database = DatabaseClient;
+
+/**
+ * Message attachments repository
+ *
+ * Metadata for image/audio media attached to session messages. Bytes live
+ * on local disk (see `storagePath`); rows start unlinked (`messageId` null)
+ * for user uploads and are linked to the message at submit time.
+ */
+export class MessageAttachmentsRepository {
+  constructor(private readonly db: Database) {}
+
+  async create(input: {
+    sessionId: string;
+    messageId?: string;
+    kind: schema.AttachmentKind;
+    source: schema.AttachmentSource;
+    name?: string;
+    mimeType: string;
+    sizeBytes: number;
+    storagePath: string;
+  }): Promise<schema.MessageAttachment> {
+    const [attachment] = await this.db
+      .insert(schema.messageAttachments)
+      .values({
+        id: nanoid(),
+        sessionId: input.sessionId,
+        messageId: input.messageId ?? null,
+        kind: input.kind,
+        source: input.source,
+        name: input.name ?? null,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+        storagePath: input.storagePath,
+        createdAt: new Date(),
+      })
+      .returning();
+
+    return attachment!;
+  }
+
+  async findById(id: string): Promise<schema.MessageAttachment | null> {
+    const results = await this.db
+      .select()
+      .from(schema.messageAttachments)
+      .where(eq(schema.messageAttachments.id, id))
+      .limit(1);
+
+    return results[0] ?? null;
+  }
+
+  /**
+   * Link unlinked (pending) attachments to a persisted message. Only rows
+   * that belong to the given session and have no message yet are updated,
+   * so an attachment can never be re-linked or claimed across sessions.
+   * Returns the linked rows.
+   */
+  async linkToMessage(input: {
+    attachmentIds: string[];
+    sessionId: string;
+    messageId: string;
+  }): Promise<schema.MessageAttachment[]> {
+    if (input.attachmentIds.length === 0) return [];
+
+    return this.db
+      .update(schema.messageAttachments)
+      .set({ messageId: input.messageId })
+      .where(
+        and(
+          inArray(schema.messageAttachments.id, input.attachmentIds),
+          eq(schema.messageAttachments.sessionId, input.sessionId),
+          isNull(schema.messageAttachments.messageId),
+        ),
+      )
+      .returning();
+  }
+
+  /** List all linked attachments for a session (chronological). */
+  async listBySession(sessionId: string): Promise<schema.MessageAttachment[]> {
+    return this.db
+      .select()
+      .from(schema.messageAttachments)
+      .where(eq(schema.messageAttachments.sessionId, sessionId))
+      .orderBy(schema.messageAttachments.createdAt);
+  }
+
+  async listByMessage(messageId: string): Promise<schema.MessageAttachment[]> {
+    return this.db
+      .select()
+      .from(schema.messageAttachments)
+      .where(eq(schema.messageAttachments.messageId, messageId))
+      .orderBy(schema.messageAttachments.createdAt);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const results = await this.db
+      .delete(schema.messageAttachments)
+      .where(eq(schema.messageAttachments.id, id))
+      .returning();
+    return results.length > 0;
+  }
+}
+
+/**
+ * Create a message attachments repository instance
+ */
+export function createMessageAttachmentsRepository(
+  db: Database,
+): MessageAttachmentsRepository {
+  return new MessageAttachmentsRepository(db);
+}

--- a/packages/db/src/schema/sessions.ts
+++ b/packages/db/src/schema/sessions.ts
@@ -112,6 +112,51 @@ export const sessionMessages = pgTable(
 );
 
 /**
+ * Message attachments table
+ *
+ * Binary media (images/audio) associated with session messages. Only
+ * metadata lives here — the bytes are written to local disk and referenced
+ * via `storagePath`. Rows are created unlinked (`messageId` null) when a
+ * user uploads a file, then linked to the user message at submit time;
+ * tool-produced media (e.g. screenshots) is linked directly to the tool
+ * result message.
+ */
+export const messageAttachments = pgTable(
+  'message_attachments',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id')
+      .notNull()
+      .references(() => sessions.id, { onDelete: 'cascade' }),
+    // Null until the attachment is linked to a persisted message
+    messageId: text('message_id').references(() => sessionMessages.id, {
+      onDelete: 'cascade',
+    }),
+    // 'image' | 'audio'
+    kind: text('kind').notNull(),
+    // 'user_upload' | 'tool_output'
+    source: text('source').notNull().default('user_upload'),
+    // Original filename (uploads) or generated name (tool output)
+    name: text('name'),
+    mimeType: text('mime_type').notNull(),
+    sizeBytes: integer('size_bytes').notNull(),
+    // Absolute path of the stored bytes on local disk
+    storagePath: text('storage_path').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    messageIdIdx: index('message_attachments_message_id_idx').on(
+      table.messageId,
+    ),
+    sessionIdIdx: index('message_attachments_session_id_idx').on(
+      table.sessionId,
+    ),
+  }),
+);
+
+/**
  * Run status enum
  *
  * Designed to support future async execution:
@@ -173,3 +218,10 @@ export type SessionMessage = typeof sessionMessages.$inferSelect;
 export type NewSessionMessage = typeof sessionMessages.$inferInsert;
 export type SessionRun = typeof sessionRuns.$inferSelect;
 export type NewSessionRun = typeof sessionRuns.$inferInsert;
+export type MessageAttachment = typeof messageAttachments.$inferSelect;
+export type NewMessageAttachment = typeof messageAttachments.$inferInsert;
+
+/** Attachment media kind */
+export type AttachmentKind = 'image' | 'audio';
+/** How the attachment entered the system */
+export type AttachmentSource = 'user_upload' | 'tool_output';

--- a/packages/db/src/types/index.ts
+++ b/packages/db/src/types/index.ts
@@ -5,6 +5,7 @@ import type {
 } from '../client';
 import type { SessionsRepository } from '../repositories/sessions';
 import type { SessionMessagesRepository } from '../repositories/session-messages';
+import type { MessageAttachmentsRepository } from '../repositories/message-attachments';
 import type { SessionRunsRepository } from '../repositories/session-runs';
 import type { JobsRepository } from '../repositories/jobs';
 import type { JobRunsRepository } from '../repositories/job-runs';
@@ -162,6 +163,16 @@ export type SessionMessagesStore = Pick<
   | 'countBySession'
 >;
 
+export type MessageAttachmentsStore = Pick<
+  MessageAttachmentsRepository,
+  | 'create'
+  | 'findById'
+  | 'linkToMessage'
+  | 'listBySession'
+  | 'listByMessage'
+  | 'delete'
+>;
+
 export type SessionRunsStore = Pick<
   SessionRunsRepository,
   | 'create'
@@ -241,6 +252,7 @@ export type DatabaseRepositories = {
   sessions: SessionsStore;
   sessionMessages: SessionMessagesStore;
   sessionRuns: SessionRunsStore;
+  messageAttachments: MessageAttachmentsStore;
   jobs: JobsStore;
   jobRuns: JobRunsStore;
   pairingRequests: PairingRequestsStore;

--- a/packages/runtime/src/messages/index.ts
+++ b/packages/runtime/src/messages/index.ts
@@ -19,10 +19,26 @@ export type SystemMessage = BaseMessage & {
 };
 
 /**
+ * Inline media attachment on a user message — bytes are carried as base64
+ * so the per-vendor request mappers can emit provider-specific content
+ * blocks (Anthropic `image`, OpenAI `image_url`/`input_audio`, Gemini
+ * `inlineData`) without touching disk.
+ */
+export type MessageAttachment = {
+  readonly kind: 'image' | 'audio';
+  readonly mimeType: string;
+  /** Base64-encoded bytes (no data: URI prefix) */
+  readonly data: string;
+  readonly name?: string;
+};
+
+/**
  * User message
  */
 export type UserMessage = BaseMessage & {
   readonly role: 'user';
+  /** Inline image/audio media to send alongside the text content */
+  readonly attachments?: readonly MessageAttachment[];
 };
 
 /**

--- a/packages/sdk/src/websocket-client.types.ts
+++ b/packages/sdk/src/websocket-client.types.ts
@@ -187,6 +187,8 @@ export type MessageOptions = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
+  /** Ids of previously-uploaded attachments to link to this message */
+  attachmentIds?: string[];
   metadata?: Record<string, unknown>;
 };
 

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -201,6 +201,19 @@ export type SessionDeleteRequest = WSMessage<
   }
 >;
 
+/**
+ * Attachment metadata surfaced on session messages (bytes are fetched
+ * separately via GET /api/attachments/:id/raw).
+ */
+export type SessionMessageAttachment = {
+  id: string;
+  kind: 'image' | 'audio';
+  source: 'user_upload' | 'tool_output';
+  name?: string | null;
+  mimeType: string;
+  sizeBytes: number;
+};
+
 export type SessionMessageRequest = WSMessage<
   'session.message',
   {
@@ -211,6 +224,8 @@ export type SessionMessageRequest = WSMessage<
     agentId?: string;
     providerId?: string;
     modelId?: string;
+    /** Ids of previously-uploaded attachments to link to this message */
+    attachmentIds?: string[];
     metadata?: Record<string, unknown>;
   }
 >;
@@ -279,6 +294,7 @@ export type SessionMessagesResponse = WSMessage<
       sequence: number;
       createdAt: string;
       metadata?: Record<string, unknown>;
+      attachments?: SessionMessageAttachment[];
     }>;
     total: number;
   }


### PR DESCRIPTION
Closes #403

## What

End-to-end support for attaching images and audio to chat messages, with native multimodal delivery to capable models and graceful degradation otherwise.

## How it works

**Storage** — new `message_attachments` table (metadata only: kind, source, mime, size, storage path); bytes live on local disk under `OPENAIDY_HOME/attachments/<sessionId>/`. Migration `0012` for Postgres plus the SQLite schema init. Uploads are created *unlinked* and linked to the user message at submit time.

**Upload / serving** — `POST /api/sessions/:id/attachments` (base64 JSON body, 25MB decoded limit, mime allowlist) and authenticated `GET /api/attachments/:id/raw`, mirroring the existing `/workspace/:agentId/raw/*` pattern.

**Model delivery** — the vendor-neutral `UserMessage` gains optional `attachments` (inline base64). All three request-mappers emit native blocks:
- Anthropic: `image` content blocks (audio degrades to a text note — no audio input API)
- OpenAI-compatible: `image_url` (data URI) and `input_audio` parts
- Gemini: `inlineData` parts for both

**Capability check** — at send time the session service asks the provider for the model's capabilities. If the model is known to lack `vision`/`audio_input`, the attachment is *not* embedded; instead the message carries a note with the on-disk path so the model can reach for an MCP/vision tool. Unknown capabilities are treated optimistically.

**Tool-produced media** — generalizes the screenshot special case: any inline image an MCP tool returns is persisted into the agent workspace (`screenshots/` for screenshot tools, `media/` otherwise) and registered as a `tool_output` attachment on the tool-result message, so it renders inline in chat instead of leaving only a path breadcrumb.

**Web UI** — composer gets an attach button, paste-image, and drag-drop with pending-file chips (queued messages keep their attachments); messages render attachments via a new `AttachmentList` component (image thumbnails / audio player, fetched through the authenticated wrapper as object URLs).

**Plumbing** — `attachmentIds` threaded through the REST `submitMessageSchema` (content may now be empty when attachments are present), the WS `session.message` payload, the SDK `MessageOptions`, and `session.messages` responses now include attachment metadata.

## Verification

- Typecheck clean across `packages/db`, `packages/runtime`, `packages/shared-types`, `packages/sdk`, `apps/server`, `apps/web`
- Full `packages/db` suite green (including the "creates all expected tables" client test picking up the new table)
- Full `apps/server` suite green (3087 tests)

## Notes / follow-ups

- History replay re-embeds every prior attachment's bytes each turn; long image-heavy sessions may want a "recent-N only" cap later.
- The secondary MCP path in `dispatch/service.ts` (channels/tasks) still stringifies tool results without image persistence — same behavior as before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)