### PR TITLE
fix(server): await workspace deletion in DELETE /agents handler

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -85,7 +85,7 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
       reply.code(404);
       return { error: 'Agent not found', agentId };
     }
-    personalityService?.deleteWorkspace(agentId).catch(() => {});
+    await personalityService?.deleteWorkspace(agentId).catch(() => {});
     return { deleted };
   });
 


### PR DESCRIPTION
## Fix

The DELETE `/agents/:agentId` handler fired `deleteWorkspace` as a fire-and-forget promise (`.catch(() => {})`), causing a race condition where the response was sent before the workspace directory was actually removed.

This made `apps/server/src/routes/agents.test.ts > deletes the agent workspace directory when the agent is deleted` flaky on CI — the test only waits 50ms, which isn't enough under load.

**Change:** `await` the `deleteWorkspace` call before returning the response.

## Test

All 21 agents tests pass locally.