### PR TITLE
fix(server): add no-cache header for index.html on root route

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -864,6 +864,9 @@ export async function buildApp() {
           'public, max-age=31536000, immutable',
         );
       }
+      if (request.url === '/' || request.url.endsWith('/index.html')) {
+        void reply.header('cache-control', 'no-cache, must-revalidate');
+      }
     });
 
     // SPA fallback — serve index.html for client-side routes (e.g.


### PR DESCRIPTION
## Fix

`@fastify/static` serves `index.html` for `/` without cache headers, so browsers cache the old HTML and miss new asset hashes after deploys.

Adds `no-cache, must-revalidate` to the `onSend` hook for `index.html` on the root route, matching the existing SPA fallback behavior.