### PR TITLE
feat: empty-provider install with post-login provider onboarding

### DIFF
--- a/apps/server/src/agents/schema.test.ts
+++ b/apps/server/src/agents/schema.test.ts
@@ -28,14 +28,19 @@ describe('AgentSchema', () => {
     expect(agent.model).toBe('openai/gpt-4o-mini');
   });
 
-  it('should require model field', () => {
+  it('should allow a model-less agent (inherits the config default)', () => {
+    // A fresh install ships an agent with no model; it resolves to the
+    // config default provider/model at runtime once a provider is connected.
     const result = AgentSchema.safeParse({
       id: 'test-agent',
       name: 'Test Agent',
       enabled: true,
       systemPrompt: 'You are a test assistant.',
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBeUndefined();
+    }
   });
 
   it('should allow optional fields', () => {

--- a/apps/server/src/agents/schema.ts
+++ b/apps/server/src/agents/schema.ts
@@ -84,9 +84,12 @@ export const AgentSchema = z.object({
   name: z.string().min(1),
   enabled: z.boolean(),
   systemPrompt: z.string().min(1),
-  model: z.string().min(1), // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini"
 
   // Optional fields
+  // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini". Optional so a
+  // fresh install can ship an agent with no model; it inherits the config
+  // default at runtime (set once the first provider is connected).
+  model: z.string().min(1).optional(),
   description: z.string().optional(),
 
   // MCP server references - tools from external MCP server processes
@@ -132,7 +135,7 @@ export type AgentSummary = {
   tools: string[] | undefined;
   skills: string[] | undefined;
   mcpServers: McpServerRef[] | undefined;
-  model: string; // Format: "providerId/modelId"
+  model: string | undefined; // Format: "providerId/modelId"; undefined = inherit config default
   workspace?: WorkspaceConfig | undefined;
 };
 

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -259,10 +259,18 @@ export class AppConfigService {
       this.providers.registry.register(result.provider, registrationOptions);
     }
 
-    if (this.providers.registry.has(config.defaults.providerId)) {
+    // On a fresh (unconfigured) install both are undefined; only set a default
+    // once a default provider is configured and actually registered.
+    const { providerId: defaultProviderId, modelId: defaultModelId } =
+      config.defaults;
+    if (
+      defaultProviderId !== undefined &&
+      defaultModelId !== undefined &&
+      this.providers.registry.has(defaultProviderId)
+    ) {
       this.providers.registry.setDefault({
-        providerId: config.defaults.providerId,
-        modelId: config.defaults.modelId,
+        providerId: defaultProviderId,
+        modelId: defaultModelId,
       });
     }
   }

--- a/apps/server/src/dispatch/service.ts
+++ b/apps/server/src/dispatch/service.ts
@@ -209,18 +209,24 @@ export class DispatchService {
       };
     }
 
-    // Parse model string "providerId/modelId"
-    const modelParts = agent.model.split('/');
-    if (modelParts.length !== 2 || !modelParts[0] || !modelParts[1]) {
-      return {
-        error: {
-          code: 'agent.model_invalid',
-          message: `Invalid model format "${agent.model}" for agent "${agentId}". Expected "providerId/modelId"`,
-        },
-      };
+    // Parse the agent's model string "providerId/modelId" when set. A
+    // model-less agent (fresh install) leaves these undefined and falls back
+    // to the per-run overrides / system defaults resolved below.
+    let agentProviderId: string | undefined;
+    let agentModelId: string | undefined;
+    if (agent.model !== undefined) {
+      const modelParts = agent.model.split('/');
+      if (modelParts.length !== 2 || !modelParts[0] || !modelParts[1]) {
+        return {
+          error: {
+            code: 'agent.model_invalid',
+            message: `Invalid model format "${agent.model}" for agent "${agentId}". Expected "providerId/modelId"`,
+          },
+        };
+      }
+      agentProviderId = modelParts[0];
+      agentModelId = modelParts[1];
     }
-    const agentProviderId = modelParts[0];
-    const agentModelId = modelParts[1];
 
     // Resolution precedence
     const providerId =

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,8 +50,10 @@ import {
   listAddons,
   deleteSession,
   uploadAttachment,
+  getConfig,
   type AddonRecord,
 } from './lib/api';
+import { ProviderOnboarding } from './components/onboarding/ProviderOnboarding';
 import type { ChoicesEvent } from '@openaidy/shared-types';
 import { ChoicesCard } from './components/ChoicesCard';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
@@ -455,6 +457,34 @@ function AppContent(props: AppContentProps) {
     },
     enabled: !!selectedSessionId(),
   }));
+
+  // Drives the first-run onboarding gate. A fresh install has no provider
+  // configured; we show the onboarding screen until the user sets one up.
+  // The ['config'] key is shared with the settings `useConfig` hook, so saving
+  // a provider during onboarding invalidates and refreshes this automatically.
+  const configGateQuery = createQuery(() => ({
+    queryKey: ['config'],
+    queryFn: getConfig,
+  }));
+
+  // True once config has loaded and the install is still unconfigured: there
+  // is no usable default provider. We key off `config.defaults.providerId`
+  // (which onboarding sets when it configures the first provider — local or
+  // remote) rather than credential connection status, because a credential can
+  // exist in the DB for a provider that is not in `config.providers` (e.g. a
+  // leftover from earlier testing); such a provider is "connected" but not
+  // usable for chat. Requiring the default to actually exist in the provider
+  // list is the correct "can the user chat?" signal. While loading we return
+  // false so a configured user isn't shown a flash of onboarding.
+  const needsProviderSetup = () => {
+    const data = configGateQuery.data;
+    const cfg = data && 'config' in data ? data.config : undefined;
+    if (!cfg) return false;
+    const defaultProviderId = cfg.defaults?.providerId;
+    if (!defaultProviderId) return true;
+    const configured = cfg.providers?.some((p) => p.id === defaultProviderId);
+    return !configured;
+  };
 
   // Create session mutation
   const createSessionMutation = createMutation(() => ({
@@ -914,88 +944,101 @@ function AppContent(props: AppContentProps) {
         </Show>
 
         <Show when={view() === 'chat'}>
-          <Show when={!selectedSessionId()}>
-            <div class="flex-1 flex items-center justify-center">
-              <div class="text-center">
-                <h1 class="text-2xl font-bold text-text-primary mb-2">
-                  Welcome to OpenAidy
-                </h1>
-                <p class="text-text-secondary mb-4">
-                  Select a session or create a new one to start chatting
-                </p>
-                <button
-                  onClick={handleCreateSession}
-                  disabled={createSessionMutation.isPending}
-                  class="px-4 py-2 bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white rounded-lg transition-colors"
-                >
-                  {createSessionMutation.isPending
-                    ? 'Creating...'
-                    : 'Create New Session'}
-                </button>
-              </div>
-            </div>
+          {/* First-run gate: on a fresh install with no provider configured,
+              the chat landing view is replaced by the provider onboarding
+              screen. The sidebar and logout stay reachable (not a modal). */}
+          <Show when={needsProviderSetup()}>
+            <ProviderOnboarding
+              onConfigured={() => void configGateQuery.refetch()}
+            />
           </Show>
 
-          <Show when={selectedSessionId()}>
-            <ChatView
-              messages={messages()}
-              isLoading={messagesQuery.isLoading}
-              error={messagesQuery.error?.message}
-              isStreaming={isStreaming()}
-              streamingContent={isStreaming() ? streamingContent() : undefined}
-              streamingToolCalls={
-                isStreaming() ? streamingToolCalls() : undefined
-              }
-              onCancelTool={handleCancelTool}
-              onCancelRun={handleCancelRun}
-              runActivity={isStreaming() ? runActivity() : undefined}
-              queuedMessages={messageQueue.items()}
-              onEditQueued={messageQueue.edit}
-              onRemoveQueued={messageQueue.remove}
-              scrollToMessageId={scrollToMessageId()}
-            />
-            <Show when={currentChoices()}>
-              {(c) => (
-                <ChoicesCard
-                  question={c().question}
-                  choices={c().choices}
-                  onSelect={(choice) => {
-                    setCurrentChoices(null);
-                    handleSubmit(choice, selectedAgentId());
-                  }}
-                  onDismiss={() => {
-                    setCurrentChoices(null);
-                    // Resume draining the queue now that the prompt is gone.
-                    processQueue();
-                    setTimeout(() => focusChatInput()?.(), 50);
-                  }}
-                />
-              )}
-            </Show>
-            <RunList
-              runs={runs()}
-              isLoading={runsQuery.isLoading}
-              error={runsQuery.error?.message}
-              sessionId={selectedSessionId()}
-              onRunClick={(firstMessageId) => {
-                if (firstMessageId) {
-                  setScrollToMessageId(firstMessageId);
-                }
-              }}
-            />
-            <ChatComposer
-              onSend={handleSubmit}
-              isStreaming={isStreaming()}
-              placeholder="Type your message..."
-              agents={agents()}
-              selectedAgentId={effectiveAgentId()}
-              onAgentSelect={handleAgentSelect}
-              onInputReady={(focus) => setFocusChatInput(() => focus)}
-            />
-            <Show when={submitError()}>
-              <div class="absolute bottom-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-lg shadow-lg">
-                {submitError()}
+          <Show when={!needsProviderSetup()}>
+            <Show when={!selectedSessionId()}>
+              <div class="flex-1 flex items-center justify-center">
+                <div class="text-center">
+                  <h1 class="text-2xl font-bold text-text-primary mb-2">
+                    Welcome to OpenAidy
+                  </h1>
+                  <p class="text-text-secondary mb-4">
+                    Select a session or create a new one to start chatting
+                  </p>
+                  <button
+                    onClick={handleCreateSession}
+                    disabled={createSessionMutation.isPending}
+                    class="px-4 py-2 bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white rounded-lg transition-colors"
+                  >
+                    {createSessionMutation.isPending
+                      ? 'Creating...'
+                      : 'Create New Session'}
+                  </button>
+                </div>
               </div>
+            </Show>
+
+            <Show when={selectedSessionId()}>
+              <ChatView
+                messages={messages()}
+                isLoading={messagesQuery.isLoading}
+                error={messagesQuery.error?.message}
+                isStreaming={isStreaming()}
+                streamingContent={
+                  isStreaming() ? streamingContent() : undefined
+                }
+                streamingToolCalls={
+                  isStreaming() ? streamingToolCalls() : undefined
+                }
+                onCancelTool={handleCancelTool}
+                onCancelRun={handleCancelRun}
+                runActivity={isStreaming() ? runActivity() : undefined}
+                queuedMessages={messageQueue.items()}
+                onEditQueued={messageQueue.edit}
+                onRemoveQueued={messageQueue.remove}
+                scrollToMessageId={scrollToMessageId()}
+              />
+              <Show when={currentChoices()}>
+                {(c) => (
+                  <ChoicesCard
+                    question={c().question}
+                    choices={c().choices}
+                    onSelect={(choice) => {
+                      setCurrentChoices(null);
+                      handleSubmit(choice, selectedAgentId());
+                    }}
+                    onDismiss={() => {
+                      setCurrentChoices(null);
+                      // Resume draining the queue now that the prompt is gone.
+                      processQueue();
+                      setTimeout(() => focusChatInput()?.(), 50);
+                    }}
+                  />
+                )}
+              </Show>
+              <RunList
+                runs={runs()}
+                isLoading={runsQuery.isLoading}
+                error={runsQuery.error?.message}
+                sessionId={selectedSessionId()}
+                onRunClick={(firstMessageId) => {
+                  if (firstMessageId) {
+                    setScrollToMessageId(firstMessageId);
+                  }
+                }}
+              />
+              <ChatComposer
+                onSend={handleSubmit}
+                isStreaming={isStreaming()}
+                placeholder="Type your message..."
+                agents={agents()}
+                selectedAgentId={effectiveAgentId()}
+                onAgentSelect={handleAgentSelect}
+                onInputReady={(focus) => setFocusChatInput(() => focus)}
+              />
+              <Show when={submitError()}>
+                <div class="absolute bottom-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-lg shadow-lg">
+                  {submitError()}
+                </div>
+              </Show>
             </Show>
           </Show>
         </Show>

--- a/apps/web/src/components/onboarding/ProviderOnboarding.tsx
+++ b/apps/web/src/components/onboarding/ProviderOnboarding.tsx
@@ -1,0 +1,185 @@
+/**
+ * Provider Onboarding
+ *
+ * Shown after login on a fresh install where no provider is configured yet.
+ * It reuses the same "Ready Providers" pieces as the Settings › Providers tab
+ * (PresetProviderCard grid, DialogConnectProvider, PresetProviderModal) so
+ * there is a single provider-configuration UX, but frames it as a focused
+ * first-run step and — crucially — sets the project default provider/model
+ * once the first provider is configured, so a model-less agent immediately
+ * has something to inherit.
+ *
+ * The parent (AppContent) decides when to show this based on whether a usable
+ * default provider is configured; `onConfigured` tells it to re-check once the
+ * full connect → configure → set-default flow has completed.
+ */
+
+import { createSignal, Show, For } from 'solid-js';
+import { Sparkles } from 'lucide-solid';
+import { PresetProviderCard } from '../settings/PresetProviderCard';
+import { PresetProviderModal } from '../settings/PresetProviderModal';
+import { DialogConnectProvider } from '../providers/DialogConnectProvider';
+import { useConfig } from '../settings/hooks/useConfig';
+import type { AppConfig, ProviderConfig } from '../../lib/api';
+import type { ProviderPreset } from '@openaidy/shared-types';
+import { PROVIDER_PRESETS } from '@openaidy/shared-types';
+
+interface ProviderOnboardingProps {
+  /**
+   * Called after the first provider has been fully connected, configured, and
+   * set as the project default. The parent re-checks connection status and,
+   * once a provider is connected, dismisses this screen.
+   */
+  onConfigured: () => void;
+}
+
+export function ProviderOnboarding(props: ProviderOnboardingProps) {
+  const { config, updateConfigData, updateMutation } = useConfig();
+
+  const [selectedPreset, setSelectedPreset] =
+    createSignal<ProviderPreset | null>(null);
+  const [connectingProvider, setConnectingProvider] =
+    createSignal<ProviderPreset | null>(null);
+
+  const isConfigured = (preset: ProviderPreset) =>
+    config()?.providers?.some((p) => p.id === preset.id) ?? false;
+
+  const handleSelect = (preset: ProviderPreset) => {
+    // Configured providers — and local providers, which need no API key — go
+    // straight to the model-config modal. Only remote, unconfigured providers
+    // open the credential dialog first.
+    if (isConfigured(preset) || preset.local) {
+      setSelectedPreset(preset);
+    } else {
+      setConnectingProvider(preset);
+    }
+  };
+
+  // Pick the default model for a freshly-configured provider: the preset's
+  // recommended model when it is enabled, otherwise the first enabled model.
+  const pickDefaultModel = (provider: ProviderConfig): string | undefined => {
+    const enabled = provider.models.filter((m) => m.enabled !== false);
+    const preset = PROVIDER_PRESETS.find((p) => p.id === provider.id);
+    if (preset && enabled.some((m) => m.id === preset.recommendedModel)) {
+      return preset.recommendedModel;
+    }
+    return enabled[0]?.id;
+  };
+
+  const handleSavePreset = async (providers: ProviderConfig[]) => {
+    const cfg = config();
+    if (!cfg || providers.length === 0) {
+      setSelectedPreset(null);
+      return;
+    }
+
+    // Upsert every returned provider (OpenCode Go can return two) into the
+    // config's provider list.
+    const merged = [...(cfg.providers ?? [])];
+    for (const provider of providers) {
+      const index = merged.findIndex((p) => p.id === provider.id);
+      if (index !== -1) {
+        merged[index] = provider;
+      } else {
+        merged.push(provider);
+      }
+    }
+
+    // Set the project default from the first configured provider when the
+    // install has no default yet, so the model-less seeded agent becomes
+    // usable immediately after onboarding. Also stamp the chosen model onto
+    // any model-less agent, so the config JSON carries an explicit
+    // "providerId/modelId" instead of relying on the runtime default fallback.
+    let defaults = cfg.defaults;
+    let agents = cfg.agents;
+    if (!defaults.providerId || !defaults.modelId) {
+      const primary = providers[0]!;
+      const modelId = pickDefaultModel(primary);
+      if (modelId) {
+        const model = `${primary.id}/${modelId}`;
+        defaults = { ...defaults, providerId: primary.id, modelId };
+        agents = cfg.agents.map((a) => (a.model ? a : { ...a, model }));
+      }
+    }
+
+    const updated = {
+      ...cfg,
+      providers: merged,
+      defaults,
+      agents,
+    } as AppConfig;
+
+    await updateConfigData(updated);
+    setSelectedPreset(null);
+    props.onConfigured();
+  };
+
+  return (
+    <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+      <div class="max-w-3xl mx-auto py-8 sm:py-12 px-4 sm:px-6">
+        <div class="text-center mb-8">
+          <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-primary/10 text-primary mb-4">
+            <Sparkles class="w-6 h-6" />
+          </div>
+          <h1 class="text-2xl font-bold text-text-primary mb-2">
+            Connect your first AI provider
+          </h1>
+          <p class="text-text-secondary max-w-xl mx-auto">
+            OpenAidy doesn't ship with any providers configured. Pick a provider
+            below and add your API key to start chatting — you can add more or
+            change the default later in Settings.
+          </p>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-4 sm:p-6">
+          <div class="flex items-center gap-2 mb-3">
+            <Sparkles class="w-4 h-4 text-primary" />
+            <h2 class="text-sm font-medium text-text-primary">
+              Ready Providers
+            </h2>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <For each={PROVIDER_PRESETS as ProviderPreset[]}>
+              {(preset) => (
+                <PresetProviderCard
+                  preset={preset}
+                  isConfigured={isConfigured(preset)}
+                  onSelect={handleSelect}
+                />
+              )}
+            </For>
+          </div>
+        </div>
+      </div>
+
+      {/* Configure-models modal (opened after connecting, or directly for
+          local providers / already-configured ones). */}
+      <Show when={selectedPreset()}>
+        <PresetProviderModal
+          preset={selectedPreset()!}
+          existingProvider={
+            config()?.providers?.find((p) => p.id === selectedPreset()!.id) as
+              | ProviderConfig
+              | undefined
+          }
+          onClose={() => setSelectedPreset(null)}
+          onSave={handleSavePreset}
+          isPending={updateMutation.isPending}
+        />
+      </Show>
+
+      {/* Credential dialog for remote, unconfigured providers. */}
+      <DialogConnectProvider
+        provider={connectingProvider()}
+        onClose={() => setConnectingProvider(null)}
+        onConnected={(providerId) => {
+          setConnectingProvider(null);
+          const preset = PROVIDER_PRESETS.find((p) => p.id === providerId);
+          if (preset) {
+            setSelectedPreset(preset);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/tabs/ProvidersTab.tsx
+++ b/apps/web/src/components/settings/tabs/ProvidersTab.tsx
@@ -97,67 +97,84 @@ export function ProvidersTab(props: ProvidersTabProps) {
   // ── Disconnect impact analysis ─────────────────────────────────
   //
   // Removing a provider breaks every agent whose `model` field
-  // references it ("<providerId>/<modelId>"). The server-side
-  // config schema rejects such a state, so we have to rewire the
-  // affected agents in the same write that removes the provider.
-  // We also need to flag the cases where the user can't disconnect
-  // at all: when the target is the project default provider, or
-  // when it would leave the config with zero enabled providers.
+  // references it ("<providerId>/<modelId>"). The server-side config
+  // schema rejects such a state, so `buildRewiredConfig` rewires the
+  // affected agents in the same write that removes the provider. This
+  // helper just lists them so the confirm dialog can name them.
 
-  type DisconnectImpact = {
-    /** Agents that need to be re-pointed at the project default. */
-    affectedAgents: { id: string; name: string }[];
-    /** True when this provider is the project default. */
-    isDefaultProvider: boolean;
-    /** True when removing this provider would leave no enabled providers. */
-    isLastEnabledProvider: boolean;
-  };
-
-  const computeDisconnectImpact = (targetId: string): DisconnectImpact => {
+  const computeDisconnectImpact = (
+    targetId: string,
+  ): { affectedAgents: { id: string; name: string }[] } => {
     const cfg = props.config();
     const affectedAgents =
       cfg?.agents
-        .filter((a) => a.model.split('/')[0] === targetId)
+        .filter((a) => a.model?.split('/')[0] === targetId)
         .map((a) => ({ id: a.id, name: a.name })) ?? [];
-    const isDefaultProvider = cfg?.defaults.providerId === targetId;
-    const isLastEnabledProvider =
-      cfg?.providers.filter((p) => p.id !== targetId && p.enabled).length === 0;
-    return { affectedAgents, isDefaultProvider, isLastEnabledProvider };
+    return { affectedAgents };
   };
 
-  // Build a new AppConfig with the target provider removed and all
-  // affected agents re-pointed at the project default. Returns
-  // `null` when the impact analysis says the user must change the
-  // default provider first (in which case `canDisconnect` is the
-  // source of truth for the UI).
+  // Build a new AppConfig with the target provider removed, the project
+  // default reassigned, and every affected agent (one whose model references
+  // the removed provider) rewired. Three outcomes:
+  //   • Default still valid  → keep it; affected agents point at it.
+  //   • Default removed, others remain → promote the first remaining provider
+  //     with an enabled model to default; affected agents point at it.
+  //   • No providers remain → clear the default and make affected agents
+  //     model-less, returning the install to its unconfigured state so the
+  //     onboarding gate reappears.
+  // Always returns a valid config (never null unless config hasn't loaded).
   const buildRewiredConfig = (targetId: string): AppConfig | null => {
     const cfg = props.config();
     if (!cfg) return null;
-    const impact = computeDisconnectImpact(targetId);
-    if (impact.isDefaultProvider || impact.isLastEnabledProvider) {
-      return null;
+
+    const remaining = cfg.providers.filter((p) => p.id !== targetId);
+
+    let defaults = cfg.defaults;
+    let replacementModel: string | undefined;
+
+    const defaultStillValid =
+      !!defaults.providerId &&
+      defaults.providerId !== targetId &&
+      remaining.some((p) => p.id === defaults.providerId);
+
+    if (defaultStillValid) {
+      replacementModel = `${defaults.providerId}/${defaults.modelId}`;
+    } else {
+      const next = remaining.find(
+        (p) =>
+          p.enabled !== false && p.models?.some((m) => m.enabled !== false),
+      );
+      if (next) {
+        const model =
+          next.models.find((m) => m.enabled !== false) ?? next.models[0];
+        defaults = { ...defaults, providerId: next.id, modelId: model?.id };
+        replacementModel = model ? `${next.id}/${model.id}` : undefined;
+      } else {
+        // Back to unconfigured — drop the default provider/model entirely.
+        defaults = { agentId: defaults.agentId };
+        replacementModel = undefined;
+      }
     }
-    const fallbackModel = `${cfg.defaults.providerId}/${cfg.defaults.modelId}`;
+
     return {
       ...cfg,
-      providers: cfg.providers.filter((p) => p.id !== targetId),
-      agents: cfg.agents.map((a) =>
-        a.model.split('/')[0] === targetId ? { ...a, model: fallbackModel } : a,
-      ),
+      providers: remaining,
+      defaults,
+      agents: cfg.agents.map((a) => {
+        if (a.model?.split('/')[0] !== targetId) return a;
+        if (replacementModel) return { ...a, model: replacementModel };
+        // No provider left to point at: strip the model so the agent falls
+        // back to the (now empty) default and the config stays schema-valid.
+        const { model: _removed, ...rest } = a;
+        return rest;
+      }),
     } as AppConfig;
   };
 
-  // Can the user disconnect this provider at all? Drives the
-  // confirm button's disabled state.
-  const canDisconnect = (targetId: string): boolean => {
-    const impact = computeDisconnectImpact(targetId);
-    return !impact.isDefaultProvider && !impact.isLastEnabledProvider;
-  };
-
   // Confirmed disconnect — order matters:
-  //   1. Persist the rewired config (with provider removed and
-  //      affected agents re-pointed at the project default) so the
-  //      server-side schema accepts the write.
+  //   1. Persist the rewired config (provider removed, default reassigned or
+  //      cleared, affected agents rewired accordingly) so the server-side
+  //      schema accepts the write.
   //   2. Clear the encrypted credential server-side. The OpenAI-
   //      compatible adapter's in-memory cache is invalidated by the
   //      repository's `onChange` hook on the credential write.
@@ -166,30 +183,24 @@ export function ProvidersTab(props: ProvidersTabProps) {
   const confirmDisconnect = async () => {
     const target = disconnectTarget();
     if (!target) return;
-    if (!canDisconnect(target.id)) {
-      setDisconnectError(
-        'Set another provider as the project default before disconnecting this one.',
-      );
-      return;
-    }
     const cfg = props.config();
     const rewired = buildRewiredConfig(target.id);
     if (!rewired || !cfg) return;
 
-    // Snapshot the pre-rewire model per agent before the new
-    // config is persisted, so the notice can say "this used to be
-    // X, now it's Y" instead of just "the model changed".
-    const fallbackModel = `${cfg.defaults.providerId}/${cfg.defaults.modelId}`;
-    const rewiredAgents = cfg.agents.filter(
-      (a) => a.model.split('/')[0] === target.id,
-    );
-    const notices: RewiredAgentNotice[] = rewiredAgents.map((a) => ({
-      agentId: a.id,
-      fromProviderId: target.id,
-      fromModel: a.model,
-      toModel: fallbackModel,
-      rewiredAt: new Date().toISOString(),
-    }));
+    // Derive one notice per affected agent by comparing its model before and
+    // after the rewire. `toModel` is empty when the agent was made model-less
+    // (the last provider was removed), which the Agents tab renders as "no
+    // model set".
+    const newAgentById = new Map(rewired.agents.map((a) => [a.id, a]));
+    const notices: RewiredAgentNotice[] = cfg.agents
+      .filter((a) => a.model?.split('/')[0] === target.id)
+      .map((a) => ({
+        agentId: a.id,
+        fromProviderId: target.id,
+        fromModel: a.model ?? '',
+        toModel: newAgentById.get(a.id)?.model ?? '',
+        rewiredAt: new Date().toISOString(),
+      }));
 
     setIsDisconnecting(true);
     setDisconnectError(null);
@@ -348,9 +359,6 @@ export function ProvidersTab(props: ProvidersTabProps) {
         tone="danger"
         confirmLabel="Disconnect"
         isPending={isDisconnecting()}
-        confirmDisabled={
-          !!disconnectTarget() && !canDisconnect(disconnectTarget()!.id)
-        }
         onConfirm={confirmDisconnect}
         onCancel={() => {
           if (!isDisconnecting()) setDisconnectTarget(null);
@@ -359,6 +367,13 @@ export function ProvidersTab(props: ProvidersTabProps) {
           <Show when={disconnectTarget()} keyed>
             {(target) => {
               const impact = computeDisconnectImpact(target.id);
+              const rewired = buildRewiredConfig(target.id);
+              // After removal, is the install left with no configured default
+              // (i.e. this was the only provider)? Then we return to setup.
+              const becomesUnconfigured = !rewired?.defaults.providerId;
+              const newDefault = rewired?.defaults.providerId
+                ? `${rewired.defaults.providerId}/${rewired.defaults.modelId}`
+                : '';
               return (
                 <div class="space-y-2">
                   <p>
@@ -379,27 +394,20 @@ export function ProvidersTab(props: ProvidersTabProps) {
                         </For>
                       </ul>
                       <p class="mt-1">
-                        They will be re-pointed at the project default model (
-                        <code class="font-mono">
-                          {props.config()?.defaults.providerId}/
-                          {props.config()?.defaults.modelId}
-                        </code>
-                        ).
+                        <Show
+                          when={!becomesUnconfigured}
+                          fallback="They will be left without a model until you connect another provider."
+                        >
+                          They will be re-pointed at{' '}
+                          <code class="font-mono">{newDefault}</code>.
+                        </Show>
                       </p>
                     </div>
                   </Show>
-                  <Show when={impact.isDefaultProvider}>
-                    <div class="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-2 text-xs text-red-700 dark:text-red-300">
-                      This provider is your project default. Set another
-                      provider as default in the Configuration defaults before
-                      disconnecting.
-                    </div>
-                  </Show>
-                  <Show when={impact.isLastEnabledProvider}>
-                    <div class="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-2 text-xs text-red-700 dark:text-red-300">
-                      This is the only enabled provider. Enable another provider
-                      first or the configuration would be left with no usable
-                      model.
+                  <Show when={becomesUnconfigured}>
+                    <div class="rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-2 text-xs text-blue-700 dark:text-blue-300">
+                      This is your only configured provider. Disconnecting takes
+                      you back to the setup screen to connect another.
                     </div>
                   </Show>
                   <Show when={disconnectError()}>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -306,7 +306,10 @@ export type AgentConfig = {
   enabled?: boolean;
   description?: string;
   systemPrompt: string;
-  model: string; // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini"
+  // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini". Optional: a
+  // model-less agent inherits the config default (set once the first provider
+  // is connected during onboarding).
+  model?: string;
   tools?: string[];
   tags?: string[];
   metadata?: Record<string, unknown>;
@@ -317,8 +320,10 @@ export type AgentConfig = {
  * Application defaults
  */
 export type AppDefaults = {
-  providerId: string;
-  modelId: string;
+  // Optional to represent an unconfigured install (no providers yet). Both are
+  // set once the first provider is connected during onboarding.
+  providerId?: string;
+  modelId?: string;
   agentId: string;
 };
 

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -1,8 +1,6 @@
 {
   "version": 1,
   "defaults": {
-    "providerId": "openai",
-    "modelId": "gpt-4o-mini",
     "agentId": "default"
   },
   "mcpServers": [
@@ -63,67 +61,14 @@
       }
     }
   ],
-  "providers": [
-    {
-      "id": "openai",
-      "name": "OpenAI",
-      "vendorFamily": "openai-compatible",
-      "models": [
-        {
-          "id": "gpt-4o-mini",
-          "name": "GPT-4o Mini",
-          "contextWindow": 128000,
-          "maxOutputTokens": 4096
-        },
-        {
-          "id": "gpt-4o",
-          "name": "GPT-4o",
-          "contextWindow": 128000,
-          "maxOutputTokens": 4096
-        }
-      ]
-    },
-    {
-      "id": "anthropic",
-      "name": "Anthropic",
-      "vendorFamily": "anthropic",
-      "models": [
-        {
-          "id": "claude-3-5-sonnet",
-          "name": "Claude 3.5 Sonnet",
-          "contextWindow": 200000,
-          "maxOutputTokens": 8192
-        },
-        {
-          "id": "claude-3-5-haiku",
-          "name": "Claude 3.5 Haiku",
-          "contextWindow": 200000,
-          "maxOutputTokens": 8192
-        }
-      ]
-    },
-    {
-      "id": "google-genai",
-      "name": "Google Generative AI",
-      "vendorFamily": "gemini",
-      "models": [
-        {
-          "id": "gemini-2.0-flash",
-          "name": "Gemini 2.0 Flash",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 8192
-        }
-      ]
-    }
-  ],
+  "providers": [],
   "agents": [
     {
       "id": "default",
       "name": "Default Assistant",
-      "description": "A general-purpose assistant that can read from the code assistant's workspace for context",
+      "description": "A general-purpose assistant. Uses the default provider/model configured after setup.",
       "enabled": true,
       "systemPrompt": "You are an AI assistant. You are helpful, friendly, and knowledgeable. You can assist with a wide range of tasks including answering questions, providing explanations, and helping with various requests.",
-      "model": "openai/gpt-4o-mini",
       "tools": ["tasks_list", "tasks_create", "tasks_update"],
       "tags": ["general", "default"],
       "workspace": {
@@ -141,45 +86,6 @@
               "read": true,
               "write": true,
               "delete": false,
-              "list": true
-            }
-          },
-          {
-            "path": "code-assistant",
-            "permissions": {
-              "read": true,
-              "write": false,
-              "delete": false,
-              "list": true
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "code-assistant",
-      "name": "Code Assistant",
-      "description": "An assistant specialized in programming, software development, and code review. Has access to workspace files for reading and modifying code.",
-      "enabled": true,
-      "systemPrompt": "You are an expert code assistant with deep knowledge of software development, programming languages, and best practices. You help with:\n\n1. Writing and editing code\n2. Code review and debugging\n3. Explaining programming concepts\n4. Suggesting improvements and optimizations\n\nWhen working with code:\n- Follow established patterns in the codebase\n- Write clear, well-documented code\n- Consider performance implications\n- Handle edge cases appropriately",
-      "model": "openai/gpt-4o",
-      "tools": [],
-      "tags": ["coding", "development", "technical"],
-      "workspace": {
-        "enabled": true,
-        "defaultPermissions": {
-          "read": true,
-          "write": true,
-          "delete": true,
-          "list": true
-        },
-        "workspaces": [
-          {
-            "path": "code-assistant",
-            "permissions": {
-              "read": true,
-              "write": true,
-              "delete": true,
               "list": true
             }
           }

--- a/packages/config/src/app-config.test.ts
+++ b/packages/config/src/app-config.test.ts
@@ -606,3 +606,70 @@ describe('appConfigSchema disabled model validation', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('appConfigSchema unconfigured (fresh install)', () => {
+  // Mirrors config/openaidy.template.json: no providers, no default
+  // provider/model, and a single model-less agent.
+  const freshInstall = {
+    version: 1,
+    defaults: { agentId: 'default' },
+    providers: [],
+    agents: [
+      {
+        id: 'default',
+        name: 'Default Assistant',
+        systemPrompt: 'You are an AI assistant.',
+        enabled: true,
+      },
+    ],
+  };
+
+  it('accepts an empty providers list with no default provider/model', () => {
+    const result = appConfigSchema.safeParse(freshInstall);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a model-less agent', () => {
+    const result = appConfigSchema.safeParse(freshInstall);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agents[0]!.model).toBeUndefined();
+    }
+  });
+
+  it('still rejects an agent whose model references an unconfigured provider', () => {
+    const config = {
+      ...freshInstall,
+      agents: [{ ...freshInstall.agents[0], model: 'ghost/model-x' }],
+    };
+    const result = appConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('still rejects a default provider that is not configured', () => {
+    const config = {
+      ...freshInstall,
+      defaults: { agentId: 'default', providerId: 'ghost', modelId: 'm' },
+    };
+    const result = appConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a default provider set without a default model', () => {
+    const config = {
+      ...freshInstall,
+      defaults: { agentId: 'default', providerId: 'openai' },
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          vendorFamily: 'openai-compatible',
+          enabled: true,
+          models: [{ id: 'm', name: 'M' }],
+        },
+      ],
+    };
+    const result = appConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -240,7 +240,10 @@ export const appAgentConfigSchema = z.object({
   enabled: z.boolean().optional().default(true),
   description: z.string().optional(),
   systemPrompt: z.string().min(1),
-  model: z.string().min(1), // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini"
+  // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini". Optional so a
+  // fresh install can ship an agent with no model; it inherits the config
+  // default (which onboarding sets once the first provider is connected).
+  model: z.string().min(1).optional(),
   tools: z.array(z.string()).optional(),
   mcpServers: z.array(appAgentMcpServerRefSchema).optional(),
   tags: z.array(z.string()).optional(),
@@ -251,8 +254,11 @@ export const appAgentConfigSchema = z.object({
 });
 
 export const appDefaultsSchema = z.object({
-  providerId: z.string().min(1),
-  modelId: z.string().min(1),
+  // providerId/modelId are optional to represent an "unconfigured" install
+  // (no providers yet). Once the first provider is connected via onboarding,
+  // these are set. agentId is always required (there is always >=1 agent).
+  providerId: z.string().min(1).optional(),
+  modelId: z.string().min(1).optional(),
   agentId: z.string().min(1),
 });
 
@@ -272,7 +278,8 @@ export const appConfigSchema = z
   .object({
     version: z.number().int().positive().default(1),
     defaults: appDefaultsSchema,
-    providers: z.array(appProviderConfigSchema).min(1),
+    // May be empty on a fresh install; providers are added via onboarding.
+    providers: z.array(appProviderConfigSchema),
     agents: z.array(appAgentConfigSchema).min(1),
     mcpServers: z.array(mcpServerConfigSchema).optional(),
     channels: z.array(channelConfigSchema).optional(),
@@ -281,7 +288,6 @@ export const appConfigSchema = z
   })
   .superRefine((config, ctx) => {
     const providerIds = new Set<string>();
-    const enabledProviderIds = new Set<string>();
     const providerModels = new Map<string, Set<string>>();
     const providerEnabledModels = new Map<string, Set<string>>();
 
@@ -294,9 +300,6 @@ export const appConfigSchema = z
         });
       }
       providerIds.add(provider.id);
-      if (provider.enabled) {
-        enabledProviderIds.add(provider.id);
-      }
 
       const modelIds = new Set<string>();
       const enabledModelIds = new Set<string>();
@@ -350,67 +353,90 @@ export const appConfigSchema = z
         enabledAgentIds.add(agent.id);
       }
 
-      // Validate model format "providerId/modelId"
-      const modelParts = agent.model.split('/');
-      if (modelParts.length !== 2) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['agents', agentIndex, 'model'],
-          message: `Invalid model format "${agent.model}". Expected "providerId/modelId"`,
-        });
-      } else {
-        const providerId = modelParts[0]!;
-        const modelId = modelParts[1]!;
-        if (!providerIds.has(providerId)) {
+      // Validate model format "providerId/modelId" only when a model is set.
+      // A model-less agent inherits the config default at runtime, so there is
+      // nothing to validate here (and it must not fail on an empty install).
+      if (agent.model !== undefined) {
+        const modelParts = agent.model.split('/');
+        if (modelParts.length !== 2) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ['agents', agentIndex, 'model'],
-            message: `Unknown provider "${providerId}" for agent "${agent.id}"`,
+            message: `Invalid model format "${agent.model}". Expected "providerId/modelId"`,
           });
         } else {
-          const models = providerModels.get(providerId);
-          if (!models?.has(modelId)) {
+          const providerId = modelParts[0]!;
+          const modelId = modelParts[1]!;
+          if (!providerIds.has(providerId)) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               path: ['agents', agentIndex, 'model'],
-              message: `Unknown model "${modelId}" for provider "${providerId}"`,
+              message: `Unknown provider "${providerId}" for agent "${agent.id}"`,
             });
-          } else if (!providerEnabledModels.get(providerId)?.has(modelId)) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['agents', agentIndex, 'model'],
-              message: `Model "${modelId}" is disabled in provider "${providerId}"`,
-            });
+          } else {
+            const models = providerModels.get(providerId);
+            if (!models?.has(modelId)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['agents', agentIndex, 'model'],
+                message: `Unknown model "${modelId}" for provider "${providerId}"`,
+              });
+            } else if (!providerEnabledModels.get(providerId)?.has(modelId)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['agents', agentIndex, 'model'],
+                message: `Model "${modelId}" is disabled in provider "${providerId}"`,
+              });
+            }
           }
         }
       }
     });
 
-    if (!providerIds.has(config.defaults.providerId)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaults', 'providerId'],
-        message: `Unknown default provider "${config.defaults.providerId}"`,
-      });
-    }
+    // Only validate the default provider/model when they are set. An
+    // unconfigured install leaves both undefined until onboarding connects a
+    // provider. If one is set, both must be set and must resolve.
+    const { providerId: defaultProviderId, modelId: defaultModelId } =
+      config.defaults;
+    if (defaultProviderId !== undefined || defaultModelId !== undefined) {
+      if (defaultProviderId === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['defaults', 'providerId'],
+          message: 'A default provider is required when a default model is set',
+        });
+      } else if (defaultModelId === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['defaults', 'modelId'],
+          message: 'A default model is required when a default provider is set',
+        });
+      } else {
+        if (!providerIds.has(defaultProviderId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['defaults', 'providerId'],
+            message: `Unknown default provider "${defaultProviderId}"`,
+          });
+        }
 
-    const defaultModels = providerModels.get(config.defaults.providerId);
-    if (!defaultModels?.has(config.defaults.modelId)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaults', 'modelId'],
-        message: `Unknown default model "${config.defaults.modelId}" for provider "${config.defaults.providerId}"`,
-      });
-    } else if (
-      !providerEnabledModels
-        .get(config.defaults.providerId)
-        ?.has(config.defaults.modelId)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaults', 'modelId'],
-        message: `Default model "${config.defaults.modelId}" is disabled in provider "${config.defaults.providerId}"`,
-      });
+        const defaultModels = providerModels.get(defaultProviderId);
+        if (!defaultModels?.has(defaultModelId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['defaults', 'modelId'],
+            message: `Unknown default model "${defaultModelId}" for provider "${defaultProviderId}"`,
+          });
+        } else if (
+          !providerEnabledModels.get(defaultProviderId)?.has(defaultModelId)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['defaults', 'modelId'],
+            message: `Default model "${defaultModelId}" is disabled in provider "${defaultProviderId}"`,
+          });
+        }
+      }
     }
 
     if (!agentIds.has(config.defaults.agentId)) {
@@ -421,13 +447,10 @@ export const appConfigSchema = z
       });
     }
 
-    if (enabledProviderIds.size === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['providers'],
-        message: 'At least one provider must be enabled',
-      });
-    }
+    // No "at least one enabled provider" check: a fresh install ships with
+    // zero providers and the user connects one via onboarding. When providers
+    // ARE present but all disabled, that is still a valid (unusable) state and
+    // is surfaced to the user through the provider connection UI instead.
 
     if (enabledAgentIds.size === 0) {
       ctx.addIssue({


### PR DESCRIPTION
## Summary

A fresh install now ships with **no providers, no default provider/model, and a single model-less agent**. The blueprint (`PROVIDER_PRESETS`, runtime registry) is untouched. After login, if no usable provider is configured, the user lands on a focused **onboarding screen** that reuses the existing Settings provider UI to connect their first provider.

## Changes

- **Config schema** (`packages/config`): allow empty `providers`, optional `defaults.providerId`/`modelId`, optional `agent.model`. All existing validation is preserved when values *are* present — dangling agent-model refs, unknown/disabled default provider/model, and provider-set-without-model are still rejected.
- **Install template** (`config/openaidy.template.json`): `providers: []`, `defaults` reduced to `{ agentId: "default" }`, a single model-less `default` agent (dropped `code-assistant`). MCP servers left untouched.
- **Server**: only set a registry default when a configured provider is actually registered (`config/service.ts`); `DispatchService` parses `agent.model` only when set and falls back to resolved defaults for model-less agents. The live chat path already degraded gracefully (empty registry returns a clean error, never crashes).
- **Web onboarding** (`apps/web`): new `ProviderOnboarding` component reuses `PresetProviderCard` / `DialogConnectProvider` / `PresetProviderModal`. The post-login gate is **config-driven** — it shows onboarding until a usable default provider is configured (robust against orphaned DB credentials from earlier testing). On first configure it sets the project default **and** stamps `"providerId/modelId"` onto model-less agents so the JSON carries an explicit model. The gate replaces the chat landing view but keeps the sidebar/logout reachable (not a modal).
- **Disconnect flow** (`ProvidersTab`): removed the guard that blocked disconnecting the default/last provider (a pre-feature assumption). Disconnect now always yields a valid config — it reassigns the default to a remaining provider, or clears the default and strips agent models to return to the onboarding state when the last provider is removed. Confirm-dialog messaging updated accordingly.

## Verification

- Full monorepo build: clean
- Full test suite (`pnpm -r test`): green (exit 0), including new empty-install schema tests and an updated agent-schema test
- Lint + Prettier: clean

## Notes / known limitations

- Gate re-evaluates on the **Chat** view, so after disconnecting your last provider in Settings, switch to Chat to see onboarding.
- The gate query uses `staleTime: Infinity` (refetched explicitly on onboarding completion), so hand-editing the config back to empty requires a reload to re-show onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)