### PR TITLE
chore(release): bump version to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Bumps the root `package.json` product version `0.3.5` → `0.3.6`.

The `v0.3.6` tag is already pushed and the release workflow is cutting the GitHub Release (auto-generated notes cover everything since `v0.3.5`: MiniMax/DeepSeek pricing, the mobile-viewport fix, the bootstrap-JWT fix (#409), the token deep-link, the empty-provider onboarding (#412), and the MCP inline-secret encryption). This PR lands the version bump on `main` so the branch matches the released tag (direct push is blocked by branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)