### PR TITLE
feat(addons): built-in sdk.ui.* component library with Tailwind CSS

### DIFF
--- a/apps/server/src/addons/component-manifest.test.ts
+++ b/apps/server/src/addons/component-manifest.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parseComponentManifest } from './component-manifest.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SDK_PATH = path.join(__dirname, '../sdk/openaidy-sdk.js');
+
+describe('parseComponentManifest', () => {
+  it('parses a single @component block with required and optional params', () => {
+    const source = `
+      var sdk = {
+        ui: {
+          /**
+           * @component
+           * @namespace sdk.ui
+           * @description A simple test component.
+           * @param {string} title - Required title
+           * @param {string} [subtitle] - Optional subtitle
+           * @returns {HTMLElement}
+           */
+          card: function (opts) { return document.createElement('div'); },
+        },
+      };
+    `;
+    const manifest = parseComponentManifest(source);
+    expect(manifest.components).toHaveLength(1);
+    const entry = manifest.components[0]!;
+    expect(entry.name).toBe('card');
+    expect(entry.namespace).toBe('sdk.ui');
+    expect(entry.description).toBe('A simple test component.');
+    expect(entry.returns).toBe('HTMLElement');
+    expect(entry.params).toEqual([
+      {
+        name: 'title',
+        type: 'string',
+        required: true,
+        description: 'Required title',
+      },
+      {
+        name: 'subtitle',
+        type: 'string',
+        required: false,
+        description: 'Optional subtitle',
+      },
+    ]);
+  });
+
+  it('ignores JSDoc blocks without an @component tag', () => {
+    const source = `
+      var sdk = {
+        /** Read a JSON value by key (resolves undefined if absent). */
+        get: function (key) { return null; },
+      };
+    `;
+    const manifest = parseComponentManifest(source);
+    expect(manifest.components).toHaveLength(0);
+  });
+
+  it('defaults version to 1.0.0 and accepts an override', () => {
+    expect(parseComponentManifest('').version).toBe('1.0.0');
+    expect(parseComponentManifest('', '2.0.0').version).toBe('2.0.0');
+  });
+
+  it('defaults returns to "void" when @returns is absent', () => {
+    const source = `
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description No explicit return type.
+       */
+      widget: function () {},
+    `;
+    const manifest = parseComponentManifest(source);
+    expect(manifest.components[0]!.returns).toBe('void');
+  });
+
+  it('parses a union type like {HTMLElement|string} verbatim', () => {
+    const source = `
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description Has a union-typed param.
+       * @param {HTMLElement|string} [children] - Content
+       * @returns {HTMLElement}
+       */
+      card: function () {},
+    `;
+    const manifest = parseComponentManifest(source);
+    expect(manifest.components[0]!.params[0]).toEqual({
+      name: 'children',
+      type: 'HTMLElement|string',
+      required: false,
+      description: 'Content',
+    });
+  });
+
+  it('parses every sdk.ui.* component in the real openaidy-sdk.js', () => {
+    const source = readFileSync(SDK_PATH, 'utf-8');
+    const manifest = parseComponentManifest(source);
+    expect(manifest.components).toHaveLength(25);
+    for (const entry of manifest.components) {
+      expect(entry.namespace).toBe('sdk.ui');
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(entry.returns).toBe('HTMLElement');
+    }
+    const names = manifest.components.map((c) => c.name);
+    expect(names).toContain('card');
+    expect(names).toContain('dialog');
+    expect(names).toContain('popover');
+  });
+});

--- a/apps/server/src/addons/component-manifest.ts
+++ b/apps/server/src/addons/component-manifest.ts
@@ -1,0 +1,105 @@
+/**
+ * Component Manifest — JSDoc-derived, agent-discoverable
+ *
+ * Parses `@component` JSDoc blocks directly out of `openaidy-sdk.js` at
+ * request time and turns them into the structured manifest served by
+ * `GET /sdk/components.json`. This is deliberately a SEPARATE source from
+ * `sdk-reference.ts`'s hand-authored `SDK_METHODS` array: this file describes
+ * the same `sdk.ui.*` surface, but reads it straight from the .js source so
+ * the manifest can never drift from the actual runtime implementation —
+ * adding a component is "add the JSDoc block + implementation", nothing else.
+ *
+ * No JSDoc-parsing library exists anywhere in this monorepo (checked), and the
+ * codebase generally favors small hand-rolled parsers over new dependencies
+ * for this kind of narrowly-scoped text extraction (see the CSP/domain regex
+ * logic in routes/addons.ts and tools/addons/create.ts) — this follows that
+ * precedent rather than pulling in e.g. `comment-parser`.
+ */
+
+export type ComponentManifestParam = {
+  readonly name: string;
+  readonly type: string;
+  readonly required: boolean;
+  readonly description: string;
+};
+
+export type ComponentManifestEntry = {
+  readonly name: string;
+  readonly namespace: string;
+  readonly description: string;
+  readonly params: readonly ComponentManifestParam[];
+  readonly returns: string;
+};
+
+export type ComponentManifest = {
+  readonly version: string;
+  readonly components: readonly ComponentManifestEntry[];
+};
+
+/** Matches a JSDoc block immediately followed by `name: function`. */
+const JSDOC_METHOD_RE =
+  /\/\*\*([\s\S]*?)\*\/\s*([A-Za-z_$][\w$]*)\s*:\s*function/g;
+
+/**
+ * Matches a `@param {type} name - description` (or `{type} [name] -
+ * description` for an optional param) line, after `*`-prefix stripping.
+ */
+const PARAM_LINE_RE = /^@param\s+\{([^}]+)\}\s+(\[[^\]]+\]|\S+)\s*-\s*(.*)$/;
+
+/** Strip the leading `*`/whitespace JSDoc comment lines carry. */
+function stripCommentPrefix(raw: string): string[] {
+  return raw.split('\n').map((line) => line.replace(/^\s*\*\s?/, '').trim());
+}
+
+function parseParamLine(line: string): ComponentManifestParam | null {
+  const match = PARAM_LINE_RE.exec(line);
+  if (!match) return null;
+  const type = match[1] as string;
+  const rawName = match[2] as string;
+  const description = match[3] as string;
+  const required = !rawName.startsWith('[');
+  const name = rawName.replace(/^\[|\]$/g, '').split('=')[0] as string;
+  return { name, type, required, description };
+}
+
+/**
+ * Parse every `@component`-tagged JSDoc block in `sdkSource` into a
+ * {@link ComponentManifest}. Blocks without `@component` are ignored, so this
+ * only ever picks up `sdk.ui.*` (or any future namespace opted in the same
+ * way) — not the rest of the SDK's plain one-line doc comments.
+ */
+export function parseComponentManifest(
+  sdkSource: string,
+  version = '1.0.0',
+): ComponentManifest {
+  const components: ComponentManifestEntry[] = [];
+
+  for (const match of sdkSource.matchAll(JSDOC_METHOD_RE)) {
+    const [, rawComment, name] = match as unknown as [string, string, string];
+    if (!rawComment.includes('@component')) continue;
+
+    const lines = stripCommentPrefix(rawComment);
+    let namespace = '';
+    let description = '';
+    let returns = 'void';
+    const params: ComponentManifestParam[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith('@namespace')) {
+        namespace = line.slice('@namespace'.length).trim();
+      } else if (line.startsWith('@description')) {
+        description = line.slice('@description'.length).trim();
+      } else if (line.startsWith('@returns')) {
+        const returnMatch = /\{([^}]+)\}/.exec(line);
+        if (returnMatch) returns = returnMatch[1] as string;
+      } else if (line.startsWith('@param')) {
+        const param = parseParamLine(line);
+        if (param) params.push(param);
+      }
+    }
+
+    components.push({ name, namespace, description, params, returns });
+  }
+
+  return { version, components };
+}

--- a/apps/server/src/addons/sdk-reference.ts
+++ b/apps/server/src/addons/sdk-reference.ts
@@ -20,9 +20,17 @@ export type SdkParamKind =
   | 'string'
   | 'object'
   | 'number'
+  | 'boolean'
+  | 'function'
+  | 'array'
+  | 'element'
   | 'optional_string'
   | 'optional_object'
-  | 'optional_number';
+  | 'optional_number'
+  | 'optional_boolean'
+  | 'optional_function'
+  | 'optional_array'
+  | 'optional_element';
 
 export type SdkParam = {
   readonly name: string;
@@ -33,8 +41,13 @@ export type SdkParam = {
 export type SdkMethod = {
   readonly name: string;
   readonly category: string;
-  readonly proxyPath: string;
-  readonly httpMethod: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  /**
+   * Server proxy path for methods that make a round-trip (`/api/addon-proxy/...`).
+   * Omitted for pure client-side DOM builders (category 'UI') — they never
+   * touch the network, so there is no proxy path or HTTP method to document.
+   */
+  readonly proxyPath?: string;
+  readonly httpMethod?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   readonly requiredPermission?: string;
   readonly params: readonly SdkParam[];
   readonly returns: string;
@@ -324,6 +337,530 @@ export const SDK_METHODS: readonly SdkMethod[] = [
     description: 'Full-text search over a declared FTS5 table.',
     exampleJs:
       "sdk.storage.search('notes_fts', 'vite').then(function(rows) { console.log(rows); });",
+  },
+
+  // ── UI (Tailwind-styled component library) ─────────────────────────────────
+  // Pure client-side DOM builders — no proxyPath/httpMethod (no server
+  // round-trip) and no requiredPermission (nothing to gate). Every entry
+  // mirrors the @component JSDoc above the method in openaidy-sdk.js; see
+  // GET /sdk/components.json for the machine-readable version of the same data.
+  {
+    name: 'ui.card',
+    category: 'UI',
+    params: [
+      { name: 'title', kind: 'string', description: 'The card title' },
+      {
+        name: 'subtitle',
+        kind: 'optional_string',
+        description: 'Optional subtitle text',
+      },
+      {
+        name: 'children',
+        kind: 'optional_element',
+        description:
+          'Content to render inside the card (HTMLElement or string)',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A styled card container with a title and optional subtitle.',
+    exampleJs: "sdk.ui.card({ title: 'Stats', subtitle: 'Last 7 days' });",
+  },
+  {
+    name: 'ui.tabs',
+    category: 'UI',
+    params: [
+      {
+        name: 'tabs',
+        kind: 'array',
+        description: 'Array of { id, label, content: HTMLElement|string }',
+      },
+      {
+        name: 'activeTab',
+        kind: 'optional_string',
+        description: 'id of the initially active tab (defaults to the first)',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A tabbed panel with keyboard navigation (Left/Right arrow keys).',
+    exampleJs:
+      "sdk.ui.tabs({ tabs: [{ id: 'a', label: 'A', content: 'Tab A' }] });",
+  },
+  {
+    name: 'ui.accordion',
+    category: 'UI',
+    params: [
+      {
+        name: 'items',
+        kind: 'array',
+        description: 'Array of { title, content: HTMLElement|string }',
+      },
+      {
+        name: 'multiple',
+        kind: 'optional_boolean',
+        description: 'Allow more than one item open at once (default false)',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A vertically-stacked accordion of expandable items.',
+    exampleJs:
+      "sdk.ui.accordion({ items: [{ title: 'FAQ', content: '...' }] });",
+  },
+  {
+    name: 'ui.separator',
+    category: 'UI',
+    params: [
+      {
+        name: 'orientation',
+        kind: 'optional_string',
+        description: '"horizontal" (default) or "vertical"',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A thin horizontal or vertical divider line.',
+    exampleJs: 'sdk.ui.separator();',
+  },
+  {
+    name: 'ui.button',
+    category: 'UI',
+    params: [
+      { name: 'text', kind: 'string', description: 'Button label' },
+      {
+        name: 'variant',
+        kind: 'optional_string',
+        description: '"primary" (default), "secondary", "ghost", or "danger"',
+      },
+      {
+        name: 'onClick',
+        kind: 'optional_function',
+        description: 'Click handler',
+      },
+      {
+        name: 'loading',
+        kind: 'optional_boolean',
+        description: 'Show a spinner and disable the button',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A clickable button with variants, sizes, an optional icon, and loading/disabled states.',
+    exampleJs: "sdk.ui.button({ text: 'Save', onClick: function() {} });",
+  },
+  {
+    name: 'ui.buttonGroup',
+    category: 'UI',
+    params: [
+      {
+        name: 'buttons',
+        kind: 'array',
+        description: 'Array of { text, variant, onClick }',
+      },
+      {
+        name: 'orientation',
+        kind: 'optional_string',
+        description: '"horizontal" (default) or "vertical"',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A visually grouped set of buttons with shared borders.',
+    exampleJs:
+      "sdk.ui.buttonGroup({ buttons: [{ text: 'A' }, { text: 'B' }] });",
+  },
+  {
+    name: 'ui.dropdownMenu',
+    category: 'UI',
+    params: [
+      {
+        name: 'trigger',
+        kind: 'element',
+        description: 'The element or label that opens the menu',
+      },
+      {
+        name: 'items',
+        kind: 'array',
+        description: 'Array of { label, onClick, icon: HTMLElement|string }',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A trigger button that opens a menu of clickable items; closes on outside click, item selection, or Escape.',
+    exampleJs:
+      "sdk.ui.dropdownMenu({ trigger: 'Actions', items: [{ label: 'Edit', onClick: function() {} }] });",
+  },
+  {
+    name: 'ui.table',
+    category: 'UI',
+    params: [
+      {
+        name: 'columns',
+        kind: 'array',
+        description: 'Array of { key, label }',
+      },
+      { name: 'rows', kind: 'array', description: 'Array of row objects' },
+      {
+        name: 'onRowClick',
+        kind: 'optional_function',
+        description: 'Called with the row object when a row is clicked',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A data table with an empty state and optional row-click handling.',
+    exampleJs:
+      "sdk.ui.table({ columns: [{ key: 'name', label: 'Name' }], rows: [{ name: 'Ada' }] });",
+  },
+  {
+    name: 'ui.badge',
+    category: 'UI',
+    params: [
+      { name: 'text', kind: 'string', description: 'Badge text' },
+      {
+        name: 'color',
+        kind: 'optional_string',
+        description: '"blue" (default), "green", "red", "gray", or "yellow"',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A small colored label for status/tags.',
+    exampleJs: "sdk.ui.badge({ text: 'Active', color: 'green' });",
+  },
+  {
+    name: 'ui.avatar',
+    category: 'UI',
+    params: [
+      { name: 'src', kind: 'optional_string', description: 'Image URL' },
+      {
+        name: 'fallback',
+        kind: 'optional_string',
+        description:
+          'Fallback text (e.g. initials) shown when there is no image',
+      },
+      {
+        name: 'size',
+        kind: 'optional_string',
+        description: '"sm", "md" (default), or "lg"',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A circular avatar image with a text fallback when no image loads.',
+    exampleJs: "sdk.ui.avatar({ fallback: 'AB' });",
+  },
+  {
+    name: 'ui.skeleton',
+    category: 'UI',
+    params: [
+      {
+        name: 'variant',
+        kind: 'optional_string',
+        description: '"text" (default, rounded bar), "circle", or "rect"',
+      },
+      { name: 'width', kind: 'optional_string', description: 'CSS width' },
+      { name: 'height', kind: 'optional_string', description: 'CSS height' },
+    ],
+    returns: 'HTMLElement',
+    description: 'A pulsing placeholder shown while content is loading.',
+    exampleJs: "sdk.ui.skeleton({ variant: 'circle', width: '2.5rem' });",
+  },
+  {
+    name: 'ui.breadcrumb',
+    category: 'UI',
+    params: [
+      {
+        name: 'items',
+        kind: 'array',
+        description: 'Array of { label, href, onClick }',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A breadcrumb trail of navigation items.',
+    exampleJs: "sdk.ui.breadcrumb({ items: [{ label: 'Home', href: '/' }] });",
+  },
+  {
+    name: 'ui.toast',
+    category: 'UI',
+    params: [
+      { name: 'message', kind: 'string', description: 'Toast message' },
+      {
+        name: 'type',
+        kind: 'optional_string',
+        description: '"info" (default), "success", "error", or "warning"',
+      },
+      {
+        name: 'duration',
+        kind: 'optional_number',
+        description: 'Auto-dismiss delay in ms (default 4000; 0 disables)',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'Shows a transient stacked notification in the top-right corner; auto-dismisses after `duration`.',
+    exampleJs: "sdk.ui.toast({ message: 'Saved!', type: 'success' });",
+  },
+  {
+    name: 'ui.alert',
+    category: 'UI',
+    params: [
+      { name: 'message', kind: 'string', description: 'Alert message' },
+      {
+        name: 'variant',
+        kind: 'optional_string',
+        description: '"info" (default), "success", "warning", or "error"',
+      },
+      {
+        name: 'dismissible',
+        kind: 'optional_boolean',
+        description: 'Show a close button that removes the alert',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'An inline banner for important messages, with an optional dismiss button.',
+    exampleJs:
+      "sdk.ui.alert({ message: 'Something needs attention', variant: 'warning' });",
+  },
+  {
+    name: 'ui.dialog',
+    category: 'UI',
+    params: [
+      { name: 'title', kind: 'string', description: 'Dialog title' },
+      {
+        name: 'content',
+        kind: 'element',
+        description: 'Dialog body content (HTMLElement or string)',
+      },
+      {
+        name: 'buttons',
+        kind: 'optional_array',
+        description:
+          'Array of { text, variant, onClick } rendered in the footer',
+      },
+      {
+        name: 'onClose',
+        kind: 'optional_function',
+        description: 'Called when the dialog is dismissed (any method)',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A focus-trapped modal dialog with a backdrop; closes on Escape, backdrop click, or Cancel/close.',
+    exampleJs:
+      "sdk.ui.dialog({ title: 'Confirm', content: 'Are you sure?', buttons: [{ text: 'OK' }] });",
+  },
+  {
+    name: 'ui.tooltip',
+    category: 'UI',
+    params: [
+      { name: 'content', kind: 'string', description: 'Tooltip text' },
+      {
+        name: 'children',
+        kind: 'element',
+        description: 'The element the tooltip is attached to',
+      },
+      {
+        name: 'position',
+        kind: 'optional_string',
+        description: '"top" (default), "bottom", "left", or "right"',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'Wraps `children` with a hover/focus-triggered tooltip bubble.',
+    exampleJs:
+      "sdk.ui.tooltip({ content: 'More info', children: sdk.ui.button({ text: '?' }) });",
+  },
+  {
+    name: 'ui.input',
+    category: 'UI',
+    params: [
+      { name: 'label', kind: 'optional_string', description: 'Label text' },
+      {
+        name: 'placeholder',
+        kind: 'optional_string',
+        description: 'Placeholder text',
+      },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new string value on every input event',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A labeled text input.',
+    exampleJs: "sdk.ui.input({ label: 'Name', onChange: function(v) {} });",
+  },
+  {
+    name: 'ui.textarea',
+    category: 'UI',
+    params: [
+      { name: 'label', kind: 'optional_string', description: 'Label text' },
+      {
+        name: 'rows',
+        kind: 'optional_number',
+        description: 'Visible rows (default 3)',
+      },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new string value on every input event',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A labeled multi-line text input.',
+    exampleJs: "sdk.ui.textarea({ label: 'Notes' });",
+  },
+  {
+    name: 'ui.select',
+    category: 'UI',
+    params: [
+      { name: 'label', kind: 'optional_string', description: 'Label text' },
+      {
+        name: 'options',
+        kind: 'array',
+        description: 'Array of { value, label }',
+      },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new string value on change',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A labeled dropdown select.',
+    exampleJs:
+      "sdk.ui.select({ label: 'Sort', options: [{ value: 'asc', label: 'Ascending' }] });",
+  },
+  {
+    name: 'ui.switch',
+    category: 'UI',
+    params: [
+      {
+        name: 'checked',
+        kind: 'optional_boolean',
+        description: 'Initial checked state',
+      },
+      { name: 'label', kind: 'optional_string', description: 'Label text' },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new boolean state on toggle',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'An accessible toggle switch (role="switch").',
+    exampleJs: "sdk.ui.switch({ label: 'Enabled', onChange: function(v) {} });",
+  },
+  {
+    name: 'ui.checkbox',
+    category: 'UI',
+    params: [
+      {
+        name: 'checked',
+        kind: 'optional_boolean',
+        description: 'Initial checked state',
+      },
+      { name: 'label', kind: 'optional_string', description: 'Label text' },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new boolean state on change',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A native checkbox with a label.',
+    exampleJs: "sdk.ui.checkbox({ label: 'Accept terms' });",
+  },
+  {
+    name: 'ui.radioGroup',
+    category: 'UI',
+    params: [
+      {
+        name: 'name',
+        kind: 'string',
+        description: 'Shared name attribute for the group',
+      },
+      {
+        name: 'options',
+        kind: 'array',
+        description: 'Array of { value, label }',
+      },
+      {
+        name: 'onChange',
+        kind: 'optional_function',
+        description: 'Called with the new string value on change',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A group of mutually-exclusive radio buttons.',
+    exampleJs:
+      "sdk.ui.radioGroup({ name: 'plan', options: [{ value: 'free', label: 'Free' }] });",
+  },
+  {
+    name: 'ui.label',
+    category: 'UI',
+    params: [
+      { name: 'text', kind: 'string', description: 'Label text' },
+      {
+        name: 'required',
+        kind: 'optional_boolean',
+        description: 'Show a red asterisk after the text',
+      },
+    ],
+    returns: 'HTMLElement',
+    description: 'A form label, with an optional required-field asterisk.',
+    exampleJs: "sdk.ui.label({ text: 'Email', required: true });",
+  },
+  {
+    name: 'ui.sheet',
+    category: 'UI',
+    params: [
+      { name: 'title', kind: 'string', description: 'Sheet title' },
+      {
+        name: 'children',
+        kind: 'element',
+        description: 'Sheet body content (HTMLElement or string)',
+      },
+      {
+        name: 'side',
+        kind: 'optional_string',
+        description: '"right" (default) or "left"',
+      },
+      {
+        name: 'onClose',
+        kind: 'optional_function',
+        description: 'Called when the sheet is dismissed',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'A focus-trapped panel that slides in from a screen edge; closes on Escape, backdrop click, or close button.',
+    exampleJs: "sdk.ui.sheet({ title: 'Details', children: 'Body content' });",
+  },
+  {
+    name: 'ui.popover',
+    category: 'UI',
+    params: [
+      {
+        name: 'trigger',
+        kind: 'element',
+        description: 'The element that toggles the popover',
+      },
+      {
+        name: 'content',
+        kind: 'element',
+        description: 'Popover body content (HTMLElement or string)',
+      },
+      {
+        name: 'onOpenChange',
+        kind: 'optional_function',
+        description: 'Called with the new boolean open state on toggle',
+      },
+    ],
+    returns: 'HTMLElement',
+    description:
+      'An anchored popover that opens near its trigger; closes on outside click or Escape.',
+    exampleJs:
+      "sdk.ui.popover({ trigger: sdk.ui.button({ text: 'More' }), content: 'Popover body' });",
   },
 ] as const;
 

--- a/apps/server/src/routes/addons.ts
+++ b/apps/server/src/routes/addons.ts
@@ -9,6 +9,10 @@ import { signAssetToken, verifyAssetToken } from '../lib/asset-token';
 import { createAddonService } from '../addons/service';
 import type { AddonsRepository } from '@openaidy/db';
 import type { ManifestValidator } from '../addons/manifest-validator';
+import {
+  parseComponentManifest,
+  type ComponentManifest,
+} from '../addons/component-manifest';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,6 +21,18 @@ const ADMIN_SCOPE = '*';
 // Asset tokens are short-lived; the addon's static assets all load within
 // seconds of the iframe navigation, so a small window is plenty.
 const ASSET_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * The Tailwind Play CDN origin every addon's `index.html` auto-loads (see
+ * `tools/addons/create.ts`). This is a fixed PLATFORM allowance, not derived
+ * from a given addon's `externalDomains` — those only ever feed
+ * `connect-src`/`img-src` (fetch/XHR and images), never `script-src`, and we
+ * deliberately don't widen `script-src` to arbitrary addon-declared domains
+ * (an addon declaring an API host for fetch() should not thereby also be
+ * allowed to load a <script> from that same host). Tailwind is a built-in
+ * platform feature every addon gets, so it gets its own explicit allowance.
+ */
+const TAILWIND_CDN_ORIGIN = 'https://cdn.tailwindcss.com';
 
 /**
  * Append an asset token to a same-origin subresource URL. External, absolute,
@@ -407,6 +423,29 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
       .send(fs.readFileSync(sdkPath));
   });
 
+  // GET /sdk/components.json - Serve the sdk.ui.* component manifest, parsed
+  // from @component JSDoc blocks in openaidy-sdk.js. Not asset-token gated —
+  // this is documentation, not a credential, same as GET /info. Cached after
+  // the first parse: the SDK file doesn't change within a server's lifetime.
+  let componentManifestCache: ComponentManifest | null = null;
+  app.get('/sdk/components.json', async (_request, reply) => {
+    if (!componentManifestCache) {
+      const sdkPath =
+        process.env['OPENAIDY_SDK_PATH'] ??
+        path.join(__dirname, '../sdk/openaidy-sdk.js');
+      if (!fs.existsSync(sdkPath)) {
+        return reply.code(404).send({ error: 'SDK not found' });
+      }
+      componentManifestCache = parseComponentManifest(
+        fs.readFileSync(sdkPath, 'utf-8'),
+      );
+    }
+    return reply
+      .header('Access-Control-Allow-Origin', '*')
+      .header('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .send(componentManifestCache);
+  });
+
   // GET /addons/:addonId/* - Serve addon static files
   app.get<{ Params: { addonId: string; '*': string } }>(
     '/addons/:addonId/*',
@@ -498,6 +537,7 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
         "'unsafe-inline'",
         ...(requestHost ? [`http://${requestHost}`] : []),
         `http://localhost:${env.PORT}`,
+        TAILWIND_CDN_ORIGIN,
       ];
       const scriptSrc = scriptSrcOrigins.join(' ');
 

--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -118,6 +118,172 @@
     });
   }
 
+  // ── UI helpers (internal — not exposed on sdk.ui) ──────────────────────
+  // Small, reused primitives so the 25 sdk.ui.* components below stay DRY.
+  var _uid = 0;
+  function _nextId(prefix) {
+    return (prefix || 'oa') + '-' + ++_uid;
+  }
+
+  /** classnames-style joiner: filters falsy args, joins the rest with a space. */
+  function _cx() {
+    var parts = [];
+    for (var i = 0; i < arguments.length; i++) {
+      if (arguments[i]) parts.push(arguments[i]);
+    }
+    return parts.join(' ');
+  }
+
+  /** Append a string, element, or array of either onto a parent node. */
+  function _append(parent, children) {
+    var list = Array.isArray(children) ? children : [children];
+    list.forEach(function (c) {
+      if (c === null || c === undefined || c === false) return;
+      parent.appendChild(
+        typeof c === 'string' ? document.createTextNode(c) : c,
+      );
+    });
+    return parent;
+  }
+
+  /**
+   * Create an element with a className, attribute/event map, and children.
+   * `attrs` keys starting with "on" (e.g. onClick) are wired as
+   * addEventListener(type, handler); everything else is setAttribute.
+   */
+  function _el(tag, className, attrs, children) {
+    var e = document.createElement(tag);
+    if (className) e.className = className;
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        var v = attrs[k];
+        if (v === undefined || v === null) return;
+        if (/^on[A-Z]/.test(k) && typeof v === 'function') {
+          e.addEventListener(k.slice(2).toLowerCase(), v);
+        } else if (k === 'text') {
+          e.textContent = v;
+        } else if (typeof v === 'boolean') {
+          if (v) e.setAttribute(k, '');
+        } else {
+          e.setAttribute(k, v);
+        }
+      });
+    }
+    if (children !== undefined) _append(e, children);
+    return e;
+  }
+
+  // Tailwind utility fragments shared across components — kept here once so
+  // every component's focus ring / disabled state / transition looks the same.
+  var _FOCUS_RING =
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500';
+  var _TRANSITION = 'transition-colors duration-150';
+
+  var _VARIANT_CLASSES = {
+    primary: 'bg-sky-600 text-white hover:bg-sky-700',
+    secondary:
+      'bg-gray-100 text-gray-900 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600',
+    ghost:
+      'bg-transparent text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800',
+    danger: 'bg-red-600 text-white hover:bg-red-700',
+  };
+  var _SIZE_CLASSES = {
+    sm: 'text-xs px-2.5 py-1.5 gap-1.5',
+    md: 'text-sm px-3.5 py-2 gap-2',
+    lg: 'text-base px-5 py-2.5 gap-2.5',
+  };
+  var _BADGE_COLOR_CLASSES = {
+    blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+    green:
+      'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    red: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+    gray: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
+    yellow:
+      'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  };
+  var _ALERT_VARIANT_CLASSES = {
+    info: 'bg-sky-50 text-sky-800 border-sky-200 dark:bg-sky-900/30 dark:text-sky-200 dark:border-sky-800',
+    success:
+      'bg-green-50 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-200 dark:border-green-800',
+    warning:
+      'bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-200 dark:border-yellow-800',
+    error:
+      'bg-red-50 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-200 dark:border-red-800',
+  };
+
+  /** A simple inline SVG spinner used by button() loading states. */
+  function _spinnerSvg() {
+    var span = _el(
+      'span',
+      'inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent',
+      { 'aria-hidden': 'true' },
+    );
+    return span;
+  }
+
+  /**
+   * Trap Tab/Shift+Tab focus within `container` and close on Escape. Returns a
+   * cleanup function that removes the listener — callers MUST call it when the
+   * container is dismissed/removed to avoid leaking a document-level listener.
+   */
+  function _trapFocus(container, onEscape) {
+    var previouslyFocused = document.activeElement;
+    function focusables() {
+      return Array.prototype.slice
+        .call(
+          container.querySelectorAll(
+            'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])',
+          ),
+        )
+        .filter(function (el) {
+          return !el.disabled && !el.hidden;
+        });
+    }
+    function onKeydown(e) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        if (onEscape) onEscape();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      var items = focusables();
+      if (items.length === 0) return;
+      var first = items[0];
+      var last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+    document.addEventListener('keydown', onKeydown, true);
+    var initial = focusables()[0];
+    if (initial) initial.focus();
+    return function cleanup() {
+      document.removeEventListener('keydown', onKeydown, true);
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+    };
+  }
+
+  /** Lazily create (once) and return the fixed toast-stack container. */
+  var _toastContainer = null;
+  function _getToastContainer() {
+    if (_toastContainer && document.body.contains(_toastContainer)) {
+      return _toastContainer;
+    }
+    _toastContainer = _el(
+      'div',
+      'fixed top-4 right-4 z-50 flex flex-col gap-2 w-80',
+      { role: 'region', 'aria-label': 'Notifications' },
+    );
+    document.body.appendChild(_toastContainer);
+    return _toastContainer;
+  }
+
   const sdk = {
     /** Register a callback to run once the SDK is initialized with a token */
     ready: function (cb) {
@@ -233,6 +399,1273 @@
         }).then(function (r) {
           return r.rows;
         });
+      },
+    },
+
+    // ── UI (Tailwind-styled component library) ─────────────────────────────
+    // Pure client-side DOM builders — no server round-trip, no permission
+    // required. Every component returns a real HTMLElement so it can be
+    // manipulated after creation. See GET /sdk/components.json for a
+    // machine-readable manifest of this namespace.
+    ui: {
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A styled card container with a title and optional subtitle.
+       * @param {string} title - The card title
+       * @param {string} [subtitle] - Optional subtitle text
+       * @param {HTMLElement|string} [children] - Content to render inside the card
+       * @param {string} [class] - Extra Tailwind classes to merge onto the container
+       * @returns {HTMLElement}
+       */
+      card: function (opts) {
+        opts = opts || {};
+        var root = _el(
+          'div',
+          _cx(
+            'rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800',
+            opts['class'],
+          ),
+        );
+        if (opts.title) {
+          _append(
+            root,
+            _el(
+              'h3',
+              'text-base font-semibold text-gray-900 dark:text-gray-100',
+              {
+                text: opts.title,
+              },
+            ),
+          );
+        }
+        if (opts.subtitle) {
+          _append(
+            root,
+            _el('p', 'mt-1 text-sm text-gray-500 dark:text-gray-400', {
+              text: opts.subtitle,
+            }),
+          );
+        }
+        if (opts.children !== undefined) {
+          var body = _el('div', (opts.title || opts.subtitle) && 'mt-4');
+          _append(body, opts.children);
+          _append(root, body);
+        }
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A tabbed panel with keyboard navigation (Left/Right arrow keys).
+       * @param {Array} tabs - Array of { id, label, content: HTMLElement|string }
+       * @param {string} [activeTab] - id of the initially active tab (defaults to the first)
+       * @param {string} [class] - Extra Tailwind classes to merge onto the container
+       * @returns {HTMLElement}
+       */
+      tabs: function (opts) {
+        opts = opts || {};
+        var items = opts.tabs || [];
+        var groupId = _nextId('tabs');
+        var active = opts.activeTab || (items[0] && items[0].id);
+
+        var root = _el('div', _cx('w-full', opts['class']));
+        var tablist = _el(
+          'div',
+          'flex gap-1 border-b border-gray-200 dark:border-gray-700',
+          {
+            role: 'tablist',
+          },
+        );
+        var panelHost = _el('div', 'py-4');
+
+        var buttons = {};
+        function renderPanel() {
+          panelHost.innerHTML = '';
+          var current = items.filter(function (t) {
+            return t.id === active;
+          })[0];
+          if (current) _append(panelHost, current.content);
+        }
+        function activate(id) {
+          active = id;
+          items.forEach(function (t) {
+            var btn = buttons[t.id];
+            var selected = t.id === id;
+            btn.setAttribute('aria-selected', String(selected));
+            btn.tabIndex = selected ? 0 : -1;
+            btn.className = _cx(
+              'px-3 py-2 text-sm font-medium border-b-2 -mb-px',
+              _TRANSITION,
+              selected
+                ? 'border-sky-600 text-sky-600 dark:text-sky-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+            );
+          });
+          renderPanel();
+        }
+
+        items.forEach(function (t, index) {
+          var btn = _el(
+            'button',
+            '',
+            {
+              type: 'button',
+              role: 'tab',
+              id: groupId + '-tab-' + t.id,
+              'aria-controls': groupId + '-panel-' + t.id,
+              onClick: function () {
+                activate(t.id);
+                btn.focus();
+              },
+              onKeydown: function (e) {
+                if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+                e.preventDefault();
+                var dir = e.key === 'ArrowRight' ? 1 : -1;
+                var nextIndex = (index + dir + items.length) % items.length;
+                var nextTab = items[nextIndex];
+                activate(nextTab.id);
+                buttons[nextTab.id].focus();
+              },
+            },
+            t.label,
+          );
+          buttons[t.id] = btn;
+          _append(tablist, btn);
+        });
+
+        activate(active);
+        _append(root, [tablist, panelHost]);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A vertically-stacked accordion of expandable items.
+       * @param {Array} items - Array of { title, content: HTMLElement|string }
+       * @param {boolean} [multiple] - Allow more than one item open at once (default false)
+       * @param {string} [class] - Extra Tailwind classes to merge onto the container
+       * @returns {HTMLElement}
+       */
+      accordion: function (opts) {
+        opts = opts || {};
+        var items = opts.items || [];
+        var multiple = !!opts.multiple;
+        var root = _el(
+          'div',
+          _cx(
+            'divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-700 dark:border-gray-700',
+            opts['class'],
+          ),
+        );
+        var panels = [];
+
+        items.forEach(function (item, index) {
+          var panelId = _nextId('accordion-panel');
+          var panel = _el(
+            'div',
+            'hidden px-4 pb-4 text-sm text-gray-600 dark:text-gray-300',
+            { id: panelId, role: 'region' },
+          );
+          _append(panel, item.content);
+          panels.push(panel);
+
+          var chevron = _el('span', 'transition-transform duration-150', {
+            'aria-hidden': 'true',
+            text: '›',
+          });
+          var btn = _el(
+            'button',
+            'flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-800/60',
+            {
+              type: 'button',
+              'aria-expanded': 'false',
+              'aria-controls': panelId,
+              onClick: function () {
+                var willOpen = panel.classList.contains('hidden');
+                if (willOpen && !multiple) {
+                  panels.forEach(function (p, i) {
+                    if (i === index) return;
+                    p.classList.add('hidden');
+                    if (p.previousSibling) {
+                      p.previousSibling.setAttribute('aria-expanded', 'false');
+                    }
+                  });
+                }
+                panel.classList.toggle('hidden', !willOpen);
+                btn.setAttribute('aria-expanded', String(willOpen));
+                chevron.style.transform = willOpen ? 'rotate(90deg)' : '';
+              },
+            },
+            [item.title, chevron],
+          );
+          _append(root, [btn, panel]);
+        });
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A thin horizontal or vertical divider line.
+       * @param {string} [orientation] - "horizontal" (default) or "vertical"
+       * @param {string} [class] - Extra Tailwind classes to merge onto the element
+       * @returns {HTMLElement}
+       */
+      separator: function (opts) {
+        opts = opts || {};
+        var vertical = opts.orientation === 'vertical';
+        return _el(
+          'div',
+          _cx(
+            'border-gray-200 dark:border-gray-700',
+            vertical ? 'inline-block h-full w-px border-l' : 'w-full border-t',
+            opts['class'],
+          ),
+          {
+            role: 'separator',
+            'aria-orientation': vertical ? 'vertical' : 'horizontal',
+          },
+        );
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A clickable button with variants, sizes, an optional icon, and loading/disabled states.
+       * @param {string} text - Button label
+       * @param {string} [variant] - "primary" (default), "secondary", "ghost", or "danger"
+       * @param {string} [size] - "sm", "md" (default), or "lg"
+       * @param {HTMLElement|string} [icon] - Icon rendered before the label
+       * @param {Function} [onClick] - Click handler
+       * @param {boolean} [disabled] - Disable the button
+       * @param {boolean} [loading] - Show a spinner and disable the button
+       * @param {string} [class] - Extra Tailwind classes to merge onto the button
+       * @returns {HTMLElement}
+       */
+      button: function (opts) {
+        opts = opts || {};
+        var variant = _VARIANT_CLASSES[opts.variant] ? opts.variant : 'primary';
+        var size = _SIZE_CLASSES[opts.size] ? opts.size : 'md';
+        var isDisabled = !!opts.disabled || !!opts.loading;
+        var btn = _el(
+          'button',
+          _cx(
+            'inline-flex items-center justify-center rounded-lg font-medium',
+            _TRANSITION,
+            _FOCUS_RING,
+            _VARIANT_CLASSES[variant],
+            _SIZE_CLASSES[size],
+            isDisabled && 'opacity-50 cursor-not-allowed',
+            opts['class'],
+          ),
+          {
+            type: 'button',
+            disabled: isDisabled,
+            onClick: isDisabled
+              ? undefined
+              : function (e) {
+                  if (opts.onClick) opts.onClick(e);
+                },
+          },
+        );
+        if (opts.loading) _append(btn, _spinnerSvg());
+        else if (opts.icon !== undefined) _append(btn, opts.icon);
+        _append(btn, _el('span', '', { text: opts.text }));
+        return btn;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A visually grouped set of buttons with shared borders.
+       * @param {Array} buttons - Array of { text, variant, onClick }
+       * @param {string} [orientation] - "horizontal" (default) or "vertical"
+       * @param {string} [class] - Extra Tailwind classes to merge onto the container
+       * @returns {HTMLElement}
+       */
+      buttonGroup: function (opts) {
+        opts = opts || {};
+        var items = opts.buttons || [];
+        var vertical = opts.orientation === 'vertical';
+        var root = _el(
+          'div',
+          _cx('inline-flex', vertical ? 'flex-col' : 'flex-row', opts['class']),
+        );
+        items.forEach(function (b, i) {
+          var el = sdk.ui.button({
+            text: b.text,
+            variant: b.variant,
+            onClick: b.onClick,
+            disabled: b.disabled,
+            class: _cx(
+              vertical ? 'rounded-none w-full' : 'rounded-none',
+              i === 0 && (vertical ? 'rounded-t-lg' : 'rounded-l-lg'),
+              i === items.length - 1 &&
+                (vertical ? 'rounded-b-lg' : 'rounded-r-lg'),
+              i > 0 && (vertical ? '-mt-px' : '-ml-px'),
+            ),
+          });
+          _append(root, el);
+        });
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A trigger button that opens a menu of clickable items; closes on outside click, item selection, or Escape.
+       * @param {HTMLElement|string} trigger - The element or label that opens the menu
+       * @param {Array} items - Array of { label, onClick, icon: HTMLElement|string }
+       * @returns {HTMLElement}
+       */
+      dropdownMenu: function (opts) {
+        opts = opts || {};
+        var items = opts.items || [];
+        var root = _el('div', 'relative inline-block');
+        var triggerBtn =
+          typeof opts.trigger === 'string'
+            ? sdk.ui.button({ text: opts.trigger })
+            : opts.trigger;
+        triggerBtn.setAttribute('aria-haspopup', 'menu');
+        triggerBtn.setAttribute('aria-expanded', 'false');
+
+        var menu = _el(
+          'div',
+          'absolute left-0 z-10 mt-1 hidden min-w-[10rem] rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800',
+          { role: 'menu' },
+        );
+
+        function close() {
+          menu.classList.add('hidden');
+          triggerBtn.setAttribute('aria-expanded', 'false');
+          document.removeEventListener('click', onDocClick, true);
+          document.removeEventListener('keydown', onKeydown, true);
+        }
+        function open() {
+          menu.classList.remove('hidden');
+          triggerBtn.setAttribute('aria-expanded', 'true');
+          document.addEventListener('click', onDocClick, true);
+          document.addEventListener('keydown', onKeydown, true);
+        }
+        function onDocClick(e) {
+          if (!root.contains(e.target)) close();
+        }
+        function onKeydown(e) {
+          if (e.key === 'Escape') {
+            close();
+            triggerBtn.focus();
+          }
+        }
+        triggerBtn.addEventListener('click', function () {
+          if (menu.classList.contains('hidden')) open();
+          else close();
+        });
+
+        items.forEach(function (item) {
+          var itemEl = _el(
+            'button',
+            'flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700',
+            {
+              type: 'button',
+              role: 'menuitem',
+              onClick: function (e) {
+                close();
+                if (item.onClick) item.onClick(e);
+              },
+            },
+            [item.icon, item.label],
+          );
+          _append(menu, itemEl);
+        });
+
+        _append(root, [triggerBtn, menu]);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A data table with an empty state and optional row-click handling.
+       * @param {Array} columns - Array of { key, label }
+       * @param {Array} rows - Array of row objects keyed by column key
+       * @param {Function} [onRowClick] - Called with the row object when a row is clicked
+       * @param {string} [class] - Extra Tailwind classes to merge onto the table
+       * @returns {HTMLElement}
+       */
+      table: function (opts) {
+        opts = opts || {};
+        var columns = opts.columns || [];
+        var rows = opts.rows || [];
+        var table = _el(
+          'table',
+          _cx('w-full text-left text-sm', opts['class']),
+        );
+        var thead = _el(
+          'thead',
+          'border-b border-gray-200 dark:border-gray-700',
+        );
+        var headRow = _el('tr');
+        columns.forEach(function (c) {
+          _append(
+            headRow,
+            _el(
+              'th',
+              'px-3 py-2 font-medium text-gray-500 dark:text-gray-400',
+              { scope: 'col', text: c.label },
+            ),
+          );
+        });
+        _append(thead, headRow);
+
+        var tbody = _el(
+          'tbody',
+          'divide-y divide-gray-100 dark:divide-gray-800',
+        );
+        if (rows.length === 0) {
+          var emptyRow = _el('tr');
+          _append(
+            emptyRow,
+            _el(
+              'td',
+              'px-3 py-6 text-center text-gray-400 dark:text-gray-500',
+              { colspan: String(columns.length || 1), text: 'No data' },
+            ),
+          );
+          _append(tbody, emptyRow);
+        } else {
+          rows.forEach(function (row) {
+            var tr = _el(
+              'tr',
+              _cx(
+                'text-gray-700 dark:text-gray-200',
+                opts.onRowClick &&
+                  'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60',
+              ),
+              opts.onRowClick && {
+                onClick: function () {
+                  opts.onRowClick(row);
+                },
+              },
+            );
+            columns.forEach(function (c) {
+              _append(tr, _el('td', 'px-3 py-2', { text: row[c.key] }));
+            });
+            _append(tbody, tr);
+          });
+        }
+        _append(table, [thead, tbody]);
+        return table;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A small colored label for status/tags.
+       * @param {string} text - Badge text
+       * @param {string} [color] - "blue" (default), "green", "red", "gray", or "yellow"
+       * @returns {HTMLElement}
+       */
+      badge: function (opts) {
+        opts = opts || {};
+        var color = _BADGE_COLOR_CLASSES[opts.color] ? opts.color : 'blue';
+        return _el(
+          'span',
+          _cx(
+            'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+            _BADGE_COLOR_CLASSES[color],
+          ),
+          { text: opts.text },
+        );
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A circular avatar image with a text fallback when no image loads.
+       * @param {string} [src] - Image URL
+       * @param {string} [alt] - Alt text for the image
+       * @param {string} [fallback] - Fallback text (e.g. initials) shown when there is no image
+       * @param {string} [size] - "sm", "md" (default), or "lg"
+       * @returns {HTMLElement}
+       */
+      avatar: function (opts) {
+        opts = opts || {};
+        var sizeClasses = {
+          sm: 'h-6 w-6 text-xs',
+          md: 'h-10 w-10 text-sm',
+          lg: 'h-14 w-14 text-lg',
+        };
+        var size = sizeClasses[opts.size] ? opts.size : 'md';
+        var root = _el(
+          'span',
+          _cx(
+            'inline-flex items-center justify-center overflow-hidden rounded-full bg-gray-200 font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+            sizeClasses[size],
+          ),
+        );
+        if (opts.src) {
+          var img = _el('img', 'h-full w-full object-cover', {
+            src: opts.src,
+            alt: opts.alt || '',
+            onError: function () {
+              img.remove();
+              _append(
+                root,
+                _el('span', '', { text: (opts.fallback || '?').slice(0, 2) }),
+              );
+            },
+          });
+          _append(root, img);
+        } else {
+          _append(
+            root,
+            _el('span', '', { text: (opts.fallback || '?').slice(0, 2) }),
+          );
+        }
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A pulsing placeholder shown while content is loading.
+       * @param {string} [width] - CSS width (default "100%")
+       * @param {string} [height] - CSS height (default "1rem")
+       * @param {string} [variant] - "text" (default, rounded bar), "circle", or "rect"
+       * @returns {HTMLElement}
+       */
+      skeleton: function (opts) {
+        opts = opts || {};
+        var variant = opts.variant || 'text';
+        var shape =
+          variant === 'circle'
+            ? 'rounded-full'
+            : variant === 'rect'
+              ? 'rounded-md'
+              : 'rounded';
+        var el = _el(
+          'div',
+          _cx('animate-pulse bg-gray-200 dark:bg-gray-700', shape),
+          { 'aria-hidden': 'true' },
+        );
+        el.style.width = opts.width || '100%';
+        el.style.height =
+          opts.height || (variant === 'text' ? '1rem' : '2.5rem');
+        return el;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A breadcrumb trail of navigation items.
+       * @param {Array} items - Array of { label, href, onClick }
+       * @returns {HTMLElement}
+       */
+      breadcrumb: function (opts) {
+        opts = opts || {};
+        var items = opts.items || [];
+        var nav = _el('nav', '', { 'aria-label': 'Breadcrumb' });
+        var ol = _el('ol', 'flex items-center gap-1.5 text-sm');
+        items.forEach(function (item, index) {
+          var isLast = index === items.length - 1;
+          var li = _el('li', 'flex items-center gap-1.5');
+          var content;
+          if (isLast) {
+            content = _el(
+              'span',
+              'font-medium text-gray-900 dark:text-gray-100',
+              { text: item.label, 'aria-current': 'page' },
+            );
+          } else if (item.href) {
+            content = _el(
+              'a',
+              'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+              { href: item.href, text: item.label },
+            );
+          } else {
+            content = _el(
+              'button',
+              'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+              { type: 'button', text: item.label, onClick: item.onClick },
+            );
+          }
+          _append(li, content);
+          if (!isLast) {
+            _append(
+              li,
+              _el('span', 'text-gray-400 dark:text-gray-600', {
+                'aria-hidden': 'true',
+                text: '/',
+              }),
+            );
+          }
+          _append(ol, li);
+        });
+        _append(nav, ol);
+        return nav;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description Shows a transient stacked notification in the top-right corner; auto-dismisses after `duration`.
+       * @param {string} message - Toast message
+       * @param {string} [type] - "info" (default), "success", "error", or "warning"
+       * @param {number} [duration] - Auto-dismiss delay in ms (default 4000; pass 0 to disable)
+       * @returns {HTMLElement}
+       */
+      toast: function (opts) {
+        opts = opts || {};
+        var type = _ALERT_VARIANT_CLASSES[opts.type] ? opts.type : 'info';
+        var duration = opts.duration === undefined ? 4000 : opts.duration;
+        var container = _getToastContainer();
+
+        var timeoutId;
+        var el = _el(
+          'div',
+          _cx(
+            'flex items-start justify-between gap-3 rounded-lg border px-4 py-3 text-sm shadow-md',
+            _ALERT_VARIANT_CLASSES[type],
+          ),
+          { role: 'status', 'aria-live': 'polite' },
+        );
+        function dismiss() {
+          if (timeoutId) clearTimeout(timeoutId);
+          if (el.parentNode) el.parentNode.removeChild(el);
+        }
+        _append(el, [
+          _el('span', '', { text: opts.message }),
+          _el(
+            'button',
+            'shrink-0 rounded text-current opacity-60 hover:opacity-100',
+            {
+              type: 'button',
+              'aria-label': 'Dismiss',
+              onClick: dismiss,
+              text: '×',
+            },
+          ),
+        ]);
+        _append(container, el);
+        if (duration > 0) timeoutId = setTimeout(dismiss, duration);
+        return el;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description An inline banner for important messages, with an optional dismiss button.
+       * @param {string} message - Alert message
+       * @param {string} [variant] - "info" (default), "success", "warning", or "error"
+       * @param {string} [title] - Optional bold title shown above the message
+       * @param {boolean} [dismissible] - Show a close button that removes the alert
+       * @returns {HTMLElement}
+       */
+      alert: function (opts) {
+        opts = opts || {};
+        var variant = _ALERT_VARIANT_CLASSES[opts.variant]
+          ? opts.variant
+          : 'info';
+        var root = _el(
+          'div',
+          _cx(
+            'flex items-start justify-between gap-3 rounded-lg border px-4 py-3 text-sm',
+            _ALERT_VARIANT_CLASSES[variant],
+          ),
+          { role: variant === 'error' ? 'alert' : 'status' },
+        );
+        var textWrap = _el('div', '');
+        if (opts.title) {
+          _append(textWrap, _el('p', 'font-semibold', { text: opts.title }));
+        }
+        _append(
+          textWrap,
+          _el('p', opts.title ? 'mt-0.5' : '', { text: opts.message }),
+        );
+        _append(root, textWrap);
+        if (opts.dismissible) {
+          _append(
+            root,
+            _el(
+              'button',
+              'shrink-0 rounded text-current opacity-60 hover:opacity-100',
+              {
+                type: 'button',
+                'aria-label': 'Dismiss',
+                onClick: function () {
+                  root.remove();
+                },
+                text: '×',
+              },
+            ),
+          );
+        }
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A focus-trapped modal dialog with a backdrop; closes on Escape, backdrop click, or Cancel/close.
+       * @param {string} title - Dialog title
+       * @param {HTMLElement|string} content - Dialog body content
+       * @param {Array} [buttons] - Array of { text, variant, onClick } rendered in the footer
+       * @param {Function} [onClose] - Called when the dialog is dismissed (any method)
+       * @returns {HTMLElement}
+       */
+      dialog: function (opts) {
+        opts = opts || {};
+        var titleId = _nextId('dialog-title');
+        var backdrop = _el(
+          'div',
+          'fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4',
+        );
+        var panel = _el(
+          'div',
+          'w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-800',
+          { role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': titleId },
+        );
+
+        var cleanupFocus;
+        function close() {
+          if (cleanupFocus) cleanupFocus();
+          if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop);
+          if (opts.onClose) opts.onClose();
+        }
+
+        _append(
+          panel,
+          _el('h2', 'text-lg font-semibold text-gray-900 dark:text-gray-100', {
+            id: titleId,
+            text: opts.title,
+          }),
+        );
+        var body = _el('div', 'mt-3 text-sm text-gray-600 dark:text-gray-300');
+        _append(body, opts.content);
+        _append(panel, body);
+
+        if (opts.buttons && opts.buttons.length > 0) {
+          var footer = _el('div', 'mt-6 flex justify-end gap-2');
+          opts.buttons.forEach(function (b) {
+            _append(
+              footer,
+              sdk.ui.button({
+                text: b.text,
+                variant: b.variant,
+                onClick: function (e) {
+                  if (b.onClick) b.onClick(e);
+                  close();
+                },
+              }),
+            );
+          });
+          _append(panel, footer);
+        }
+
+        backdrop.addEventListener('click', function (e) {
+          if (e.target === backdrop) close();
+        });
+        _append(backdrop, panel);
+        document.body.appendChild(backdrop);
+        cleanupFocus = _trapFocus(panel, close);
+        return backdrop;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description Wraps `children` with a hover/focus-triggered tooltip bubble.
+       * @param {string} content - Tooltip text
+       * @param {HTMLElement} children - The element the tooltip is attached to
+       * @param {string} [position] - "top" (default), "bottom", "left", or "right"
+       * @returns {HTMLElement}
+       */
+      tooltip: function (opts) {
+        opts = opts || {};
+        var position = opts.position || 'top';
+        var posClasses = {
+          top: 'bottom-full left-1/2 -translate-x-1/2 mb-1.5',
+          bottom: 'top-full left-1/2 -translate-x-1/2 mt-1.5',
+          left: 'right-full top-1/2 -translate-y-1/2 mr-1.5',
+          right: 'left-full top-1/2 -translate-y-1/2 ml-1.5',
+        };
+        var tipId = _nextId('tooltip');
+        var wrapper = _el('span', 'relative inline-block');
+        var bubble = _el(
+          'span',
+          _cx(
+            'pointer-events-none absolute z-20 hidden whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs text-white dark:bg-gray-700',
+            posClasses[position] || posClasses.top,
+          ),
+          { id: tipId, role: 'tooltip', text: opts.content },
+        );
+        function show() {
+          bubble.classList.remove('hidden');
+        }
+        function hide() {
+          bubble.classList.add('hidden');
+        }
+        opts.children.addEventListener('mouseenter', show);
+        opts.children.addEventListener('mouseleave', hide);
+        opts.children.addEventListener('focus', show);
+        opts.children.addEventListener('blur', hide);
+        opts.children.setAttribute('aria-describedby', tipId);
+        _append(wrapper, [opts.children, bubble]);
+        return wrapper;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A labeled text input.
+       * @param {string} [label] - Label text shown above the input
+       * @param {string} [placeholder] - Placeholder text
+       * @param {string} [type] - HTML input type (default "text")
+       * @param {string} [value] - Initial value
+       * @param {Function} [onChange] - Called with the new string value on every input event
+       * @param {boolean} [disabled] - Disable the input
+       * @returns {HTMLElement}
+       */
+      input: function (opts) {
+        opts = opts || {};
+        var id = _nextId('input');
+        var root = _el('div', '');
+        if (opts.label) {
+          _append(
+            root,
+            _el(
+              'label',
+              'mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300',
+              {
+                for: id,
+                text: opts.label,
+              },
+            ),
+          );
+        }
+        _append(
+          root,
+          _el(
+            'input',
+            _cx(
+              'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100',
+              _FOCUS_RING,
+              opts.disabled &&
+                'opacity-50 cursor-not-allowed bg-gray-100 dark:bg-gray-800',
+            ),
+            {
+              id: id,
+              type: opts.type || 'text',
+              placeholder: opts.placeholder,
+              value: opts.value,
+              disabled: !!opts.disabled,
+              onInput: function (e) {
+                if (opts.onChange) opts.onChange(e.target.value);
+              },
+            },
+          ),
+        );
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A labeled multi-line text input.
+       * @param {string} [label] - Label text shown above the textarea
+       * @param {string} [placeholder] - Placeholder text
+       * @param {string} [value] - Initial value
+       * @param {number} [rows] - Number of visible rows (default 3)
+       * @param {Function} [onChange] - Called with the new string value on every input event
+       * @param {boolean} [disabled] - Disable the textarea
+       * @returns {HTMLElement}
+       */
+      textarea: function (opts) {
+        opts = opts || {};
+        var id = _nextId('textarea');
+        var root = _el('div', '');
+        if (opts.label) {
+          _append(
+            root,
+            _el(
+              'label',
+              'mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300',
+              {
+                for: id,
+                text: opts.label,
+              },
+            ),
+          );
+        }
+        var ta = _el(
+          'textarea',
+          _cx(
+            'w-full resize-y rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100',
+            _FOCUS_RING,
+            opts.disabled &&
+              'opacity-50 cursor-not-allowed bg-gray-100 dark:bg-gray-800',
+          ),
+          {
+            id: id,
+            rows: String(opts.rows || 3),
+            placeholder: opts.placeholder,
+            disabled: !!opts.disabled,
+            onInput: function (e) {
+              if (opts.onChange) opts.onChange(e.target.value);
+            },
+          },
+        );
+        if (opts.value) ta.value = opts.value;
+        _append(root, ta);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A labeled dropdown select.
+       * @param {string} [label] - Label text shown above the select
+       * @param {Array} options - Array of { value, label }
+       * @param {string} [value] - Initially selected value
+       * @param {Function} [onChange] - Called with the new string value on change
+       * @param {boolean} [disabled] - Disable the select
+       * @returns {HTMLElement}
+       */
+      select: function (opts) {
+        opts = opts || {};
+        var id = _nextId('select');
+        var root = _el('div', '');
+        if (opts.label) {
+          _append(
+            root,
+            _el(
+              'label',
+              'mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300',
+              {
+                for: id,
+                text: opts.label,
+              },
+            ),
+          );
+        }
+        var select = _el(
+          'select',
+          _cx(
+            'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100',
+            _FOCUS_RING,
+            opts.disabled &&
+              'opacity-50 cursor-not-allowed bg-gray-100 dark:bg-gray-800',
+          ),
+          {
+            id: id,
+            disabled: !!opts.disabled,
+            onChange: function (e) {
+              if (opts.onChange) opts.onChange(e.target.value);
+            },
+          },
+        );
+        (opts.options || []).forEach(function (o) {
+          var optionEl = _el('option', '', { value: o.value, text: o.label });
+          if (o.value === opts.value) optionEl.selected = true;
+          _append(select, optionEl);
+        });
+        _append(root, select);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description An accessible toggle switch (role="switch").
+       * @param {boolean} [checked] - Initial checked state
+       * @param {Function} [onChange] - Called with the new boolean state on toggle
+       * @param {string} [label] - Optional label text shown beside the switch
+       * @param {boolean} [disabled] - Disable the switch
+       * @returns {HTMLElement}
+       */
+      switch: function (opts) {
+        opts = opts || {};
+        var checked = !!opts.checked;
+        var track = _el(
+          'button',
+          _cx(
+            'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full',
+            _TRANSITION,
+            _FOCUS_RING,
+            checked ? 'bg-sky-600' : 'bg-gray-300 dark:bg-gray-600',
+            opts.disabled && 'opacity-50 cursor-not-allowed',
+          ),
+          {
+            type: 'button',
+            role: 'switch',
+            'aria-checked': String(checked),
+            disabled: !!opts.disabled,
+          },
+        );
+        var thumb = _el(
+          'span',
+          _cx(
+            'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+            checked ? 'translate-x-6' : 'translate-x-1',
+          ),
+        );
+        _append(track, thumb);
+        track.addEventListener('click', function () {
+          checked = !checked;
+          track.setAttribute('aria-checked', String(checked));
+          track.className = _cx(
+            'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full',
+            _TRANSITION,
+            _FOCUS_RING,
+            checked ? 'bg-sky-600' : 'bg-gray-300 dark:bg-gray-600',
+            opts.disabled && 'opacity-50 cursor-not-allowed',
+          );
+          thumb.className = _cx(
+            'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+            checked ? 'translate-x-6' : 'translate-x-1',
+          );
+          if (opts.onChange) opts.onChange(checked);
+        });
+        if (!opts.label) return track;
+        var root = _el('label', 'inline-flex items-center gap-2');
+        _append(root, [
+          track,
+          _el('span', 'text-sm text-gray-700 dark:text-gray-300', {
+            text: opts.label,
+          }),
+        ]);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A native checkbox with a label.
+       * @param {boolean} [checked] - Initial checked state
+       * @param {Function} [onChange] - Called with the new boolean state on change
+       * @param {string} [label] - Label text shown beside the checkbox
+       * @param {boolean} [disabled] - Disable the checkbox
+       * @returns {HTMLElement}
+       */
+      checkbox: function (opts) {
+        opts = opts || {};
+        var id = _nextId('checkbox');
+        var input = _el(
+          'input',
+          _cx('h-4 w-4 rounded border-gray-300 accent-sky-600', _FOCUS_RING),
+          {
+            id: id,
+            type: 'checkbox',
+            checked: !!opts.checked,
+            disabled: !!opts.disabled,
+            onChange: function (e) {
+              if (opts.onChange) opts.onChange(e.target.checked);
+            },
+          },
+        );
+        var root = _el(
+          'label',
+          'inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300',
+          {
+            for: id,
+          },
+        );
+        _append(root, [input, opts.label]);
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A group of mutually-exclusive radio buttons.
+       * @param {string} name - Shared name attribute for the radio group
+       * @param {Array} options - Array of { value, label }
+       * @param {string} [value] - Initially selected value
+       * @param {Function} [onChange] - Called with the new string value on change
+       * @param {boolean} [disabled] - Disable every radio in the group
+       * @returns {HTMLElement}
+       */
+      radioGroup: function (opts) {
+        opts = opts || {};
+        var root = _el('div', 'flex flex-col gap-2', { role: 'radiogroup' });
+        (opts.options || []).forEach(function (o) {
+          var id = _nextId('radio');
+          var input = _el(
+            'input',
+            _cx('h-4 w-4 border-gray-300 accent-sky-600', _FOCUS_RING),
+            {
+              id: id,
+              type: 'radio',
+              name: opts.name,
+              value: o.value,
+              checked: o.value === opts.value,
+              disabled: !!opts.disabled,
+              onChange: function (e) {
+                if (e.target.checked && opts.onChange) opts.onChange(o.value);
+              },
+            },
+          );
+          var label = _el(
+            'label',
+            'inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300',
+            {
+              for: id,
+            },
+          );
+          _append(label, [input, o.label]);
+          _append(root, label);
+        });
+        return root;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A form label, with an optional required-field asterisk.
+       * @param {string} text - Label text
+       * @param {string} [for] - id of the associated form control
+       * @param {boolean} [required] - Show a red asterisk after the text
+       * @returns {HTMLElement}
+       */
+      label: function (opts) {
+        opts = opts || {};
+        var el = _el(
+          'label',
+          'block text-sm font-medium text-gray-700 dark:text-gray-300',
+          {
+            for: opts['for'],
+          },
+        );
+        _append(el, opts.text);
+        if (opts.required) {
+          _append(el, _el('span', 'ml-0.5 text-red-500', { text: '*' }));
+        }
+        return el;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description A focus-trapped panel that slides in from a screen edge; closes on Escape, backdrop click, or close button.
+       * @param {string} title - Sheet title
+       * @param {HTMLElement|string} children - Sheet body content
+       * @param {Function} [onClose] - Called when the sheet is dismissed
+       * @param {string} [side] - "right" (default) or "left"
+       * @param {boolean} [open] - Whether to render the sheet already open (default true)
+       * @returns {HTMLElement}
+       */
+      sheet: function (opts) {
+        opts = opts || {};
+        var side = opts.side === 'left' ? 'left' : 'right';
+        var initiallyOpen = opts.open !== false;
+        var titleId = _nextId('sheet-title');
+
+        var backdrop = _el('div', 'fixed inset-0 z-50 bg-black/50');
+        var panel = _el(
+          'div',
+          _cx(
+            'fixed inset-y-0 z-50 flex w-full max-w-sm flex-col bg-white p-6 shadow-2xl transition-transform duration-200 dark:bg-gray-800',
+            side === 'right' ? 'right-0' : 'left-0',
+            initiallyOpen
+              ? 'translate-x-0'
+              : side === 'right'
+                ? 'translate-x-full'
+                : '-translate-x-full',
+          ),
+          { role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': titleId },
+        );
+
+        var cleanupFocus;
+        function close() {
+          if (cleanupFocus) cleanupFocus();
+          if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop);
+          if (panel.parentNode) panel.parentNode.removeChild(panel);
+          if (opts.onClose) opts.onClose();
+        }
+
+        var header = _el('div', 'mb-4 flex items-center justify-between');
+        _append(header, [
+          _el('h2', 'text-lg font-semibold text-gray-900 dark:text-gray-100', {
+            id: titleId,
+            text: opts.title,
+          }),
+          _el(
+            'button',
+            'rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-200',
+            {
+              type: 'button',
+              'aria-label': 'Close',
+              onClick: close,
+              text: '×',
+            },
+          ),
+        ]);
+        var body = _el(
+          'div',
+          'flex-1 overflow-y-auto text-sm text-gray-600 dark:text-gray-300',
+        );
+        _append(body, opts.children);
+        _append(panel, [header, body]);
+
+        backdrop.addEventListener('click', close);
+        document.body.appendChild(backdrop);
+        document.body.appendChild(panel);
+        if (initiallyOpen) cleanupFocus = _trapFocus(panel, close);
+        return panel;
+      },
+
+      /**
+       * @component
+       * @namespace sdk.ui
+       * @description An anchored popover that opens near its trigger; closes on outside click or Escape.
+       * @param {HTMLElement} trigger - The element that toggles the popover
+       * @param {HTMLElement|string} content - Popover body content
+       * @param {boolean} [open] - Initial open state (default false)
+       * @param {Function} [onOpenChange] - Called with the new boolean open state on toggle
+       * @returns {HTMLElement}
+       */
+      popover: function (opts) {
+        opts = opts || {};
+        var root = _el('div', 'relative inline-block');
+        var panel = _el(
+          'div',
+          _cx(
+            'absolute left-0 z-20 mt-1 min-w-[12rem] rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-800',
+            opts.open ? '' : 'hidden',
+          ),
+        );
+        _append(panel, opts.content);
+
+        function setOpen(next) {
+          panel.classList.toggle('hidden', !next);
+          if (next) {
+            document.addEventListener('click', onDocClick, true);
+            document.addEventListener('keydown', onKeydown, true);
+          } else {
+            document.removeEventListener('click', onDocClick, true);
+            document.removeEventListener('keydown', onKeydown, true);
+          }
+          if (opts.onOpenChange) opts.onOpenChange(next);
+        }
+        function onDocClick(e) {
+          if (!root.contains(e.target)) setOpen(false);
+        }
+        function onKeydown(e) {
+          if (e.key === 'Escape') {
+            setOpen(false);
+            opts.trigger.focus();
+          }
+        }
+        opts.trigger.addEventListener('click', function () {
+          setOpen(panel.classList.contains('hidden'));
+        });
+
+        _append(root, [opts.trigger, panel]);
+        if (opts.open) setOpen(true);
+        return root;
       },
     },
 

--- a/apps/server/src/tools/addons/create.test.ts
+++ b/apps/server/src/tools/addons/create.test.ts
@@ -323,7 +323,7 @@ OpenAidy.ready(function(sdk) {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('writes app/index.html from files param', async () => {
+  it('writes app/index.html from files param (with Tailwind CDN auto-injected)', async () => {
     await tool.execute(VALID_ARGS, {
       agentId: 'agent',
       sessionId: 'test-session',
@@ -331,7 +331,76 @@ OpenAidy.ready(function(sdk) {
     const htmlPath = path.join(addonsDir, 'my-addon', 'app', 'index.html');
     expect(fs.existsSync(htmlPath)).toBe(true);
     const html = fs.readFileSync(htmlPath, 'utf-8');
-    expect(html).toBe(VALID_HTML);
+    // The Tailwind <script> is injected right before the SDK script tag (see
+    // 'auto-injects the Tailwind CDN script tag' below); everything else is
+    // written verbatim.
+    expect(html).toBe(
+      VALID_HTML.replace(
+        '<script src="/sdk/openaidy-sdk.js">',
+        '<script src="https://cdn.tailwindcss.com"></script>\n  <script src="/sdk/openaidy-sdk.js">',
+      ),
+    );
+  });
+
+  it('auto-injects the Tailwind CDN script tag before the SDK script tag', async () => {
+    await tool.execute(VALID_ARGS, {
+      agentId: 'agent',
+      sessionId: 'test-session',
+    });
+    const htmlPath = path.join(addonsDir, 'my-addon', 'app', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    expect(html).toContain('<script src="https://cdn.tailwindcss.com">');
+    expect(html.indexOf('cdn.tailwindcss.com')).toBeLessThan(
+      html.indexOf('/sdk/openaidy-sdk.js'),
+    );
+  });
+
+  it('does not duplicate the Tailwind tag if the agent already included it', async () => {
+    const htmlWithTailwind = VALID_HTML.replace(
+      '<script src="/sdk/openaidy-sdk.js">',
+      '<script src="https://cdn.tailwindcss.com"></script><script src="/sdk/openaidy-sdk.js">',
+    );
+    await tool.execute(
+      {
+        ...VALID_ARGS,
+        files: { ...VALID_ARGS.files, 'app/index.html': htmlWithTailwind },
+      },
+      { agentId: 'agent', sessionId: 'test-session' },
+    );
+    const htmlPath = path.join(addonsDir, 'my-addon', 'app', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    expect(html.match(/cdn\.tailwindcss\.com/g)?.length).toBe(1);
+  });
+
+  it('auto-adds cdn.tailwindcss.com to addon.json externalDomains', async () => {
+    await tool.execute(VALID_ARGS, {
+      agentId: 'agent',
+      sessionId: 'test-session',
+    });
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(addonsDir, 'my-addon', 'addon.json'), 'utf-8'),
+    );
+    expect(manifest.externalDomains).toContain('cdn.tailwindcss.com');
+  });
+
+  it('keeps agent-declared externalDomains alongside the auto-added Tailwind host', async () => {
+    const jsWithFetch = `window.parent.postMessage({ type: 'ADDON_READY' }, '*');
+OpenAidy.ready(function(sdk) {
+  fetch('https://api.example.com/data').then(r => r.json());
+});`;
+    await tool.execute(
+      {
+        ...VALID_ARGS,
+        externalDomains: ['api.example.com'],
+        files: { ...VALID_ARGS.files, 'app/index.js': jsWithFetch },
+      },
+      { agentId: 'agent', sessionId: 'test-session' },
+    );
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(addonsDir, 'my-addon', 'addon.json'), 'utf-8'),
+    );
+    expect(manifest.externalDomains).toContain('api.example.com');
+    expect(manifest.externalDomains).toContain('cdn.tailwindcss.com');
   });
 
   it('writes app/index.js from files param', async () => {
@@ -473,11 +542,22 @@ OpenAidy.ready(function(sdk) {
 // ── sdk-reference integration ──────────────────────────────────────────────────
 
 describe('sdk-reference', () => {
-  it('every SDK_METHOD has a proxyPath starting with /api/addon-proxy/', async () => {
+  it('every non-UI SDK_METHOD has a proxyPath starting with /api/addon-proxy/', async () => {
     const { SDK_METHODS } = await import('../../addons/sdk-reference.js');
     for (const method of SDK_METHODS) {
-      if (method.name === 'request') continue;
+      if (method.name === 'request' || method.category === 'UI') continue;
       expect(method.proxyPath).toMatch(/^\/api\/addon-proxy\//);
+    }
+  });
+
+  it('UI components have no proxyPath/httpMethod — pure client-side, no server round-trip', async () => {
+    const { SDK_METHODS } = await import('../../addons/sdk-reference.js');
+    const uiMethods = SDK_METHODS.filter((m) => m.category === 'UI');
+    expect(uiMethods.length).toBe(25);
+    for (const m of uiMethods) {
+      expect(m.proxyPath).toBeUndefined();
+      expect(m.httpMethod).toBeUndefined();
+      expect(m.requiredPermission).toBeUndefined();
     }
   });
 

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -47,6 +47,32 @@ function isValidId(id: string): boolean {
   return /^[a-z0-9][a-z0-9-]*$/.test(id);
 }
 
+// ── Tailwind CDN auto-injection ────────────────────────────────────────────
+//
+// Every addon gets Tailwind CSS for free — the agent should never have to
+// remember to add it. We inject the plain (unversioned) Play CDN script,
+// which always serves the latest Tailwind v3; a specific release can be
+// pinned later by appending "/<version>" to the URL, once that path format
+// is verified against the currently-shipped version (not done here, since it
+// isn't checkable without network access at authoring time, and a wrong pin
+// would silently 404 every addon's styling).
+const TAILWIND_CDN_URL = 'https://cdn.tailwindcss.com';
+const TAILWIND_CDN_HOST = 'cdn.tailwindcss.com';
+const SDK_SCRIPT_TAG = '<script src="/sdk/openaidy-sdk.js">';
+
+/**
+ * Inject the Tailwind CDN <script> tag into an addon's index.html, right
+ * before the (already-validated) SDK script tag. Idempotent — a no-op if the
+ * agent already included the tag itself.
+ */
+function injectTailwindCdn(html: string): string {
+  if (html.includes(TAILWIND_CDN_HOST)) return html;
+  return html.replace(
+    SDK_SCRIPT_TAG,
+    `<script src="${TAILWIND_CDN_URL}"></script>\n  ${SDK_SCRIPT_TAG}`,
+  );
+}
+
 // ── SDK snippet helpers (derived from sdk-reference — no hardcoding) ──────────
 
 function sdkBootstrapSnippet(): string {
@@ -130,6 +156,18 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
       'Then at the top of app/index.js:',
       '',
       sdkBootstrapSnippet(),
+      '',
+      '',
+      'STYLING: TAILWIND CSS + sdk.ui.* COMPONENTS',
+      '────────────────────────────────────────────',
+      'Tailwind CSS is auto-injected into every addon — use utility classes freely,',
+      'no setup needed. For common UI (cards, buttons, tables, dialogs, forms, toasts,',
+      'etc.) prefer the built-in sdk.ui.* component library over hand-rolled HTML: it is',
+      'accessible (ARIA, keyboard nav, focus management), responsive, and already styled',
+      'to match the platform. Every sdk.ui.* method returns a real HTMLElement — build it',
+      'and append it, e.g. document.body.appendChild(sdk.ui.card({ title: "Hi" })).',
+      'See the UI section of the reference below for the full list with parameters, or',
+      'fetch GET /sdk/components.json at runtime for a machine-readable manifest.',
       '',
       '',
       'EXTERNAL DOMAINS (required when using fetch())',
@@ -423,7 +461,8 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
             error: `File "${filePath}" must have string content`,
           };
         }
-        extraFiles[filePath] = content;
+        extraFiles[filePath] =
+          filePath === 'app/index.html' ? injectTailwindCdn(content) : content;
       }
 
       // ── Validate externalDomains: detect undeclared external fetch() calls ─
@@ -461,12 +500,19 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
 
       // ── Step 1: scaffold files via shared template generator ─────────────
 
+      // The Tailwind CDN <script> is auto-injected above; document it in the
+      // manifest's externalDomains too (informational — script-src for it is
+      // enforced as a fixed platform allowance, see routes/addons.ts).
+      const externalDomainsWithTailwind = Array.from(
+        new Set([...(externalDomains ?? []), TAILWIND_CDN_HOST]),
+      );
+
       const generated = await generateFromTemplate(template, addonDir, {
         name,
         id,
         description,
         permissions: permissions as string[],
-        ...(externalDomains ? { externalDomains } : {}),
+        externalDomains: externalDomainsWithTailwind,
         ...(externalImageDomains ? { externalImageDomains } : {}),
       });
 

--- a/packages/addon-scaffolding/src/template-generator.ts
+++ b/packages/addon-scaffolding/src/template-generator.ts
@@ -68,9 +68,11 @@ function writeManifest(
     dependencies: {},
     ...extra,
   };
-  if (opts.externalDomains && opts.externalDomains.length > 0) {
-    manifest['externalDomains'] = opts.externalDomains;
-  }
+  // Every addon gets the Tailwind CDN <script> above (informational here —
+  // enforcement is a fixed platform script-src allowance, see routes/addons.ts).
+  manifest['externalDomains'] = Array.from(
+    new Set([...(opts.externalDomains ?? []), 'cdn.tailwindcss.com']),
+  );
   if (opts.externalImageDomains && opts.externalImageDomains.length > 0) {
     manifest['externalImageDomains'] = opts.externalImageDomains;
   }
@@ -93,6 +95,12 @@ function writeReadme(projectPath: string, opts: TemplateOptions): void {
     `# ${opts.name}\n\n${opts.description ?? `${opts.name} addon for OpenAidy`}\n\n## Development\n\nEdit \`app/index.html\` and \`app/index.js\` directly — no build step needed.\n\n## Validate\n\n\`\`\`bash\nopenaidy addon validate\n\`\`\`\n`,
   );
 }
+
+// Every addon gets Tailwind CSS for free — see apps/server/src/tools/addons/create.ts
+// for the matching injection on the agent-tool path (which overwrites this
+// template's index.html with agent-supplied content, so both places need it).
+const TAILWIND_CDN_TAG =
+  '  <script src="https://cdn.tailwindcss.com"></script>';
 
 // Shared CSS for both templates
 const SHARED_CSS = `    * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -220,6 +228,7 @@ function generateBasicTemplate(
   <style>
 ${SHARED_CSS}
   </style>
+${TAILWIND_CDN_TAG}
 </head>
 <body>
   <main>
@@ -298,6 +307,7 @@ function generateAgentTemplate(
   <style>
 ${SHARED_CSS}
   </style>
+${TAILWIND_CDN_TAG}
 </head>
 <body>
   <main>


### PR DESCRIPTION
Closes #417.

## Summary

Adds a 25-component, Tailwind-styled vanilla-JS UI library to the addon SDK (`sdk.ui.*`) — Card, Tabs, Accordion, Separator, Button, ButtonGroup, DropdownMenu, Table, Badge, Avatar, Skeleton, Breadcrumb, Toast, Alert, Dialog, Tooltip, Input, Textarea, Select, Switch, Checkbox, RadioGroup, Label, Sheet, Popover. Every component returns a real `HTMLElement`, is keyboard-navigable and ARIA-annotated, supports loading/disabled states and `class` overrides, and cleans up any document-level listeners (focus trap, outside-click detection) on close.

## Changes

- **`apps/server/src/sdk/openaidy-sdk.js`** — new `sdk.ui.*` namespace plus a small set of internal DOM helpers (`_el`/`_append`/`_cx`/`_trapFocus`/toast-stack singleton) shared across the 25 components, mirroring the existing `sdk.storage.*` nesting convention. Each component carries an `@component` JSDoc block.
- **`apps/server/src/addons/sdk-reference.ts`** — all 25 components added as first-class `SDK_METHODS` entries (`category: 'UI'`), so they appear in `addon_create`'s rendered reference automatically — no separate doc to maintain. `proxyPath`/`httpMethod` are now optional on `SdkMethod`, since UI components are pure client-side DOM builders with no server round-trip.
- **`apps/server/src/addons/component-manifest.ts`** (new) — hand-rolled `@component` JSDoc parser (no JSDoc-parsing library exists anywhere in the monorepo; this follows the codebase's existing preference for small regex-based parsers over new deps, e.g. the CSP/domain-scanning logic already in `routes/addons.ts` and `tools/addons/create.ts`). This is the source of `GET /sdk/components.json` — deliberately a *separate*, runtime-derived manifest so agent discovery can never drift from the actual implementation.
- **`apps/server/src/routes/addons.ts`** — registers `GET /sdk/components.json` (parsed once, cached; ungated like `/info` since it's documentation, not a credential).
- **`apps/server/src/tools/addons/create.ts`** + **`packages/addon-scaffolding/src/template-generator.ts`** — auto-inject the Tailwind Play CDN `<script>` into every new addon's `index.html` (idempotent — skips if already present) and auto-add `cdn.tailwindcss.com` to the manifest's `externalDomains`. Both files needed this: `create.ts` is the agent-tool path (which overwrites the scaffolded `index.html` with agent-supplied content), and `template-generator.ts` is the CLI scaffolding path (`openaidy addon create`, which bypasses `create.ts` entirely) — either one can be what actually ships the addon.

### Necessary fix beyond the issue's file list

`routes/addons.ts`'s CSP `script-src` was **hardcoded** and never consulted `externalDomains` at all — that field only ever fed `connect-src`/`img-src` (fetch/XHR and images). Simply declaring `cdn.tailwindcss.com` in `externalDomains`, as the issue describes, would **not** have let the injected `<script src="https://cdn.tailwindcss.com">` actually load — the browser would silently block it via CSP, and the whole feature would look shipped but not work. Added a fixed platform-level `script-src` allowance for the Tailwind CDN origin instead of widening `script-src` to arbitrary addon-declared domains (which would let any addon that declares an API host for `fetch()` also load a `<script>` from that same host — a bigger permission than what was requested).

## Verification

- Full monorepo build, lint, and test suite: all green (exit 0, zero failures)
- New unit tests: `component-manifest.test.ts` (parser correctness against synthetic input + the real SDK file — all 25 components parse correctly), plus new/updated `create.test.ts` cases for the Tailwind injection (idempotency, `externalDomains` merge) and the relaxed `sdk-reference` invariant (UI methods have no `proxyPath`/`httpMethod`)
- **jsdom functional smoke test** of all 25 real components (click handlers, keyboard nav, focus trap, toast dismiss/stacking, outside-click close) — caught and fixed one real bug in the process: `_trapFocus`'s initial-focus step relied on `offsetParent !== null`, which is always `null` under jsdom (no layout engine) and is a fragile visibility check in general anyway; replaced with a `hidden`-attribute check.

## Test plan

- [ ] Create an addon via `addon_create` and confirm `app/index.html` has the Tailwind `<script>` injected before the SDK script tag
- [ ] Call `sdk.ui.dialog(...)` / `sdk.ui.toast(...)` etc. from an addon and confirm they render styled and interactive in the actual iframe (not just jsdom)
- [ ] `curl localhost:PORT/sdk/components.json` and confirm all 25 components are listed with params
- [ ] Confirm the Tailwind CDN script isn't blocked by CSP in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)