### PR TITLE
feat(channels): link WhatsApp from the UI

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -81,7 +81,10 @@ import { createSkillRegistry } from './skills';
 import { skillRoutes } from './routes/skills';
 import { seedBundledSkills } from './skills/seed';
 import { createAgentPersonalityService } from './agents/personality-service';
-import { createChannelRegistry } from './channels/index.js';
+import {
+  createChannelRegistry,
+  reconcileChannelRegistry,
+} from './channels/index.js';
 import { PulseService } from './pulses/service.js';
 import { channelRoutes } from './routes/channels.js';
 import path from 'node:path';
@@ -364,13 +367,20 @@ export async function buildApp() {
   });
 
   // Create and wire channel registry
+  const channelDeps = {
+    sessionService,
+    authBaseDir: path.join(env.OPENAIDY_HOME, 'channels'),
+    logger: log as unknown as FastifyBaseLogger,
+  };
   const channelRegistry = createChannelRegistry(
     configService.getConfig().channels,
-    {
-      sessionService,
-      authBaseDir: path.join(env.OPENAIDY_HOME, 'channels'),
-      logger: log as unknown as FastifyBaseLogger,
-    },
+    channelDeps,
+  );
+
+  // Keep the live registry in sync when the config is saved (e.g. a WhatsApp
+  // channel added/removed from the UI), so it works without a restart.
+  configService.setChannelReconciler((channels) =>
+    reconcileChannelRegistry(channelRegistry, channels, channelDeps),
   );
 
   // Auto-connect enabled channels (non-blocking)

--- a/apps/server/src/channels/index.ts
+++ b/apps/server/src/channels/index.ts
@@ -2,6 +2,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { ChannelConfig } from '@openaidy/config';
 import type { SessionMessageService } from '../sessions/service';
 import { ChannelRegistry } from './registry.js';
+import type { IChannel } from './interface.js';
 import { WhatsAppChannel } from './whatsapp/service.js';
 
 export type ChannelRegistryDeps = {
@@ -15,8 +16,10 @@ export { ChannelRegistry };
 export type { IChannel } from './interface.js';
 
 /**
- * Instantiates a ChannelRegistry from the channels config array.
- * Called once during app startup in app.ts.
+ * Build a live channel instance from its config entry. The single place that
+ * maps a channel `type` to its service class — both {@link createChannelRegistry}
+ * and {@link reconcileChannelRegistry} go through here, so adding a new channel
+ * type is a one-line change.
  *
  * To add a new channel type:
  *   1. Add its config schema to packages/config (discriminated union)
@@ -24,20 +27,68 @@ export type { IChannel } from './interface.js';
  *   3. Add an `if (cfg.type === 'newtype')` branch below
  *   Zero other files need to change.
  */
+function createChannelInstance(
+  cfg: ChannelConfig,
+  deps: ChannelRegistryDeps,
+): IChannel | null {
+  if (cfg.type === 'whatsapp') {
+    return new WhatsAppChannel(cfg, deps);
+  }
+  // Future channel types go here, e.g.:
+  // if (cfg.type === 'telegram') {
+  //   const { TelegramChannel } = await import('./telegram/service.js');
+  //   return new TelegramChannel(cfg, deps);
+  // }
+  return null;
+}
+
+/**
+ * Instantiates a ChannelRegistry from the channels config array.
+ * Called once during app startup in app.ts.
+ */
 export function createChannelRegistry(
   configs: ChannelConfig[] | undefined,
   deps: ChannelRegistryDeps,
 ): ChannelRegistry {
   const registry = new ChannelRegistry();
   for (const cfg of configs ?? []) {
-    if (cfg.type === 'whatsapp') {
-      registry.register(new WhatsAppChannel(cfg, deps));
-    }
-    // Future channel types go here, e.g.:
-    // if (cfg.type === 'telegram') {
-    //   const { TelegramChannel } = await import('./telegram/service.js');
-    //   registry.register(new TelegramChannel(cfg, deps));
-    // }
+    const channel = createChannelInstance(cfg, deps);
+    if (channel) registry.register(channel);
   }
   return registry;
+}
+
+/**
+ * Reconcile the live registry against a (possibly changed) channels config —
+ * the runtime counterpart to persisting `config.channels`. Registry instances
+ * are built only once at startup, so without this a channel added or removed
+ * via the UI/config PUT would not take effect until a restart.
+ *
+ * - A channel id newly present in config is registered (but NOT auto-connected;
+ *   the user explicitly clicks Connect to start the QR pairing flow).
+ * - A channel id no longer in config is disconnected and removed.
+ * - An existing id is left untouched. Changing an already-registered channel's
+ *   agentId/allowlist in place still requires a restart — a rare edit, and
+ *   recreating a live instance would drop an active WhatsApp session.
+ */
+export async function reconcileChannelRegistry(
+  registry: ChannelRegistry,
+  configs: ChannelConfig[] | undefined,
+  deps: ChannelRegistryDeps,
+): Promise<void> {
+  const desired = new Map((configs ?? []).map((cfg) => [cfg.id, cfg]));
+
+  // Remove channels that are gone from config (disconnects them first).
+  for (const channel of registry.getAll()) {
+    if (!desired.has(channel.id)) {
+      await registry.remove(channel.id);
+    }
+  }
+
+  // Register channels newly added to config.
+  for (const cfg of desired.values()) {
+    if (registry.has(cfg.id)) continue;
+    const channel = createChannelInstance(cfg, deps);
+    if (channel) registry.register(channel);
+  }
 }

--- a/apps/server/src/channels/reconcile.test.ts
+++ b/apps/server/src/channels/reconcile.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import type { FastifyBaseLogger } from 'fastify';
+import type { WhatsAppChannelConfig } from '@openaidy/config';
+import {
+  createChannelRegistry,
+  reconcileChannelRegistry,
+  type ChannelRegistryDeps,
+} from './index.js';
+
+function makeDeps(): ChannelRegistryDeps {
+  return {
+    // WhatsAppChannel only touches sessionService when a message arrives, and
+    // authBaseDir/logger only on connect() — none of which the reconcile
+    // tests exercise, so lightweight stubs are enough.
+    sessionService: {} as ChannelRegistryDeps['sessionService'],
+    authBaseDir: path.join(os.tmpdir(), 'oa-reconcile-test'),
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as FastifyBaseLogger,
+  };
+}
+
+function wa(id: string, agentId = 'default'): WhatsAppChannelConfig {
+  return { type: 'whatsapp', id, agentId, enabled: true };
+}
+
+describe('createChannelRegistry', () => {
+  it('builds a channel instance per whatsapp config entry', () => {
+    const registry = createChannelRegistry([wa('a'), wa('b')], makeDeps());
+    expect(
+      registry
+        .getAll()
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(['a', 'b']);
+    expect(registry.get('a')?.type).toBe('whatsapp');
+  });
+
+  it('handles undefined config as no channels', () => {
+    const registry = createChannelRegistry(undefined, makeDeps());
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});
+
+describe('reconcileChannelRegistry', () => {
+  it('registers a newly-added channel', async () => {
+    const deps = makeDeps();
+    const registry = createChannelRegistry([wa('a')], deps);
+
+    await reconcileChannelRegistry(registry, [wa('a'), wa('b')], deps);
+
+    expect(registry.has('a')).toBe(true);
+    expect(registry.has('b')).toBe(true);
+  });
+
+  it('does NOT auto-connect a newly-added channel', async () => {
+    const deps = makeDeps();
+    const registry = createChannelRegistry([], deps);
+
+    await reconcileChannelRegistry(registry, [wa('new')], deps);
+
+    const channel = registry.get('new')!;
+    const connectSpy = vi.spyOn(channel, 'connect');
+    // Reconcile already ran; a freshly-registered channel must sit at
+    // 'disconnected' until the user explicitly connects it (QR flow).
+    expect(channel.getStatus()).toBe('disconnected');
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it('disconnects and removes a channel dropped from config', async () => {
+    const deps = makeDeps();
+    const registry = createChannelRegistry([wa('keep'), wa('drop')], deps);
+    const dropped = registry.get('drop')!;
+    const disconnectSpy = vi.spyOn(dropped, 'disconnect');
+
+    await reconcileChannelRegistry(registry, [wa('keep')], deps);
+
+    expect(disconnectSpy).toHaveBeenCalledOnce();
+    expect(registry.has('drop')).toBe(false);
+    expect(registry.has('keep')).toBe(true);
+  });
+
+  it('leaves an existing channel instance untouched', async () => {
+    const deps = makeDeps();
+    const registry = createChannelRegistry([wa('a')], deps);
+    const before = registry.get('a');
+
+    await reconcileChannelRegistry(registry, [wa('a'), wa('b')], deps);
+
+    // Same object identity — not recreated (which would drop a live session).
+    expect(registry.get('a')).toBe(before);
+  });
+
+  it('removes all channels when config becomes empty/undefined', async () => {
+    const deps = makeDeps();
+    const registry = createChannelRegistry([wa('a'), wa('b')], deps);
+
+    await reconcileChannelRegistry(registry, undefined, deps);
+
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});

--- a/apps/server/src/config/service.test.ts
+++ b/apps/server/src/config/service.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { OpenAidyAppConfig } from '@openaidy/config';
+import { AppConfigService } from './service.js';
+import type { ProviderServices } from '../providers';
+import type { AgentRegistry } from '../agents';
+
+/**
+ * Minimal config that passes appConfigSchema without needing any real
+ * providers: empty providers list + a model-less agent + no default provider
+ * (the empty-install shape). Keeps applyConfig's provider loop and default
+ * block from doing any real work, so we can focus on the channel-reconciler
+ * wiring in save().
+ */
+function baseConfig(): OpenAidyAppConfig {
+  return {
+    version: 1,
+    defaults: { agentId: 'default' },
+    providers: [],
+    agents: [
+      {
+        id: 'default',
+        name: 'Default',
+        systemPrompt: 'You are helpful.',
+        enabled: true,
+      },
+    ],
+  } as unknown as OpenAidyAppConfig;
+}
+
+// Providers/agents are no-op stubs — applyConfig only calls registry.clear()
+// (empty provider loop) and agents.replaceAll() for this config shape.
+function stubProviders(): ProviderServices {
+  return {
+    registry: {
+      clear: vi.fn(),
+      register: vi.fn(),
+      has: vi.fn(() => false),
+      setDefault: vi.fn(),
+    },
+  } as unknown as ProviderServices;
+}
+
+function stubAgents(): AgentRegistry {
+  return { replaceAll: vi.fn() } as unknown as AgentRegistry;
+}
+
+describe('AppConfigService channel reconciler', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-config-test-'));
+    configPath = path.join(dir, 'openaidy.json');
+    fs.writeFileSync(configPath, JSON.stringify(baseConfig()), 'utf-8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeService(): AppConfigService {
+    return new AppConfigService({
+      configPath,
+      templatePath: configPath,
+      providers: stubProviders(),
+      agents: stubAgents(),
+    });
+  }
+
+  it('invokes the reconciler with the saved channels on save()', async () => {
+    const service = makeService();
+    await service.load();
+    const reconcile = vi.fn();
+    service.setChannelReconciler(reconcile);
+
+    const channels = [
+      {
+        type: 'whatsapp' as const,
+        id: 'personal',
+        agentId: 'default',
+        enabled: true,
+      },
+    ];
+    await service.save({ ...baseConfig(), channels });
+
+    expect(reconcile).toHaveBeenCalledOnce();
+    expect(reconcile).toHaveBeenCalledWith(channels);
+  });
+
+  it('passes undefined channels through when none are configured', async () => {
+    const service = makeService();
+    await service.load();
+    const reconcile = vi.fn();
+    service.setChannelReconciler(reconcile);
+
+    await service.save(baseConfig());
+
+    expect(reconcile).toHaveBeenCalledOnce();
+    expect(reconcile).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not throw when no reconciler is registered', async () => {
+    const service = makeService();
+    await service.load();
+    await expect(service.save(baseConfig())).resolves.toBeDefined();
+  });
+});

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -11,6 +11,7 @@ import {
   appConfigSchema,
   envSecret,
   type AppProviderConfig,
+  type ChannelConfig,
   type McpServerConfig,
   type OpenAidyAppConfig,
   type ProviderConfig,
@@ -41,6 +42,9 @@ export class AppConfigService {
   private readonly credentialProvider: CredentialProvider | undefined;
   private currentConfig: OpenAidyAppConfig | undefined;
   private issues: AppConfigIssue[] = [];
+  private channelReconciler:
+    | ((channels: ChannelConfig[] | undefined) => void | Promise<void>)
+    | undefined;
 
   constructor(options: AppConfigServiceOptions) {
     this.configPath = options.configPath;
@@ -48,6 +52,20 @@ export class AppConfigService {
     this.providers = options.providers;
     this.agents = options.agents;
     this.credentialProvider = options.credentialProvider;
+  }
+
+  /**
+   * Register a callback that syncs the live channel registry to the persisted
+   * `config.channels` after every {@link save}. Set once at startup (the
+   * registry is built after this service is constructed, hence a setter rather
+   * than a constructor option). Without it, a channel added/removed via the
+   * config PUT would not take effect until a restart. Kept as an injected
+   * callback so this config module stays free of channel/WhatsApp internals.
+   */
+  setChannelReconciler(
+    reconcile: (channels: ChannelConfig[] | undefined) => void | Promise<void>,
+  ): void {
+    this.channelReconciler = reconcile;
   }
 
   getConfig(): OpenAidyAppConfig {
@@ -158,6 +176,14 @@ export class AppConfigService {
     this.writeConfigFile(parsed);
     await this.applyConfig(parsed);
     this.currentConfig = parsed;
+    // Sync runtime channels to the freshly-saved config (registers new
+    // channels, disconnects+removes deleted ones) so UI changes take effect
+    // without a restart. applyConfig handles agents/providers; channels are
+    // reconciled here via the injected callback to keep this module decoupled
+    // from channel internals.
+    if (this.channelReconciler) {
+      await this.channelReconciler(parsed.channels);
+    }
     return parsed;
   }
 

--- a/apps/web/src/components/pages/ChannelsPage.tsx
+++ b/apps/web/src/components/pages/ChannelsPage.tsx
@@ -15,10 +15,20 @@ import {
   AlertCircle,
   CheckCircle,
   QrCode,
+  Plus,
+  Trash2,
+  X,
 } from 'lucide-solid';
 import { Layout } from './Layout';
 import type { ChannelStatusResponse } from '@openaidy/shared-types';
-import { listChannels, connectChannel, disconnectChannel } from '../../lib/api';
+import {
+  listChannels,
+  connectChannel,
+  disconnectChannel,
+  addWhatsAppChannel,
+  removeChannel,
+  listAgents,
+} from '../../lib/api';
 import { useWebSocketContext } from '../../lib/ws-provider';
 
 function StatusBadge(props: { status: ChannelStatusResponse['status'] }) {
@@ -147,10 +157,162 @@ function QrPanel(props: { channelId: string; onConnected: () => void }) {
   );
 }
 
+function AddChannelDialog(props: {
+  onClose: () => void;
+  onAdded: (id: string) => void;
+}) {
+  const [agents] = createResource(async () => (await listAgents()).items);
+  const [id, setId] = createSignal('');
+  const [agentId, setAgentId] = createSignal('');
+  const [allowlist, setAllowlist] = createSignal('');
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const canSave = () => id().trim().length > 0 && agentId().length > 0;
+
+  const handleSave = async () => {
+    if (!canSave()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const allowlistArr = allowlist()
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      await addWhatsAppChannel({
+        id: id().trim(),
+        agentId: agentId(),
+        ...(allowlistArr.length > 0 ? { allowlist: allowlistArr } : {}),
+      });
+      props.onAdded(id().trim());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add channel');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-md mx-4">
+        <div class="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Add WhatsApp channel
+          </h2>
+          <button
+            onClick={props.onClose}
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            aria-label="Close"
+          >
+            <X class="w-5 h-5" />
+          </button>
+        </div>
+
+        <div class="p-4 space-y-4">
+          <Show when={error()}>
+            <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+              {error()}
+            </div>
+          </Show>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Channel ID <span class="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={id()}
+              onInput={(e) => setId(e.currentTarget.value)}
+              placeholder="e.g. personal"
+              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <p class="mt-1 text-xs text-text-tertiary">
+              A unique name for this WhatsApp connection.
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Agent <span class="text-red-500">*</span>
+            </label>
+            <select
+              value={agentId()}
+              onChange={(e) => setAgentId(e.currentTarget.value)}
+              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              <option value="">Select an agent…</option>
+              <For each={agents() ?? []}>
+                {(agent) => <option value={agent.id}>{agent.name}</option>}
+              </For>
+            </select>
+            <p class="mt-1 text-xs text-text-tertiary">
+              The agent that replies to messages on this channel.
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Allowlist
+            </label>
+            <input
+              type="text"
+              value={allowlist()}
+              onInput={(e) => setAllowlist(e.currentTarget.value)}
+              placeholder="e.g. 15551234567, 15559876543"
+              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <p class="mt-1 text-xs text-text-tertiary">
+              Optional. Comma-separated phone numbers allowed to message this
+              channel. Leave empty to allow everyone.
+            </p>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-end gap-3 p-4 border-t dark:border-gray-700">
+          <button
+            onClick={props.onClose}
+            class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving() || !canSave()}
+            class="px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+          >
+            {saving() ? 'Adding…' : 'Add channel'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ChannelsPage() {
   const [channels, { refetch }] = createResource(listChannels);
   const [pending, setPending] = createSignal<string | null>(null);
   const [qrOpen, setQrOpen] = createSignal<string | null>(null);
+  const [showAdd, setShowAdd] = createSignal(false);
+  const [confirmRemove, setConfirmRemove] = createSignal<string | null>(null);
+
+  const handleAdded = (id: string) => {
+    setShowAdd(false);
+    void refetch();
+    // Jump straight into linking the freshly-added channel.
+    void handleConnect(id);
+  };
+
+  const handleRemove = async (id: string) => {
+    setPending(id);
+    try {
+      await removeChannel(id);
+      setConfirmRemove(null);
+      if (qrOpen() === id) setQrOpen(null);
+      void refetch();
+    } finally {
+      setPending(null);
+    }
+  };
 
   const handleConnect = async (id: string) => {
     setPending(id);
@@ -175,11 +337,29 @@ export function ChannelsPage() {
     }
   };
 
+  const addButton = (
+    <button
+      onClick={() => setShowAdd(true)}
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+    >
+      <Plus class="w-4 h-4" />
+      Add WhatsApp
+    </button>
+  );
+
   return (
     <Layout
       title="Channels"
       description="Connect WhatsApp, Telegram, Discord, Slack"
+      actions={addButton}
     >
+      <Show when={showAdd()}>
+        <AddChannelDialog
+          onClose={() => setShowAdd(false)}
+          onAdded={handleAdded}
+        />
+      </Show>
+
       <Show when={channels.loading}>
         <div class="flex items-center justify-center h-48">
           <p class="text-text-tertiary">Loading channels...</p>
@@ -201,21 +381,17 @@ export function ChannelsPage() {
               <h3 class="text-lg font-medium text-text-primary mb-2">
                 No channels configured
               </h3>
-              <p class="text-sm text-text-secondary mb-4">
-                Add a channel to{' '}
-                <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs font-mono">
-                  openaidy.json
-                </code>{' '}
-                to get started.
+              <p class="text-sm text-text-secondary mb-4 max-w-sm">
+                Connect a WhatsApp number so an agent can chat with you there.
+                Add a channel, then scan the QR code from your phone.
               </p>
-              <pre class="text-xs text-left bg-gray-100 dark:bg-gray-800 p-3 rounded border border-gray-200 dark:border-gray-700 text-text-secondary font-mono">{`"channels": [
-  {
-    "type": "whatsapp",
-    "id": "personal",
-    "agentId": "my-agent",
-    "enabled": true
-  }
-]`}</pre>
+              <button
+                onClick={() => setShowAdd(true)}
+                class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+              >
+                <Plus class="w-4 h-4" />
+                Add WhatsApp channel
+              </button>
             </div>
           }
         >
@@ -277,6 +453,36 @@ export function ChannelsPage() {
                             ? 'Disconnecting...'
                             : 'Disconnect'}
                         </button>
+                      </Show>
+                      <Show
+                        when={confirmRemove() === channel.id}
+                        fallback={
+                          <button
+                            onClick={() => setConfirmRemove(channel.id)}
+                            class="inline-flex items-center gap-1 text-xs text-text-tertiary hover:text-red-500 transition-colors"
+                          >
+                            <Trash2 class="w-3.5 h-3.5" />
+                            Remove
+                          </button>
+                        }
+                      >
+                        <div class="flex items-center gap-2">
+                          <button
+                            disabled={pending() === channel.id}
+                            onClick={() => handleRemove(channel.id)}
+                            class="text-xs font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+                          >
+                            {pending() === channel.id
+                              ? 'Removing…'
+                              : 'Confirm remove'}
+                          </button>
+                          <button
+                            onClick={() => setConfirmRemove(null)}
+                            class="text-xs text-text-tertiary hover:text-text-secondary"
+                          >
+                            Cancel
+                          </button>
+                        </div>
                       </Show>
                     </div>
                   </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -75,6 +75,7 @@ export type {
   UpdateMcpServerRequest,
   ImportMcpServersRequest,
   ChannelStatusResponse,
+  ChannelConfig,
 } from './types';
 
 export { ApiRequestError } from '@openaidy/shared-types';
@@ -122,6 +123,7 @@ import type {
   UpdateMcpServerRequest,
   ImportMcpServersRequest,
   ChannelStatusResponse,
+  ChannelConfig,
 } from './types';
 
 /**
@@ -1274,6 +1276,63 @@ export async function disconnectChannel(id: string): Promise<void> {
     method: 'POST',
   });
   if (!res.ok) throw new Error(`disconnectChannel: ${res.status}`);
+}
+
+/**
+ * Add a WhatsApp channel to the config. Reads the current config, appends the
+ * new channel entry, and persists it via the config PUT — the server then
+ * reconciles it into the live channel registry, so the caller can immediately
+ * `connectChannel(id)` to start the QR pairing flow without a restart.
+ *
+ * Throws if the id already exists or the config write fails.
+ */
+export async function addWhatsAppChannel(input: {
+  id: string;
+  agentId: string;
+  allowlist?: string[];
+}): Promise<void> {
+  const current = await getConfig();
+  if (!('config' in current)) {
+    throw new Error('Failed to load config');
+  }
+  const config = current.config;
+  const channels = config.channels ?? [];
+  if (channels.some((c) => c.id === input.id)) {
+    throw new Error(`A channel with id "${input.id}" already exists`);
+  }
+  const entry: ChannelConfig = {
+    type: 'whatsapp',
+    id: input.id,
+    agentId: input.agentId,
+    enabled: true,
+    ...(input.allowlist && input.allowlist.length > 0
+      ? { allowlist: input.allowlist }
+      : {}),
+  };
+  const result = await updateConfig({
+    ...config,
+    channels: [...channels, entry],
+  });
+  if ('error' in result) {
+    throw new Error(`Failed to save channel: ${result.error}`);
+  }
+}
+
+/**
+ * Remove a channel from the config by id. The server reconciles the live
+ * registry, disconnecting and dropping the channel.
+ */
+export async function removeChannel(id: string): Promise<void> {
+  const current = await getConfig();
+  if (!('config' in current)) {
+    throw new Error('Failed to load config');
+  }
+  const config = current.config;
+  const channels = (config.channels ?? []).filter((c) => c.id !== id);
+  const result = await updateConfig({ ...config, channels });
+  if ('error' in result) {
+    throw new Error(`Failed to remove channel: ${result.error}`);
+  }
 }
 
 // ============================================================================

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -444,13 +444,31 @@ export type ProviderConfig =
   | GeminiProviderConfig;
 
 /**
+ * A configured messaging channel. WhatsApp is the only type today; the shape
+ * mirrors `whatsappChannelConfigSchema` in packages/config.
+ */
+export type WhatsAppChannelConfig = {
+  type: 'whatsapp';
+  id: string;
+  agentId: string;
+  allowlist?: string[];
+  enabled?: boolean;
+};
+
+export type ChannelConfig = WhatsAppChannelConfig;
+
+/**
  * Application configuration
+ *
+ * `channels` (and `mcpServers`, not modelled here) round-trip through the raw
+ * config JSON; `channels` is typed so the UI can add/remove entries safely.
  */
 export type AppConfig = {
   version: number;
   defaults: AppDefaults;
   providers: ProviderConfig[];
   agents: AgentConfig[];
+  channels?: ChannelConfig[];
 };
 
 /**


### PR DESCRIPTION
## Summary

Lets users add and link a WhatsApp channel entirely from the **Channels** page — pick an agent, add the channel, scan the QR code — instead of hand-editing `openaidy.json` and restarting the server.

The QR-pairing flow itself (Baileys → QR over WebSocket → `QrPanel`) already existed. This PR fills the two gaps that forced manual config edits:

### Backend — live channel registry reconciliation

The channel registry was built **once at startup**, and `applyConfig` only re-applied agents/providers — so a channel written to `config.channels` never became a live instance until a restart.

- **`channels/index.ts`**: new `reconcileChannelRegistry(registry, configs, deps)` — registers newly-added channel ids, disconnects + removes dropped ones, and leaves existing instances untouched (recreating would drop a live WhatsApp session). Extracted `createChannelInstance` so the `type → service class` mapping lives in one place, shared with `createChannelRegistry`.
- **`config/service.ts`**: `AppConfigService` gains an injected `channelReconciler` (set via `setChannelReconciler`, since the registry is constructed *after* the service) that `save()` invokes after every config write. Kept as a callback so the config module stays decoupled from channel/WhatsApp internals.
- **`app.ts`**: wires the reconciler to the live registry + deps.
- Newly-added channels are registered but **not auto-connected** — the user clicks Connect to start QR pairing (auto-connecting would burn a Baileys socket generating a QR nobody is watching). Because `save()` awaits the reconciler, the channel is live by the time the config PUT returns, so the UI flows straight into Connect with no race.

### Web — Channels UI

- **"Add WhatsApp" dialog**: channel id, agent picker (from `listAgents`), optional allowlist. On save it appends the entry to `config.channels` and PUTs the full config; the server reconciles it live, then the flow continues into the existing Connect/QR panel.
- **Per-channel Remove** (inline confirm) → drops the entry from config; the server disconnects + deregisters it.
- Empty state now offers the **Add** button instead of an `openaidy.json` snippet.
- `lib/types`: `channels?` on `AppConfig` + `WhatsAppChannelConfig`/`ChannelConfig`. `lib/api`: `addWhatsAppChannel` / `removeChannel` (GET config → mutate `channels[]` → PUT full config, preserving other fields).

## Verification

- Full monorepo build, lint, format, and test suite: all green (exit 0, zero failures)
- New tests: `reconcileChannelRegistry` (add / remove+disconnect / leave-untouched / no-auto-connect / clear-all) and the `AppConfigService.save()` → reconciler integration seam.

## Test plan (needs a real WhatsApp number — couldn't verify from here)

- [ ] Add a channel via the dialog, confirm it appears and a QR renders on Connect
- [ ] Scan with WhatsApp → status flips to Connected, an inbound message reaches the selected agent
- [ ] Remove a channel → it disconnects and disappears without a restart
- [ ] Confirm `mcpServers`/other config fields survive the add/remove round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)