### PR TITLE
feat(sessions): show per-session token usage + cost on session cards

### DIFF
--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -46,6 +46,25 @@ export const usageRoutes: FastifyPluginAsync<UsageRoutesOptions> = async (
   });
 
   /**
+   * GET /usage/sessions
+   * Per-session usage totals for every session with succeeded runs, in one
+   * request — so the sessions list can show usage without an N+1 fan-out of
+   * `/sessions/:id/usage`. Returned as a map keyed by session id; sessions
+   * with no usage yet are simply absent.
+   */
+  app.get('/usage/sessions', async () => {
+    const rows = await sessionService.getUsageBySession();
+    const usageBySession: Record<
+      string,
+      import('@openaidy/db').SessionUsageTotals
+    > = {};
+    for (const { sessionId, ...usage } of rows) {
+      usageBySession[sessionId] = usage;
+    }
+    return { usageBySession };
+  });
+
+  /**
    * GET /usage?from=&to=
    * Aggregated usage across all sessions with day / provider / model
    * breakdowns. `from`/`to` are ISO timestamps (`to` exclusive); both

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -502,6 +502,20 @@ export class SessionMessageService {
   }
 
   /**
+   * Per-session usage totals for every session with succeeded runs, in one
+   * query. Used to show usage on the sessions list without an N+1 fan-out.
+   * Empty when no DB store.
+   */
+  async getUsageBySession(): Promise<
+    Array<import('@openaidy/db').SessionUsageTotals & { sessionId: string }>
+  > {
+    if (this.runsRepo) {
+      return this.runsRepo.getUsageBySession();
+    }
+    return [];
+  }
+
+  /**
    * Submit a message to a session (non-streaming, legacy path)
    *
    * @deprecated Prefer submitMessageStreaming for all new callers. This method

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -51,6 +51,7 @@ import {
   deleteSession,
   uploadAttachment,
   getConfig,
+  getUsageBySession,
   type AddonRecord,
 } from './lib/api';
 import { ProviderOnboarding } from './components/onboarding/ProviderOnboarding';
@@ -304,6 +305,9 @@ function AppContent(props: AppContentProps) {
       queryClient.invalidateQueries({
         queryKey: ['runs', sessionId],
       });
+      // A completed run adds tokens/cost — refresh the per-session usage that
+      // the sessions cards display.
+      queryClient.invalidateQueries({ queryKey: ['session-usage'] });
       // Drain the next queued message, if any, now that the run is idle.
       processQueue();
       // Focus the chat input after streaming completes
@@ -423,6 +427,13 @@ function AppContent(props: AppContentProps) {
   const sessionsQuery = createQuery(() => ({
     queryKey: ['sessions'],
     queryFn: listSessions,
+  }));
+
+  // Per-session usage totals (tokens + cost), keyed by session id, for the
+  // usage shown on session cards. One batched request rather than per-card.
+  const sessionUsageQuery = createQuery(() => ({
+    queryKey: ['session-usage'],
+    queryFn: getUsageBySession,
   }));
 
   // Agents query
@@ -870,6 +881,7 @@ function AppContent(props: AppContentProps) {
         <Show when={view() === 'sessions'}>
           <SessionsPage
             sessions={sessionsQuery.data?.items || []}
+            usageBySession={sessionUsageQuery.data ?? {}}
             selectedSessionId={selectedSessionId()}
             onSelectSession={(id) => {
               setSelectedSessionId(id);

--- a/apps/web/src/components/pages/SessionsPage.tsx
+++ b/apps/web/src/components/pages/SessionsPage.tsx
@@ -16,10 +16,16 @@ import {
   FileText,
   AlignLeft,
   Filter,
+  Zap,
 } from 'lucide-solid';
 import { searchSessions } from '../../lib/api';
 import type { Session } from '../../lib/api';
-import type { SessionSearchResult } from '../../lib/types';
+import type { SessionSearchResult, UsageTotals } from '../../lib/types';
+import {
+  formatTokensCompact,
+  formatCost,
+  formatNumber,
+} from '../../lib/usage-format';
 
 type SessionsPageProps = {
   sessions: Session[];
@@ -28,6 +34,8 @@ type SessionsPageProps = {
   onCreateSession: () => void;
   onDeleteSession?: (id: string) => void;
   isLoading?: boolean;
+  /** Per-session usage totals keyed by session id (absent = no usage yet). */
+  usageBySession?: Record<string, UsageTotals>;
 };
 
 // Sessions created on behalf of an addon aren't given a distinct `type` —
@@ -143,6 +151,13 @@ export function SessionsPage(props: SessionsPageProps) {
     sortedSessions().filter((s) =>
       activeCategories().includes(categorizeSession(s)),
     );
+
+  // Usage badge data for a card — only when the session has recorded tokens,
+  // so brand-new / empty sessions don't show a "0 tokens" badge.
+  const usageFor = (session: Session): UsageTotals | undefined => {
+    const usage = props.usageBySession?.[session.id];
+    return usage && usage.totalTokens > 0 ? usage : undefined;
+  };
 
   const toggleCategory = (category: SessionCategory) => {
     setActiveCategories((prev) =>
@@ -342,11 +357,27 @@ export function SessionsPage(props: SessionsPageProps) {
                         <h3 class="font-medium text-text-primary truncate">
                           {session.title}
                         </h3>
-                        <div class="flex items-center gap-2 mt-1 text-sm text-text-tertiary">
-                          <Clock class="w-3.5 h-3.5" />
-                          <span>
+                        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-text-tertiary">
+                          <span class="inline-flex items-center gap-1.5">
+                            <Clock class="w-3.5 h-3.5" />
                             {formatDate(session.updatedAt ?? session.createdAt)}
                           </span>
+                          <Show when={usageFor(session)}>
+                            {(usage) => (
+                              <span
+                                class="inline-flex items-center gap-1.5"
+                                title={`${formatNumber(usage().totalTokens)} tokens across ${usage().runCount} run(s)`}
+                              >
+                                <Zap class="w-3.5 h-3.5" />
+                                {formatTokensCompact(usage().totalTokens)}{' '}
+                                tokens
+                                <Show when={usage().hasCost}>
+                                  <span aria-hidden="true">·</span>
+                                  {formatCost(usage().cost, usage().hasCost)}
+                                </Show>
+                              </span>
+                            )}
+                          </Show>
                         </div>
                       </div>
                       <div class="flex items-center gap-2">

--- a/apps/web/src/components/pages/UsagePage.tsx
+++ b/apps/web/src/components/pages/UsagePage.tsx
@@ -2,6 +2,7 @@ import { createResource, createSignal, For, Show } from 'solid-js';
 import { Layout } from './Layout';
 import { getUsage } from '../../lib/api';
 import type { UsageByDay, UsageReport } from '../../lib/types';
+import { formatNumber, formatCost } from '../../lib/usage-format';
 
 type RangePreset = '7d' | '30d' | '90d' | 'all';
 
@@ -19,17 +20,6 @@ function fromForPreset(preset: RangePreset): string | undefined {
   const now = new Date();
   const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
   return from.toISOString();
-}
-
-function formatNumber(n: number): string {
-  return n.toLocaleString('en-US');
-}
-
-function formatCost(cost: number, hasCost: boolean): string {
-  if (!hasCost) return '—';
-  // Small costs need more precision than cents.
-  const digits = cost > 0 && cost < 1 ? 4 : 2;
-  return `$${cost.toFixed(digits)}`;
 }
 
 /**

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -572,6 +572,23 @@ export async function getSessionUsage(
 }
 
 /**
+ * Fetch per-session usage totals for every session with usage, in one request
+ * (keyed by session id). Powers the usage shown on the sessions list without
+ * an N+1 fan-out of getSessionUsage. Returns an empty map on error so the list
+ * still renders.
+ */
+export async function getUsageBySession(): Promise<
+  Record<string, import('./types').UsageTotals>
+> {
+  const response = await apiFetch(`${API_BASE}/api/usage/sessions`);
+  if (!response.ok) return {};
+  const body = (await response.json()) as {
+    usageBySession?: Record<string, import('./types').UsageTotals>;
+  };
+  return body.usageBySession ?? {};
+}
+
+/**
  * Fetch aggregated usage across all sessions, optionally within a date
  * range (ISO strings; `to` exclusive).
  */

--- a/apps/web/src/lib/usage-format.ts
+++ b/apps/web/src/lib/usage-format.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared formatting helpers for token-usage / cost display, used by the usage
+ * dashboard and the per-session usage on session cards so numbers read the
+ * same everywhere.
+ */
+
+/** Full grouped integer, e.g. 12345 → "12,345". */
+export function formatNumber(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+/**
+ * Cost in USD. `hasCost` is false when no run had known pricing, in which
+ * case we show an em-dash rather than a misleading "$0.00". Small sub-dollar
+ * amounts get 4 digits since cents aren't precise enough.
+ */
+export function formatCost(cost: number, hasCost: boolean): string {
+  if (!hasCost) return '—';
+  const digits = cost > 0 && cost < 1 ? 4 : 2;
+  return `$${cost.toFixed(digits)}`;
+}
+
+/**
+ * Compact token count for tight spots like session cards, e.g. 1500 → "1.5K",
+ * 2_300_000 → "2.3M". Values under 1000 are shown as-is.
+ */
+export function formatTokensCompact(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    const k = n / 1000;
+    return `${k % 1 === 0 ? k : k.toFixed(1)}K`;
+  }
+  const m = n / 1_000_000;
+  return `${m % 1 === 0 ? m : m.toFixed(1)}M`;
+}

--- a/packages/db/src/repositories/index.test.ts
+++ b/packages/db/src/repositories/index.test.ts
@@ -327,5 +327,71 @@ describe('Session Repositories (integration)', () => {
       expect(session2Runs[0]?.providerId).toBe('p2');
       expect(session2Runs[0]?.agentId).toBe('agent2');
     });
+
+    test('getUsageBySession aggregates succeeded runs per session', async () => {
+      const other = await sessionsRepo!.create({ title: 'Other' });
+
+      // Two succeeded runs on `sessionId`, one on `other`.
+      const r1 = await runsRepo!.create({
+        sessionId,
+        agentId: 'a',
+        providerId: 'p',
+        modelId: 'm',
+      });
+      await runsRepo!.markSucceeded(r1.id, {
+        finishReason: 'stop',
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        cost: 0.01,
+      });
+      const r2 = await runsRepo!.create({
+        sessionId,
+        agentId: 'a',
+        providerId: 'p',
+        modelId: 'm',
+      });
+      await runsRepo!.markSucceeded(r2.id, {
+        finishReason: 'stop',
+        usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+        cost: 0.02,
+      });
+      const r3 = await runsRepo!.create({
+        sessionId: other.id,
+        agentId: 'a',
+        providerId: 'p',
+        modelId: 'm',
+      });
+      await runsRepo!.markSucceeded(r3.id, {
+        finishReason: 'stop',
+        usage: { promptTokens: 7, completionTokens: 3, totalTokens: 10 },
+      });
+      // A failed run must NOT be counted.
+      const r4 = await runsRepo!.create({
+        sessionId,
+        agentId: 'a',
+        providerId: 'p',
+        modelId: 'm',
+      });
+      await runsRepo!.markFailed(r4.id, {
+        errorCode: 'provider.error',
+        errorMessage: 'boom',
+      });
+
+      const rows = await runsRepo!.getUsageBySession();
+      const byId = new Map(rows.map((row) => [row.sessionId, row]));
+
+      const main = byId.get(sessionId);
+      expect(main).toBeDefined();
+      expect(main!.runCount).toBe(2);
+      expect(main!.totalTokens).toBe(45);
+      expect(main!.promptTokens).toBe(30);
+      expect(main!.cost).toBeCloseTo(0.03);
+      expect(main!.hasCost).toBe(true);
+
+      const otherUsage = byId.get(other.id);
+      expect(otherUsage!.runCount).toBe(1);
+      expect(otherUsage!.totalTokens).toBe(10);
+      // No cost recorded for that run.
+      expect(otherUsage!.hasCost).toBe(false);
+    });
   });
 });

--- a/packages/db/src/repositories/session-runs.ts
+++ b/packages/db/src/repositories/session-runs.ts
@@ -395,6 +395,74 @@ export class SessionRunsRepository {
   }
 
   /**
+   * Cumulative usage totals for every session that has at least one succeeded
+   * run, computed in a single pass. Grouping is done in JS (like
+   * {@link listUsageRows}) so the query stays portable across SQLite and
+   * Postgres. Sessions with no succeeded runs are simply absent from the
+   * result. Lets the UI show per-session usage on the whole list without an
+   * N+1 fan-out of {@link getSessionUsage} calls.
+   */
+  async getUsageBySession(): Promise<
+    Array<SessionUsageTotals & { sessionId: string }>
+  > {
+    const rows = await this.db
+      .select({
+        sessionId: schema.sessionRuns.sessionId,
+        promptTokens: schema.sessionRuns.promptTokens,
+        completionTokens: schema.sessionRuns.completionTokens,
+        totalTokens: schema.sessionRuns.totalTokens,
+        cacheReadTokens: schema.sessionRuns.cacheReadTokens,
+        cacheCreationTokens: schema.sessionRuns.cacheCreationTokens,
+        cost: schema.sessionRuns.cost,
+      })
+      .from(schema.sessionRuns)
+      .where(eq(schema.sessionRuns.status, 'succeeded'));
+
+    type Row = {
+      sessionId: string;
+      promptTokens: number | null;
+      completionTokens: number | null;
+      totalTokens: number | null;
+      cacheReadTokens: number | null;
+      cacheCreationTokens: number | null;
+      cost: number | null;
+    };
+
+    const bySession = new Map<
+      string,
+      SessionUsageTotals & { sessionId: string }
+    >();
+    for (const r of rows as Row[]) {
+      let totals = bySession.get(r.sessionId);
+      if (!totals) {
+        totals = {
+          sessionId: r.sessionId,
+          runCount: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          cost: 0,
+          hasCost: false,
+        };
+        bySession.set(r.sessionId, totals);
+      }
+      totals.runCount += 1;
+      totals.promptTokens += r.promptTokens ?? 0;
+      totals.completionTokens += r.completionTokens ?? 0;
+      totals.totalTokens += r.totalTokens ?? 0;
+      totals.cacheReadTokens += r.cacheReadTokens ?? 0;
+      totals.cacheCreationTokens += r.cacheCreationTokens ?? 0;
+      if (r.cost !== null && r.cost !== undefined) {
+        totals.cost += r.cost;
+        totals.hasCost = true;
+      }
+    }
+    return [...bySession.values()];
+  }
+
+  /**
    * Count runs by status for a session
    */
   async countByStatus(

--- a/packages/db/src/types/index.ts
+++ b/packages/db/src/types/index.ts
@@ -188,6 +188,7 @@ export type SessionRunsStore = Pick<
   | 'countByStatus'
   | 'listUsageRows'
   | 'getSessionUsage'
+  | 'getUsageBySession'
 >;
 
 export type JobsStore = Pick<


### PR DESCRIPTION
## Summary

Each session card on the **Sessions** page now shows its cumulative token count and estimated cost — e.g. `12.3K tokens · $0.04`. Covers **every session origin** (chat, addon, task, subtask): they all record runs in `session_runs` through the same completion path, so per-session aggregation already includes them uniformly.

Usage is fetched in **one batched request** rather than an N+1 fan-out of `GET /sessions/:id/usage`.

## Changes

**db** (`packages/db`)
- `SessionRunsRepository.getUsageBySession()` — a single pass over succeeded runs, grouped per session in JS (same approach as the existing `listUsageRows`, keeping it portable across SQLite/Postgres). Added to the `SessionRunsStore` pick type.

**server** (`apps/server`)
- `SessionMessageService.getUsageBySession()` wrapper (empty when no DB store).
- New `GET /usage/sessions` route returning a `{ [sessionId]: UsageTotals }` map (distinct path from `/usage` and `/sessions/:id/usage`; same `sessions.list` scope).

**web** (`apps/web`)
- `getUsageBySession()` api fn (returns `{}` on error so the list still renders).
- `App` fetches it into a `['session-usage']` query, passed to `SessionsPage`, and invalidates it on run completion so cards stay current.
- `SessionsPage` renders a compact tokens·cost badge next to the date, only when a session has recorded tokens (no "0 tokens" noise on empty sessions). The badge's tooltip shows the exact token count and run count.
- Extracted the cost/number formatters out of `UsagePage` into a shared `lib/usage-format.ts` so the dashboard and cards format identically; added a compact `formatTokensCompact` (`1.5K` / `2.3M`) for the tight card layout.

## Verification

- `pnpm -r build`, lint, format, and web/server typecheck: all clean.
- New `getUsageBySession` aggregation test (per-session grouping, failed-run exclusion, cost / `hasCost`) added to the Postgres integration suite next to the existing `getSessionUsage`/`listUsageRows` tests.
- Reuses the exact same run-aggregation + server-side cost mechanism as the existing usage dashboard (#402), so it's consistent with proven infrastructure.

## Note (not caused by this PR)

The `apps/web` `ScheduleEditor.test.tsx` suite currently fails on `main` (verified: it fails identically with this branch's changes stashed) — it's unrelated to this change and pre-existing. Flagging so it isn't mistaken for a regression here; happy to look into it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)