### PR TITLE
feat(chat): show the effective provider/model in the run list header

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -486,6 +486,20 @@ function AppContent(props: AppContentProps) {
     return !configured;
   };
 
+  // Effective model ("providerId/modelId") for the active agent: the agent's
+  // own model, or the project default when the agent is model-less. Shown in
+  // the RunList header next to the session's usage totals.
+  const effectiveModel = (): string | undefined => {
+    const agent = agents().find((a) => a.id === effectiveAgentId());
+    if (agent?.model) return agent.model;
+    const data = configGateQuery.data;
+    const cfg = data && 'config' in data ? data.config : undefined;
+    const d = cfg?.defaults;
+    return d?.providerId && d?.modelId
+      ? `${d.providerId}/${d.modelId}`
+      : undefined;
+  };
+
   // Create session mutation
   const createSessionMutation = createMutation(() => ({
     mutationFn: (title: string) => createSession(title),
@@ -1019,6 +1033,7 @@ function AppContent(props: AppContentProps) {
                 isLoading={runsQuery.isLoading}
                 error={runsQuery.error?.message}
                 sessionId={selectedSessionId()}
+                model={effectiveModel()}
                 onRunClick={(firstMessageId) => {
                   if (firstMessageId) {
                     setScrollToMessageId(firstMessageId);

--- a/apps/web/src/components/RunList.tsx
+++ b/apps/web/src/components/RunList.tsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
   ChevronDown,
   ChevronUp,
+  Cpu,
 } from 'lucide-solid';
 import type { SessionRun, RunStatus } from '../lib/api';
 import { getSessionUsage } from '../lib/api';
@@ -17,6 +18,11 @@ type RunListProps = {
   error?: string;
   /** Session whose cumulative usage totals are shown in the header. */
   sessionId?: string;
+  /**
+   * Effective model in use ("providerId/modelId"), shown in the header next to
+   * the usage totals so the provider/model is visible on every viewport.
+   */
+  model?: string;
   /** Called when user clicks on a run — passes the run's firstMessageId to scroll to */
   onRunClick?: (firstMessageId: string | undefined) => void;
 };
@@ -100,6 +106,24 @@ export function RunList(props: RunListProps) {
     return `${tokens} tokens${cost}`;
   };
 
+  // Provider/model split from "providerId/modelId" for a compact
+  // "provider · model" indicator. Null when unknown so it's simply omitted.
+  const modelLabel = (): {
+    provider?: string;
+    model: string;
+    full: string;
+  } | null => {
+    const raw = props.model;
+    if (!raw) return null;
+    const slash = raw.indexOf('/');
+    if (slash === -1) return { model: raw, full: raw };
+    return {
+      provider: raw.slice(0, slash),
+      model: raw.slice(slash + 1),
+      full: raw,
+    };
+  };
+
   return (
     <div class="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
       {/* Header */}
@@ -116,14 +140,31 @@ export function RunList(props: RunListProps) {
           </Show>
           <h3 class="text-sm font-medium text-text-secondary">Runs</h3>
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
+          <Show when={modelLabel()}>
+            {(m) => (
+              <span
+                class="inline-flex items-center gap-1 text-xs text-text-tertiary max-w-[45%] sm:max-w-none truncate"
+                title={`Model in use: ${m().full}`}
+              >
+                <Cpu class="w-3 h-3 opacity-70 shrink-0" />
+                <span class="truncate">
+                  <Show when={m().provider}>
+                    <span class="opacity-70">{m().provider}</span>
+                    {' · '}
+                  </Show>
+                  {m().model}
+                </span>
+              </span>
+            )}
+          </Show>
           <Show when={usageSummary()}>
             <span class="text-xs text-text-tertiary tabular-nums">
               {usageSummary()}
             </span>
           </Show>
           <Show when={props.runs.length > 0}>
-            <span class="text-xs text-text-tertiary">
+            <span class="text-xs text-text-tertiary whitespace-nowrap">
               {props.runs.length} run{props.runs.length !== 1 ? 's' : ''}
             </span>
           </Show>


### PR DESCRIPTION
## Summary

Surfaces the **provider and model in use** for the open session, so it's visible while chatting without disturbing the functional areas or costing space. It lives in the **RunList header**, right next to the existing token-usage total and run count:

> **Runs** · 🖥️ `openai · gpt-4o-mini` · `12,345 tokens · $0.04` · `3 runs`

That header renders on **every viewport** (including mobile), so the model is visible everywhere — this was the follow-up to the first pass, which had put it in the desktop-only composer hint row and thus wasn't shown on mobile.

## Changes

- **`RunList.tsx`** takes a `model` (`"providerId/modelId"`) prop and renders a compact, muted `provider · model` indicator — `Cpu` icon, provider dimmed, model emphasized, full id in the tooltip. It truncates (`max-w-[45%]`) on narrow screens so it never pushes the token/run counts off-screen.
- **`App.tsx`** computes the **effective** model — the active agent's own `model`, or the project default (`config.defaults.providerId/modelId`) when the agent is model-less — and passes it to `RunList`. It updates live when the agent is switched.

## Notes

- Single source of truth: the indicator lives only in the RunList header (no duplication in the composer).
- Zero new chrome: reuses the existing header row, so it adds no vertical space and stays clear of the chat scrollback and the input.

## Verification

- Web typecheck, lint, and Prettier: clean.
- Existing `ChatComposer` tests still pass; `RunList` has no test file (no behavior/logic change beyond the presentational indicator).
- Manual visual check of the actual header wasn't run from here — worth a glance in the app (desktop + mobile widths) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)