### PR TITLE
fix(addons): don't force CORS mode on external addon scripts

### DIFF
--- a/apps/server/src/routes/addons.test.ts
+++ b/apps/server/src/routes/addons.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { rewriteAddonHtml } from './addons';
+
+describe('rewriteAddonHtml', () => {
+  it('adds crossorigin to a local script and appends the asset token', () => {
+    const html = '<script src="index.js"></script>';
+    const out = rewriteAddonHtml(html, 'TOKEN');
+    expect(out).toBe(
+      '<script crossorigin="anonymous" src="index.js?at=TOKEN"></script>',
+    );
+  });
+
+  it('adds crossorigin to the SDK script served from an absolute local path', () => {
+    const html = '<script src="/sdk/openaidy-sdk.js"></script>';
+    const out = rewriteAddonHtml(html, 'TOKEN');
+    expect(out).toBe(
+      '<script crossorigin="anonymous" src="/sdk/openaidy-sdk.js?at=TOKEN"></script>',
+    );
+  });
+
+  it('does NOT add crossorigin to an external CDN script', () => {
+    const html = '<script src="https://cdn.tailwindcss.com"></script>';
+    const out = rewriteAddonHtml(html, 'TOKEN');
+    expect(out).toBe('<script src="https://cdn.tailwindcss.com"></script>');
+    expect(out).not.toContain('crossorigin');
+  });
+
+  it('leaves an already-annotated script tag untouched', () => {
+    const html =
+      '<script crossorigin="use-credentials" src="index.js"></script>';
+    const out = rewriteAddonHtml(html, 'TOKEN');
+    expect(out).toContain('crossorigin="use-credentials"');
+    expect(out).not.toContain('crossorigin="anonymous"');
+  });
+
+  it('handles a mix of local and external scripts in one document', () => {
+    const html = [
+      '<script src="https://cdn.tailwindcss.com"></script>',
+      '<script src="/sdk/openaidy-sdk.js"></script>',
+      '<script src="index.js"></script>',
+    ].join('\n');
+    const out = rewriteAddonHtml(html, 'TOKEN');
+    expect(out).toContain(
+      '<script src="https://cdn.tailwindcss.com"></script>',
+    );
+    expect(out).toContain(
+      '<script crossorigin="anonymous" src="/sdk/openaidy-sdk.js?at=TOKEN"></script>',
+    );
+    expect(out).toContain(
+      '<script crossorigin="anonymous" src="index.js?at=TOKEN"></script>',
+    );
+  });
+});

--- a/apps/server/src/routes/addons.ts
+++ b/apps/server/src/routes/addons.ts
@@ -52,18 +52,30 @@ function appendAssetToken(url: string, token: string): string {
 /**
  * Rewrite an addon HTML document so the sandboxed iframe can load its
  * subresources: propagate the asset token onto every local `src`/`href`, and
- * mark scripts `crossorigin="anonymous"` (CORS mode) so strict dev servers
- * don't reject the cross-origin no-cors loads.
+ * mark *local* scripts `crossorigin="anonymous"` (CORS mode) so strict dev
+ * servers don't reject the cross-origin no-cors loads. External scripts
+ * (e.g. the Tailwind Play CDN) are deliberately left alone — forcing CORS
+ * mode on a third-party script whose server doesn't send
+ * `Access-Control-Allow-Origin` makes the browser block the load entirely,
+ * where a plain no-cors `<script src>` (the default) would have loaded fine.
  */
-function rewriteAddonHtml(html: string, token: string): string {
+export function rewriteAddonHtml(html: string, token: string): string {
   const withTokens = html.replace(
     /\b(src|href)=("|')(.*?)\2/gi,
     (_match, attr: string, quote: string, url: string) =>
       `${attr}=${quote}${appendAssetToken(url, token)}${quote}`,
   );
   return withTokens.replace(
-    /<script(?![^>]*\bcrossorigin\b)([^>]*\bsrc=)/gi,
-    '<script crossorigin="anonymous"$1',
+    /<script([^>]*?)\bsrc=("|')(.*?)\2([^>]*)>/gi,
+    (fullMatch, before: string, quote: string, url: string, after: string) => {
+      if (/\bcrossorigin\b/i.test(before) || /\bcrossorigin\b/i.test(after)) {
+        return fullMatch;
+      }
+      const isExternal =
+        /^(https?:)?\/\//i.test(url) || /^(data:|blob:)/i.test(url);
+      if (isExternal) return fullMatch;
+      return `<script crossorigin="anonymous"${before}src=${quote}${url}${quote}${after}>`;
+    },
   );
 }
 
@@ -559,11 +571,15 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
       // as cross-site. A classic `<script src>` tag is fetched in `no-cors`
       // mode by default, and strict dev servers reject cross-origin no-cors
       // script loads with 403 (Vite's rejectNoCorsRequestMiddleware —
-      // GHSA-4v9v-hfq4-rm2v). To let the addon's scripts (and the SDK) load,
-      // we rewrite `<script src>` tags to request in CORS mode by adding
-      // `crossorigin="anonymous"`. The responses already carry
+      // GHSA-4v9v-hfq4-rm2v). To let the addon's LOCAL scripts (and the SDK)
+      // load, we rewrite their `<script src>` tags to request in CORS mode by
+      // adding `crossorigin="anonymous"`. Those responses already carry
       // `Access-Control-Allow-Origin: *`, so the CORS check passes. This is
       // a no-op in production (the static handler still sends ACAO: *).
+      // EXTERNAL scripts (e.g. the Tailwind Play CDN) are left in the default
+      // no-cors mode instead — cdn.tailwindcss.com doesn't send an ACAO
+      // header, so forcing CORS mode on it would make the browser block the
+      // load outright rather than execute it opaquely.
       let payload: string | Buffer = fs.readFileSync(resolved);
       if (ext === '.html') {
         // Propagate the (validated) asset token onto every local subresource


### PR DESCRIPTION
## Summary

- `rewriteAddonHtml` in `apps/server/src/routes/addons.ts` stamps `crossorigin="anonymous"` onto every `<script src>` tag in an addon's `index.html` — that forces the browser into CORS mode, which requires the response to carry `Access-Control-Allow-Origin`.
- Since PR #419 auto-injects the Tailwind Play CDN `<script src="https://cdn.tailwindcss.com">` tag into every new addon, that script now gets the same treatment — but `cdn.tailwindcss.com` doesn't send an ACAO header, so the browser blocks the load outright:
  ```
  Access to script at 'https://cdn.tailwindcss.com/' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
  ```
- This predates the Tailwind CDN feature: the crossorigin rewrite was written when every script an addon loaded was local (the SDK, `index.js`), both served with `Access-Control-Allow-Origin: *` from OpenAidy's own static handler. It never anticipated an external script.

## Changes

- `rewriteAddonHtml` now only adds `crossorigin="anonymous"` to local/relative script sources. Absolute external URLs (the Tailwind CDN, or any future external script) are left untouched, so they load in their default no-cors mode — which executes fine without any CORS header, same as any ordinary third-party `<script>` tag on the web.
- Exported `rewriteAddonHtml` for direct unit testing.
- Added `apps/server/src/routes/addons.test.ts` (5 cases): local script gets `crossorigin` + asset token, SDK absolute-path script gets it too, the Tailwind CDN script does NOT get it, an already-annotated script tag is left alone, and a mixed-document case with all three.

## Verification

- New tests: 5/5 pass, including the exact regression scenario.
- Full server suite: 156 files / 3195 tests passed (1 pre-existing skip), typecheck clean.

## Test plan

- [ ] Create/open an addon and confirm the Tailwind CDN script loads without a CORS error in the browser console
- [ ] Confirm the addon's own `index.js` and the SDK script still load (crossorigin still applied to those)