### PR TITLE
fix(addons): stop leaking the master auth token into addon iframes

### DIFF
--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -18,7 +18,6 @@
   var SDK_VERSION = '0.3.0';
   console.log('[OpenAidy SDK] v' + SDK_VERSION + ' loaded');
 
-  let _token = null;
   let _apiBase = null;
   let _nonce = null;
   let _ready = false;
@@ -57,7 +56,6 @@
     if (!msg || typeof msg !== 'object') return;
 
     if (msg.type === 'OPENAIDY_INIT') {
-      _token = msg.token ?? null;
       _apiBase = msg.apiBase ?? null;
       _nonce = msg.nonce ?? null;
       _ready = true;

--- a/apps/web/src/components/pages/AddonViewPage.test.tsx
+++ b/apps/web/src/components/pages/AddonViewPage.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@solidjs/testing-library';
+import { AddonViewPage } from './AddonViewPage';
+import type { AddonRecord } from '../../lib/api';
+
+vi.mock('../../lib/api', () => ({
+  getAddonAssetToken: vi.fn(),
+  refreshAddonToken: vi.fn(),
+}));
+vi.mock('../../lib/auth-token', () => ({
+  resolveToken: vi.fn(),
+}));
+
+import { getAddonAssetToken, refreshAddonToken } from '../../lib/api';
+import { resolveToken } from '../../lib/auth-token';
+
+const ADDON: AddonRecord = {
+  id: '1',
+  addonId: 'weather-widget',
+  name: 'Weather Widget',
+  version: '1.0.0',
+  status: 'enabled',
+  installedAt: new Date(0).toISOString(),
+  installedBy: 'admin',
+  manifest: {},
+  permissions: [],
+};
+
+const ADDON_TOKEN_KEY = `openaidy_addon_token:${ADDON.addonId}`;
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Simulate a postMessage as if it came from `iframe`'s own contentWindow. */
+function postFromIframe(iframe: HTMLIFrameElement, data: unknown) {
+  window.dispatchEvent(
+    new MessageEvent('message', { data, source: iframe.contentWindow }),
+  );
+}
+
+describe('AddonViewPage — token isolation from the sandboxed iframe', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(ADDON_TOKEN_KEY, 'ADDON_SCOPED_TOKEN');
+    vi.mocked(getAddonAssetToken).mockResolvedValue({
+      token: 'ASSET_TOKEN',
+      expiresIn: 600_000,
+    });
+    // The user is logged in with a real master token — the point of these
+    // tests is that this token must never reach the iframe or be used to
+    // authorize an addon-proxy request.
+    vi.mocked(resolveToken).mockReturnValue('MASTER_ADMIN_TOKEN');
+    vi.mocked(refreshAddonToken).mockResolvedValue({
+      accessToken: 'ADDON_SCOPED_TOKEN',
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function renderAndGetIframe() {
+    const { findByTitle } = render(() => <AddonViewPage addon={ADDON} />);
+    const iframe = (await findByTitle(ADDON.name)) as HTMLIFrameElement;
+    // jsdom gives every rendered iframe a real contentWindow we can spy on.
+    return iframe;
+  }
+
+  it('never includes the master token in the OPENAIDY_INIT message', async () => {
+    const iframe = await renderAndGetIframe();
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+
+    iframe.dispatchEvent(new Event('load'));
+
+    expect(postMessage).toHaveBeenCalled();
+    const [payload] = postMessage.mock.calls[0]!;
+    expect(payload).toMatchObject({ type: 'OPENAIDY_INIT' });
+    expect(payload).not.toHaveProperty('token');
+  });
+
+  it('authorizes an allowed addon-proxy request with the addon-scoped token, never the master token', async () => {
+    const iframe = await renderAndGetIframe();
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+    iframe.dispatchEvent(new Event('load'));
+    const initPayload = postMessage.mock.calls[0]![0] as { nonce: string };
+
+    postFromIframe(iframe, {
+      type: 'OPENAIDY_REQUEST',
+      requestId: 'req-1',
+      method: 'GET',
+      path: '/api/addon-proxy/notes',
+      nonce: initPayload.nonce,
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const [, init] = vi.mocked(fetch).mock.calls[0]!;
+    const headers = init!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer ADDON_SCOPED_TOKEN');
+    expect(headers.Authorization).not.toContain('MASTER_ADMIN_TOKEN');
+  });
+
+  it('fails closed (401, no fetch) when the addon-scoped token is missing — no fallback to the master token', async () => {
+    // Prevent onMount's auto-heal (refreshAddonToken) from silently
+    // repopulating the token — this test wants it to stay genuinely absent.
+    vi.mocked(refreshAddonToken).mockRejectedValue(new Error('unavailable'));
+    localStorage.removeItem(ADDON_TOKEN_KEY);
+    const iframe = await renderAndGetIframe();
+    localStorage.removeItem(ADDON_TOKEN_KEY);
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+    iframe.dispatchEvent(new Event('load'));
+    const initPayload = postMessage.mock.calls[0]![0] as { nonce: string };
+    postMessage.mockClear();
+
+    postFromIframe(iframe, {
+      type: 'OPENAIDY_REQUEST',
+      requestId: 'req-2',
+      method: 'GET',
+      path: '/api/addon-proxy/notes',
+      nonce: initPayload.nonce,
+    });
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'OPENAIDY_RESPONSE', status: 401 }),
+        '*',
+      ),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request outside the addon-proxy allowlist without ever touching fetch or the master token', async () => {
+    const iframe = await renderAndGetIframe();
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+    iframe.dispatchEvent(new Event('load'));
+    const initPayload = postMessage.mock.calls[0]![0] as { nonce: string };
+    postMessage.mockClear();
+
+    postFromIframe(iframe, {
+      type: 'OPENAIDY_REQUEST',
+      requestId: 'req-3',
+      method: 'GET',
+      path: '/api/agents',
+      nonce: initPayload.nonce,
+    });
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'OPENAIDY_RESPONSE', status: 403 }),
+        '*',
+      ),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores a message whose source is not this addon's own iframe, even with type ADDON_READY", async () => {
+    const iframe = await renderAndGetIframe();
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+    iframe.dispatchEvent(new Event('load'));
+    postMessage.mockClear();
+
+    // No `source` set — simulates a message from an unrelated frame/window,
+    // which must not trigger sendInit() again.
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { type: 'ADDON_READY' } }),
+    );
+
+    // Give any (incorrect) async handling a tick to run, then assert nothing happened.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('honors ADDON_READY from the real iframe with no nonce required', async () => {
+    const iframe = await renderAndGetIframe();
+    const postMessage = vi.spyOn(iframe.contentWindow!, 'postMessage');
+
+    postFromIframe(iframe, { type: 'ADDON_READY' });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'OPENAIDY_INIT' }),
+      '*',
+    );
+  });
+});

--- a/apps/web/src/components/pages/AddonViewPage.tsx
+++ b/apps/web/src/components/pages/AddonViewPage.tsx
@@ -96,10 +96,15 @@ export function AddonViewPage(props: Props) {
     setTimeout(() => setReloading(false), 50);
   };
 
+  // The iframe never receives the user's auth token — it's a sandboxed,
+  // opaque-origin context that can run arbitrary (including LLM-generated)
+  // script, so anything posted into it must be assumed readable by the
+  // addon itself. All authenticated calls the addon triggers are proxied by
+  // this component (see handleMessage below) using a short-lived,
+  // addon-scoped token that never crosses into the iframe.
   const sendInit = () => {
-    const token = resolveToken();
     iframeRef?.contentWindow?.postMessage(
-      { type: 'OPENAIDY_INIT', token, apiBase: SERVER_BASE, nonce },
+      { type: 'OPENAIDY_INIT', apiBase: SERVER_BASE, nonce },
       '*',
     );
   };
@@ -124,6 +129,12 @@ export function AddonViewPage(props: Props) {
 
   // Bridge: proxy API requests from the iframe to the real backend
   const handleMessage = async (event: MessageEvent) => {
+    // The sandboxed iframe has an opaque origin, so `event.origin` can't be
+    // checked. Compare `event.source` — the iframe's actual window object —
+    // instead: this rejects messages from any other frame/tab up front, for
+    // every message type, including ADDON_READY (which necessarily arrives
+    // before the addon has a nonce to echo back).
+    if (event.source !== iframeRef?.contentWindow) return;
     const msg = event.data as Record<string, unknown>;
     if (typeof msg !== 'object') return;
     // Addon signals it is ready to receive OPENAIDY_INIT (timing safety)
@@ -178,13 +189,15 @@ export function AddonViewPage(props: Props) {
       return;
     }
 
-    // Use addon-scoped token for addon-proxy routes, user token for everything else
-    const isAddonProxy = reqPath.startsWith('/api/addon-proxy/');
+    // Every allowed path is an addon-proxy route (see ALLOWED_ROUTES above),
+    // so this always requires the short-lived, addon-scoped token — never
+    // the user's own auth token. Fail closed if it's missing; there is no
+    // fallback to a broader credential.
     const addonToken = localStorage.getItem(
       `openaidy_addon_token:${props.addon.addonId}`,
     );
 
-    if (isAddonProxy && !addonToken) {
+    if (!addonToken) {
       iframeRef?.contentWindow?.postMessage(
         {
           type: 'OPENAIDY_RESPONSE',
@@ -199,13 +212,12 @@ export function AddonViewPage(props: Props) {
       return;
     }
 
-    const token = isAddonProxy ? addonToken : resolveToken();
     try {
       const res = await fetch(`${SERVER_BASE}${reqPath}`, {
         method: method ?? 'GET',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Authorization: `Bearer ${addonToken}`,
         },
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       });


### PR DESCRIPTION
Fixes #427, #428, #429.

## Summary

All three sit in the same code path (`AddonViewPage.tsx`'s postMessage bridge to the sandboxed addon iframe), so they're fixed together in one branch/PR for easy manual testing.

### #427 — full admin token posted into every addon's sandboxed iframe (Critical)

`sendInit()` posted the user's full admin-scope auth token into every addon's iframe via `postMessage`. The iframe is `sandbox="allow-scripts allow-forms"` (opaque origin, but scripts run), so any addon's own JS — LLM-generated, not a trusted-developer artifact — could add its own `window.addEventListener('message')` and read the token straight off the `OPENAIDY_INIT` payload, then exfiltrate it through the addon's own legitimate `externalDomains` (CSP `connect-src`). One addon = full instance takeover.

Turns out the token was never even used by the SDK itself — `_token` in `openaidy-sdk.js` was assigned from the message and never read anywhere else. Pure dead exposure with zero functional purpose.

**Fix:** `sendInit()` no longer includes `token` at all. Removed the now-fully-dead `_token` variable from `openaidy-sdk.js`.

### #428 — dead-code fallback still using the master token (High)

`handleMessage`'s addon-proxy branch had `const token = isAddonProxy ? addonToken : resolveToken();` — a fallback to the master token for "non-addon-proxy" requests. It's unreachable today only because `ALLOWED_ROUTES` happens to allowlist just `/api/addon-proxy/*`; one future edit to that allowlist would silently reactivate full-master-token access from inside every addon's sandbox.

**Fix:** removed the fallback entirely. Every proxied request now requires the addon-scoped token and fails closed (401) if it's missing — no other credential path exists to fall back to.

### #429 — `ADDON_READY` had no trust check, unlike every other message type (Medium)

`OPENAIDY_REQUEST` and `ADDON_CSP_VIOLATION` both validate a nonce before acting; `ADDON_READY` didn't (it can't — it fires before the addon has received a nonce to echo back), making it the one inconsistent case.

**Fix:** added a single check at the top of `handleMessage`: reject any message whose `event.source` isn't this component's own `iframeRef.contentWindow`. This works even though the iframe's origin is opaque, since `event.source` is a window-object identity check, not an origin string comparison — and it now covers every message type uniformly, including `ADDON_READY`, instead of relying only on the nonce.

## Verification

- New `apps/web/src/components/pages/AddonViewPage.test.tsx` (6 cases): `OPENAIDY_INIT` never carries a token; an addon-proxy request is authorized with the addon-scoped token and never the (mocked, present) master token; a missing addon token fails closed with 401 and never falls back; a request outside the allowlist is rejected without ever calling `fetch`; a message with no/wrong `event.source` is ignored even if typed `ADDON_READY`; a genuine same-iframe `ADDON_READY` still triggers `OPENAIDY_INIT` with no nonce required.
- Full web suite: 41 files / 379 passed (3 pre-existing skips), typecheck clean.
- Full server addon-related suite: 16 files / 291 passed (unaffected by the `openaidy-sdk.js` change, confirmed).

## Test plan

- [ ] Open any addon and confirm it still connects (`OpenAidy.ready()` fires, SDK calls work)
- [ ] In the addon iframe's devtools console, confirm no `OPENAIDY_INIT` postMessage payload ever contains a `token` field
- [ ] Disable/re-enable an addon (clears its scoped token) and confirm SDK calls fail with a clear "Addon token not found" message rather than silently using another credential
- [ ] Confirm a normal addon reload/re-init cycle (`ADDON_READY` → `OPENAIDY_INIT`) still works end-to-end