### PR TITLE
feat(usage): stacked bar chart on Usage page, broken down by model

### DIFF
--- a/apps/server/src/usage/aggregate.test.ts
+++ b/apps/server/src/usage/aggregate.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateUsage, dayOf } from './aggregate';
+import type { UsageRunRow } from '@openaidy/db';
+
+function row(overrides: Partial<UsageRunRow>): UsageRunRow {
+  return {
+    createdAt: '2026-01-01T10:00:00.000Z',
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    promptTokens: 100,
+    completionTokens: 50,
+    totalTokens: 150,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    cost: 0.01,
+    ...overrides,
+  };
+}
+
+describe('dayOf', () => {
+  it('extracts the UTC calendar day', () => {
+    expect(dayOf('2026-01-15T23:59:59.000Z')).toBe('2026-01-15');
+  });
+});
+
+describe('aggregateUsage', () => {
+  it('returns zeroed totals for no rows', () => {
+    const report = aggregateUsage([]);
+    expect(report.totals.runCount).toBe(0);
+    expect(report.totals.totalTokens).toBe(0);
+    expect(report.totals.hasCost).toBe(false);
+    expect(report.byDay).toEqual([]);
+    expect(report.byProvider).toEqual([]);
+    expect(report.byModel).toEqual([]);
+  });
+
+  it('sums overall totals across rows', () => {
+    const report = aggregateUsage([
+      row({
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        cost: 0.01,
+      }),
+      row({
+        promptTokens: 200,
+        completionTokens: 60,
+        totalTokens: 260,
+        cost: 0.02,
+      }),
+    ]);
+    expect(report.totals.runCount).toBe(2);
+    expect(report.totals.promptTokens).toBe(300);
+    expect(report.totals.completionTokens).toBe(110);
+    expect(report.totals.totalTokens).toBe(410);
+    expect(report.totals.cost).toBeCloseTo(0.03, 10);
+    expect(report.totals.hasCost).toBe(true);
+  });
+
+  it('groups by day sorted ascending', () => {
+    const report = aggregateUsage([
+      row({ createdAt: '2026-01-02T10:00:00.000Z', totalTokens: 10 }),
+      row({ createdAt: '2026-01-01T10:00:00.000Z', totalTokens: 20 }),
+      row({ createdAt: '2026-01-01T18:00:00.000Z', totalTokens: 5 }),
+    ]);
+    expect(report.byDay.map((d) => d.day)).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+    ]);
+    expect(report.byDay[0]!.totalTokens).toBe(25);
+    expect(report.byDay[0]!.runCount).toBe(2);
+  });
+
+  it('groups by provider and model sorted by total tokens desc', () => {
+    const report = aggregateUsage([
+      row({ providerId: 'openai', modelId: 'gpt-4o', totalTokens: 100 }),
+      row({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4',
+        totalTokens: 500,
+      }),
+      row({ providerId: 'openai', modelId: 'gpt-4o', totalTokens: 50 }),
+    ]);
+    expect(report.byProvider[0]!.providerId).toBe('anthropic');
+    expect(report.byModel[0]!.modelId).toBe('claude-sonnet-4');
+    const openaiModel = report.byModel.find((m) => m.modelId === 'gpt-4o');
+    expect(openaiModel!.totalTokens).toBe(150);
+    expect(openaiModel!.runCount).toBe(2);
+  });
+
+  it('marks hasCost false when no row has a cost', () => {
+    const report = aggregateUsage([row({ cost: null }), row({ cost: null })]);
+    expect(report.totals.hasCost).toBe(false);
+    expect(report.totals.cost).toBe(0);
+  });
+
+  it('accumulates cache tokens', () => {
+    const report = aggregateUsage([
+      row({ cacheReadTokens: 40, cacheCreationTokens: 10 }),
+      row({ cacheReadTokens: 60, cacheCreationTokens: 5 }),
+    ]);
+    expect(report.totals.cacheReadTokens).toBe(100);
+    expect(report.totals.cacheCreationTokens).toBe(15);
+  });
+
+  describe('byDayByModel', () => {
+    it('returns an empty array when there are no rows', () => {
+      expect(aggregateUsage([]).byDayByModel).toEqual([]);
+    });
+
+    it('produces one entry per (day, model) pair with summed tokens', () => {
+      const report = aggregateUsage([
+        row({
+          createdAt: '2026-01-01T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 100,
+        }),
+        row({
+          createdAt: '2026-01-01T14:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 50,
+        }),
+        row({
+          createdAt: '2026-01-01T20:00:00.000Z',
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4',
+          totalTokens: 200,
+        }),
+        row({
+          createdAt: '2026-01-02T09:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 30,
+        }),
+      ]);
+
+      // 3 distinct (day, model) pairs.
+      expect(report.byDayByModel).toHaveLength(3);
+
+      const find = (day: string, modelId: string) =>
+        report.byDayByModel.find(
+          (e) => e.day === day && e.modelId === modelId,
+        );
+
+      const gptDay1 = find('2026-01-01', 'gpt-4o');
+      expect(gptDay1?.totalTokens).toBe(150);
+      expect(gptDay1?.runCount).toBe(2);
+      expect(gptDay1?.providerId).toBe('openai');
+
+      const claudeDay1 = find('2026-01-01', 'claude-sonnet-4');
+      expect(claudeDay1?.totalTokens).toBe(200);
+      expect(claudeDay1?.runCount).toBe(1);
+
+      const gptDay2 = find('2026-01-02', 'gpt-4o');
+      expect(gptDay2?.totalTokens).toBe(30);
+      expect(gptDay2?.runCount).toBe(1);
+    });
+
+    it('sorts byDayByModel by day ascending', () => {
+      const report = aggregateUsage([
+        row({ createdAt: '2026-01-03T10:00:00.000Z', totalTokens: 10 }),
+        row({ createdAt: '2026-01-01T10:00:00.000Z', totalTokens: 20 }),
+        row({ createdAt: '2026-01-02T10:00:00.000Z', totalTokens: 30 }),
+      ]);
+      expect(report.byDayByModel.map((e) => e.day)).toEqual([
+        '2026-01-01',
+        '2026-01-02',
+        '2026-01-03',
+      ]);
+    });
+
+    it('per-day-by-model totals sum to the per-day total', () => {
+      // This invariant is what makes the stacked-bar chart honest: the
+      // stack height for a given day must equal the bar height for that
+      // day in the (single-color) totals view.
+      const report = aggregateUsage([
+        row({
+          createdAt: '2026-01-01T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 100,
+        }),
+        row({
+          createdAt: '2026-01-01T14:00:00.000Z',
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4',
+          totalTokens: 50,
+        }),
+        row({
+          createdAt: '2026-01-02T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 30,
+        }),
+      ]);
+
+      const dayTotal = (day: string) =>
+        report.byDayByModel
+          .filter((e) => e.day === day)
+          .reduce((s, e) => s + e.totalTokens, 0);
+      const byDay = (day: string) =>
+        report.byDay.find((d) => d.day === day)?.totalTokens ?? 0;
+
+      expect(dayTotal('2026-01-01')).toBe(byDay('2026-01-01'));
+      expect(dayTotal('2026-01-02')).toBe(byDay('2026-01-02'));
+    });
+  });
+});

--- a/apps/server/src/usage/aggregate.ts
+++ b/apps/server/src/usage/aggregate.ts
@@ -1,0 +1,172 @@
+/**
+ * Usage aggregation helpers.
+ *
+ * Pure functions that roll up per-run usage rows into totals and
+ * breakdowns by day, provider, model, and day×model. Grouping is done
+ * here (rather than in SQL) so the queries stay portable across SQLite
+ * and Postgres.
+ */
+
+import type { UsageRunRow } from '@openaidy/db';
+
+export type UsageTotals = {
+  runCount: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  /** Sum of known run costs (USD). */
+  cost: number;
+  /** True when at least one run contributed a known cost. */
+  hasCost: boolean;
+};
+
+export type UsageByDay = UsageTotals & { day: string };
+export type UsageByProvider = UsageTotals & { providerId: string };
+export type UsageByModel = UsageTotals & {
+  providerId: string;
+  modelId: string;
+};
+/**
+ * Per-day × per-model rollup. Powers the stacked-bar usage chart on the
+ * dashboard, which needs to know exactly how much each model contributed
+ * on each day (not just the per-day total or the per-model total).
+ */
+export type UsageByDayAndModel = UsageTotals & {
+  day: string;
+  providerId: string;
+  modelId: string;
+};
+
+export type UsageReport = {
+  totals: UsageTotals;
+  byDay: UsageByDay[];
+  byProvider: UsageByProvider[];
+  byModel: UsageByModel[];
+  /** Per-day × per-model breakdown. Empty when no rows. */
+  byDayByModel: UsageByDayAndModel[];
+};
+
+function emptyTotals(): UsageTotals {
+  return {
+    runCount: 0,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    cost: 0,
+    hasCost: false,
+  };
+}
+
+function addRow(target: UsageTotals, row: UsageRunRow): void {
+  target.runCount += 1;
+  target.promptTokens += row.promptTokens;
+  target.completionTokens += row.completionTokens;
+  target.totalTokens += row.totalTokens;
+  target.cacheReadTokens += row.cacheReadTokens;
+  target.cacheCreationTokens += row.cacheCreationTokens;
+  if (row.cost !== null) {
+    target.cost += row.cost;
+    target.hasCost = true;
+  }
+}
+
+/** The UTC calendar day (YYYY-MM-DD) an ISO timestamp falls on. */
+export function dayOf(isoTimestamp: string): string {
+  return isoTimestamp.slice(0, 10);
+}
+
+/**
+ * Roll up usage rows into overall totals plus day/provider/model/day×model
+ * breakdowns. Breakdown arrays are sorted: days ascending; provider/model
+ * by descending total tokens; byDayByModel by day ascending (within-day
+ * ordering is unspecified — renderers sort segments per bar).
+ */
+export function aggregateUsage(rows: UsageRunRow[]): UsageReport {
+  const totals = emptyTotals();
+  const byDay = new Map<string, UsageByDay>();
+  const byProvider = new Map<string, UsageByProvider>();
+  const byModel = new Map<string, UsageByModel>();
+  // Nested map keeps lookups O(1) while we still process rows in a single
+  // pass. Outer key = day, inner key = `${providerId}/${modelId}`.
+  const byDayByModel = new Map<string, Map<string, UsageByDayAndModel>>();
+
+  for (const row of rows) {
+    addRow(totals, row);
+
+    const day = dayOf(row.createdAt);
+    let dayEntry = byDay.get(day);
+    if (!dayEntry) {
+      dayEntry = { ...emptyTotals(), day };
+      byDay.set(day, dayEntry);
+    }
+    addRow(dayEntry, row);
+
+    let providerEntry = byProvider.get(row.providerId);
+    if (!providerEntry) {
+      providerEntry = { ...emptyTotals(), providerId: row.providerId };
+      byProvider.set(row.providerId, providerEntry);
+    }
+    addRow(providerEntry, row);
+
+    const modelKey = `${row.providerId}/${row.modelId}`;
+    let modelEntry = byModel.get(modelKey);
+    if (!modelEntry) {
+      modelEntry = {
+        ...emptyTotals(),
+        providerId: row.providerId,
+        modelId: row.modelId,
+      };
+      byModel.set(modelKey, modelEntry);
+    }
+    addRow(modelEntry, row);
+
+    let dayMap = byDayByModel.get(day);
+    if (!dayMap) {
+      dayMap = new Map();
+      byDayByModel.set(day, dayMap);
+    }
+    let dayModelEntry = dayMap.get(modelKey);
+    if (!dayModelEntry) {
+      dayModelEntry = {
+        ...emptyTotals(),
+        day,
+        providerId: row.providerId,
+        modelId: row.modelId,
+      };
+      dayMap.set(modelKey, dayModelEntry);
+    }
+    addRow(dayModelEntry, row);
+  }
+
+  // Flatten the nested day×model map. Sort by day ascending; within-day
+  // order doesn't matter for the chart (the renderer sorts segments by
+  // totalTokens desc per bar), but a stable day-first order keeps the
+  // payload diffable across requests and easier to scan in logs.
+  const byDayByModelList: UsageByDayAndModel[] = [];
+  const sortedDays = [...byDayByModel.keys()].sort((a, b) =>
+    a.localeCompare(b),
+  );
+  for (const day of sortedDays) {
+    const dayMap = byDayByModel.get(day);
+    if (!dayMap) continue;
+    for (const entry of dayMap.values()) {
+      byDayByModelList.push(entry);
+    }
+  }
+
+  return {
+    totals,
+    byDay: [...byDay.values()].sort((a, b) => a.day.localeCompare(b.day)),
+    byProvider: [...byProvider.values()].sort(
+      (a, b) => b.totalTokens - a.totalTokens,
+    ),
+    byModel: [...byModel.values()].sort(
+      (a, b) => b.totalTokens - a.totalTokens,
+    ),
+    byDayByModel: byDayByModelList,
+  };
+}

--- a/apps/web/src/components/pages/UsagePage.tsx
+++ b/apps/web/src/components/pages/UsagePage.tsx
@@ -1,0 +1,417 @@
+import { createResource, createSignal, For, Show } from 'solid-js';
+import { Layout } from './Layout';
+import { getUsage } from '../../lib/api';
+import type {
+  UsageByDay,
+  UsageByDayAndModel,
+  UsageByModel,
+  UsageReport,
+} from '../../lib/types';
+import { formatNumber, formatCost } from '../../lib/usage-format';
+
+type RangePreset = '7d' | '30d' | '90d' | 'all';
+
+const RANGE_LABELS: Record<RangePreset, string> = {
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  '90d': 'Last 90 days',
+  all: 'All time',
+};
+
+/** Compute the ISO `from` bound for a preset (undefined for 'all'). */
+function fromForPreset(preset: RangePreset): string | undefined {
+  if (preset === 'all') return undefined;
+  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+  const now = new Date();
+  const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  return from.toISOString();
+}
+
+/**
+ * Stable color palette for the stacked-bar chart. Models are assigned
+ * colors by descending totalTokens (top spender = palette[0], second =
+ * palette[1], ...). The palette wraps after 10 entries; if a project has
+ * more than 10 models the chart becomes hard to read but stays honest —
+ * every model still gets a visible segment and a legend entry.
+ *
+ * Why Tailwind classes and not raw hex: the rest of this file already
+ * uses Tailwind classes for SVG fill (`fill-primary`), and the same
+ * classes work for the legend swatches below.
+ */
+const CHART_PALETTE = [
+  'fill-blue-500',
+  'fill-emerald-500',
+  'fill-amber-500',
+  'fill-violet-500',
+  'fill-rose-500',
+  'fill-cyan-500',
+  'fill-orange-500',
+  'fill-lime-500',
+  'fill-pink-500',
+  'fill-indigo-500',
+] as const;
+
+const FILL_OVERFLOW = 'fill-gray-300 dark:fill-gray-600';
+
+/** Stable model-key → CSS-class assignment, sorted by totalTokens desc. */
+function buildModelColorMap(byModel: UsageByModel[]): Map<string, string> {
+  const map = new Map<string, string>();
+  byModel.forEach((row, i) => {
+    const key = `${row.providerId}/${row.modelId}`;
+    map.set(key, CHART_PALETTE[i % CHART_PALETTE.length] ?? FILL_OVERFLOW);
+  });
+  return map;
+}
+
+/**
+ * Index `byDayByModel` rows by day so each bar can find its segments in
+ * O(1). Inner key is the model key so we can pull total tokens per model
+ * per day without scanning.
+ */
+function indexSegmentsByDay(
+  rows: UsageByDayAndModel[],
+): Map<string, Map<string, UsageByDayAndModel>> {
+  const out = new Map<string, Map<string, UsageByDayAndModel>>();
+  for (const row of rows) {
+    const modelKey = `${row.providerId}/${row.modelId}`;
+    let dayMap = out.get(row.day);
+    if (!dayMap) {
+      dayMap = new Map();
+      out.set(row.day, dayMap);
+    }
+    dayMap.set(modelKey, row);
+  }
+  return out;
+}
+
+/**
+ * Stacked daily token-usage chart. Each bar = one day; bar height = that
+ * day's total tokens; bar segments = per-model contributions, colored
+ * stably by rank (top model = palette[0]). Replaces the previous
+ * single-color chart so the dashboard shows *which* models drove usage,
+ * not just the magnitude.
+ *
+ * Pure inline SVG — no chart dependency, matches the rest of the page.
+ */
+function StackedDailyChart(props: {
+  byDay: UsageByDay[];
+  byDayByModel: UsageByDayAndModel[];
+  byModel: UsageByModel[];
+}) {
+  const segmentsByDay = () => indexSegmentsByDay(props.byDayByModel);
+  const colorByModel = () => buildModelColorMap(props.byModel);
+  const max = () => Math.max(1, ...props.byDay.map((d) => d.totalTokens));
+
+  const width = 720;
+  const height = 180;
+  const padBottom = 22;
+  const padTop = 8;
+  const gap = 3;
+  // Minimum visible segment height (px). Keeps tiny contributions
+  // hoverable; the tooltip shows the real (unfloored) value.
+  const minSegH = 0.5;
+
+  const barWidth = () => {
+    const n = props.byDay.length || 1;
+    return Math.max(2, (width - gap * (n - 1)) / n);
+  };
+
+  // Show at most ~8 date labels to avoid collisions.
+  const labelEvery = () => Math.max(1, Math.ceil(props.byDay.length / 8));
+
+  return (
+    <Show
+      when={props.byDay.length > 0}
+      fallback={
+        <div class="flex items-center justify-center h-44 text-text-tertiary text-sm">
+          No usage in this range
+        </div>
+      }
+    >
+      <div class="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          class="w-full min-w-[480px]"
+          role="img"
+          aria-label="Daily token usage by model"
+        >
+          <For each={props.byDay}>
+            {(day, i) => {
+              const bw = barWidth();
+              const x = i() * (bw + gap);
+              const usableH = height - padBottom - padTop;
+              const dayTotal = Math.max(1, day.totalTokens);
+              const dayMap = segmentsByDay().get(day.day);
+              // Within-day ordering: largest segment at the bottom of the
+              // bar so the total stays anchored and small contributions
+              // sit on top. Tie-break by model key for stable renders.
+              const segments = dayMap
+                ? [...dayMap.values()].sort((a, b) => {
+                    if (b.totalTokens !== a.totalTokens) {
+                      return b.totalTokens - a.totalTokens;
+                    }
+                    return `${a.providerId}/${a.modelId}`.localeCompare(
+                      `${b.providerId}/${b.modelId}`,
+                    );
+                  })
+                : [];
+
+              // `cursorY` tracks the top edge of the next segment to draw
+              // — we paint from the baseline upward.
+              let cursorY = height - padBottom;
+              const showLabel = i() % labelEvery() === 0;
+              return (
+                <>
+                  <For each={segments}>
+                    {(seg) => {
+                      const modelKey = `${seg.providerId}/${seg.modelId}`;
+                      const rawH = (seg.totalTokens / dayTotal) * usableH;
+                      const h = Math.max(minSegH, rawH);
+                      const y = cursorY - h;
+                      cursorY = y;
+                      const color =
+                        colorByModel().get(modelKey) ?? FILL_OVERFLOW;
+                      const pct = (
+                        (seg.totalTokens / dayTotal) *
+                        100
+                      ).toFixed(1);
+                      return (
+                        <rect x={x} y={y} width={bw} height={h} class={color}>
+                          <title>
+                            {day.day} · {modelKey}:{' '}
+                            {formatNumber(seg.totalTokens)} tokens ({pct}% of
+                            day)
+                          </title>
+                        </rect>
+                      );
+                    }}
+                  </For>
+                  <Show when={showLabel}>
+                    <text
+                      x={x + bw / 2}
+                      y={height - 6}
+                      text-anchor="middle"
+                      class="fill-text-tertiary"
+                      style={{ 'font-size': '9px' }}
+                    >
+                      {day.day.slice(5)}
+                    </text>
+                  </Show>
+                </>
+              );
+            }}
+          </For>
+        </svg>
+      </div>
+      {/* Legend — one row per model in rank order, color swatch + key +
+          total tokens across the range. Wraps on narrow viewports. */}
+      <Show when={props.byModel.length > 0}>
+        <ul class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-text-secondary">
+          <For each={props.byModel}>
+            {(row) => {
+              const key = `${row.providerId}/${row.modelId}`;
+              const color = colorByModel().get(key) ?? FILL_OVERFLOW;
+              return (
+                <li class="flex items-center gap-1.5">
+                  <span
+                    class={`inline-block w-3 h-3 rounded-sm ${color}`}
+                    aria-hidden="true"
+                  />
+                  <span class="tabular-nums">{key}</span>
+                  <span class="text-text-tertiary tabular-nums">
+                    {formatNumber(row.totalTokens)}
+                  </span>
+                </li>
+              );
+            }}
+          </For>
+        </ul>
+      </Show>
+    </Show>
+  );
+}
+
+function StatTile(props: { label: string; value: string; hint?: string }) {
+  return (
+    <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+      <div class="text-xs text-text-tertiary">{props.label}</div>
+      <div class="mt-1 text-2xl font-semibold text-text-primary tabular-nums">
+        {props.value}
+      </div>
+      <Show when={props.hint}>
+        <div class="mt-0.5 text-xs text-text-tertiary">{props.hint}</div>
+      </Show>
+    </div>
+  );
+}
+
+export function UsagePage() {
+  const [range, setRange] = createSignal<RangePreset>('30d');
+
+  const [report] = createResource<UsageReport | null, RangePreset>(
+    range,
+    async (preset) => {
+      const from = fromForPreset(preset);
+      const result = await getUsage(from ? { from } : {});
+      if ('error' in result) return null;
+      return result;
+    },
+  );
+
+  const totals = () => report()?.totals;
+
+  return (
+    <Layout
+      title="Usage"
+      description="Token usage and estimated cost across all sessions"
+      actions={
+        <div class="flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 p-0.5">
+          <For each={Object.keys(RANGE_LABELS) as RangePreset[]}>
+            {(preset) => (
+              <button
+                type="button"
+                onClick={() => setRange(preset)}
+                class={`px-2.5 py-1 text-xs rounded-md transition-colors ${
+                  range() === preset
+                    ? 'bg-primary text-white'
+                    : 'text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+              >
+                {RANGE_LABELS[preset]}
+              </button>
+            )}
+          </For>
+        </div>
+      }
+    >
+      <Show
+        when={!report.loading}
+        fallback={
+          <div class="flex items-center justify-center h-64 text-text-tertiary">
+            Loading usage…
+          </div>
+        }
+      >
+        <Show
+          when={report()}
+          fallback={
+            <div class="flex items-center justify-center h-64 text-text-tertiary">
+              Failed to load usage
+            </div>
+          }
+        >
+          {/* Headline stat tiles */}
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatTile
+              label="Total tokens"
+              value={formatNumber(totals()?.totalTokens ?? 0)}
+              hint={`${formatNumber(totals()?.runCount ?? 0)} runs`}
+            />
+            <StatTile
+              label="Prompt tokens"
+              value={formatNumber(totals()?.promptTokens ?? 0)}
+              hint={
+                (totals()?.cacheReadTokens ?? 0) > 0
+                  ? `${formatNumber(totals()!.cacheReadTokens)} cached`
+                  : undefined
+              }
+            />
+            <StatTile
+              label="Completion tokens"
+              value={formatNumber(totals()?.completionTokens ?? 0)}
+            />
+            <StatTile
+              label="Estimated cost"
+              value={formatCost(
+                totals()?.cost ?? 0,
+                totals()?.hasCost ?? false,
+              )}
+              hint={
+                totals() && !totals()!.hasCost
+                  ? 'No pricing for these models'
+                  : undefined
+              }
+            />
+          </div>
+
+          {/* Daily usage chart */}
+          <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 mb-4">
+            <h2 class="text-sm font-medium text-text-primary mb-3">
+              Tokens per day, by model
+            </h2>
+            <StackedDailyChart
+              byDay={report()?.byDay ?? []}
+              byDayByModel={report()?.byDayByModel ?? []}
+              byModel={report()?.byModel ?? []}
+            />
+          </div>
+
+          {/* Breakdown by model (doubles as the accessible table view) */}
+          <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+            <h2 class="text-sm font-medium text-text-primary px-4 pt-4 pb-2">
+              By model
+            </h2>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-text-tertiary border-b border-gray-200 dark:border-gray-700">
+                    <th class="px-4 py-2 font-medium">Provider</th>
+                    <th class="px-4 py-2 font-medium">Model</th>
+                    <th class="px-4 py-2 font-medium text-right">Runs</th>
+                    <th class="px-4 py-2 font-medium text-right">Prompt</th>
+                    <th class="px-4 py-2 font-medium text-right">Completion</th>
+                    <th class="px-4 py-2 font-medium text-right">Total</th>
+                    <th class="px-4 py-2 font-medium text-right">Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <Show
+                    when={(report()?.byModel.length ?? 0) > 0}
+                    fallback={
+                      <tr>
+                        <td
+                          colspan="7"
+                          class="px-4 py-6 text-center text-text-tertiary"
+                        >
+                          No usage in this range
+                        </td>
+                      </tr>
+                    }
+                  >
+                    <For each={report()?.byModel ?? []}>
+                      {(row) => (
+                        <tr class="border-b border-gray-100 dark:border-gray-700/50 last:border-0">
+                          <td class="px-4 py-2 text-text-secondary">
+                            {row.providerId}
+                          </td>
+                          <td class="px-4 py-2 text-text-primary">
+                            {row.modelId}
+                          </td>
+                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                            {formatNumber(row.runCount)}
+                          </td>
+                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                            {formatNumber(row.promptTokens)}
+                          </td>
+                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                            {formatNumber(row.completionTokens)}
+                          </td>
+                          <td class="px-4 py-2 text-right tabular-nums text-text-primary">
+                            {formatNumber(row.totalTokens)}
+                          </td>
+                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                            {formatCost(row.cost, row.hasCost)}
+                          </td>
+                        </tr>
+                      )}
+                    </For>
+                  </Show>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Show>
+      </Show>
+    </Layout>
+  );
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -20,11 +20,33 @@ export type {
   PersonalityFile,
   McpServerRecord,
   McpToolWithSchema,
+  McpSecretKind,
+  McpSecretField,
+  McpSecretValue,
   CreateMcpServerRequest,
   UpdateMcpServerRequest,
+  ImportMcpServersRequest,
   ChannelStatusResponse,
   Session,
   MessageRole,
+  SessionSearchResult,
+  // Pulse types from shared-types — single source of truth.
+  ScheduleInput,
+  // Recurring task schedules (Phase 6). These mirror the
+  // @openaidy/shared-types/task-schedules.ts DTOs — the web client
+  // does NOT redeclare them.
+  SchedulePreset,
+  TaskScheduleStatus,
+  ReplanPolicy,
+  TaskScheduleDto,
+  TaskExecutionHistoryStatus,
+  TaskExecutionHistoryDto,
+  ExecutionSubtaskSummary,
+  ExecutionSubtaskSummaryItem,
+  CreateTaskScheduleInput,
+  UpdateTaskScheduleInput,
+  ListTaskExecutionsFilters,
+  PaginatedTaskExecutions,
 } from '@openaidy/shared-types';
 
 import type {
@@ -34,10 +56,24 @@ import type {
 } from '@openaidy/shared-types';
 
 /**
+ * Attachment metadata on a session message. Bytes are fetched separately
+ * via GET /api/attachments/:id/raw (through the authenticated fetch).
+ */
+export type SessionMessageAttachment = {
+  id: string;
+  kind: 'image' | 'audio';
+  source: 'user_upload' | 'tool_output';
+  name?: string | null;
+  mimeType: string;
+  sizeBytes: number;
+};
+
+/**
  * Session message — extends shared type with UI-only reasoning content field
  */
 export type SessionMessage = SharedSessionMessage & {
   reasoningContent?: string;
+  attachments?: SessionMessageAttachment[];
 };
 
 /**
@@ -105,9 +141,22 @@ export type SessionRun = Omit<
 export type BuiltinToolInfo = {
   name: string;
   description: string;
+  category?: string;
 };
 
 export type SkillSource = 'preinstalled' | 'modified' | 'user-global' | 'agent';
+
+/** A single item that can be toggled on/off in a ToolToggleGrid. */
+export type ToggleItem = {
+  id: string;
+  label: string;
+  description?: string;
+  category?: string;
+  badge?: string;
+  badgeVariant?: 'success' | 'neutral' | 'warning';
+  disabled?: boolean;
+  disabledReason?: string;
+};
 
 /**
  * Skill info returned by GET /skills
@@ -134,6 +183,23 @@ export type CreateAgentInput = {
 };
 
 /**
+ * A user message held in the client-side send queue while the agent is
+ * responding. Queued messages are sent automatically, one at a time, once
+ * the active run completes. Owned/managed by the useMessageQueue hook and
+ * rendered by the QueuedMessageCard component.
+ */
+export type QueuedMessage = {
+  /** Stable client-generated id, used as the list key and for edit/remove. */
+  id: string;
+  /** The message body to send when this item is dequeued. */
+  content: string;
+  /** Agent selected at enqueue time, sent with the message. */
+  agentId?: string;
+  /** Attachments uploaded at enqueue time, linked when the message sends. */
+  attachmentIds?: string[];
+};
+
+/**
  * Submit message input
  */
 export type SubmitMessageInput = {
@@ -142,6 +208,62 @@ export type SubmitMessageInput = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
+  /** Ids of previously-uploaded attachments to link to this message */
+  attachmentIds?: string[];
+};
+
+/**
+ * Cumulative token usage totals (per session or overall).
+ */
+export type UsageTotals = {
+  runCount: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  cost: number;
+  hasCost: boolean;
+};
+
+export type UsageByDay = UsageTotals & { day: string };
+export type UsageByProvider = UsageTotals & { providerId: string };
+export type UsageByModel = UsageTotals & {
+  providerId: string;
+  modelId: string;
+};
+/**
+ * Per-day × per-model rollup. Powers the stacked-bar usage chart on the
+ * dashboard, which needs to know exactly how much each model contributed
+ * on each day (not just the per-day total or the per-model total).
+ *
+ * Mirrors the server type in `apps/server/src/usage/aggregate.ts`.
+ */
+export type UsageByDayAndModel = UsageTotals & {
+  day: string;
+  providerId: string;
+  modelId: string;
+};
+
+/** Aggregated usage report (GET /api/usage). */
+export type UsageReport = {
+  from?: string;
+  to?: string;
+  totals: UsageTotals;
+  byDay: UsageByDay[];
+  byProvider: UsageByProvider[];
+  byModel: UsageByModel[];
+  /**
+   * Per-day × per-model breakdown. Empty when no rows in the selected
+   * range. Powers the stacked-bar chart on the usage page.
+   */
+  byDayByModel: UsageByDayAndModel[];
+};
+
+/** Per-session usage response (GET /api/sessions/:id/usage). */
+export type SessionUsageResponse = {
+  sessionId: string;
+  usage: UsageTotals;
 };
 
 /**
@@ -204,7 +326,10 @@ export type AgentConfig = {
   enabled?: boolean;
   description?: string;
   systemPrompt: string;
-  model: string; // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini"
+  // Format: "providerId/modelId" e.g., "openai/gpt-4o-mini". Optional: a
+  // model-less agent inherits the config default (set once the first provider
+  // is connected during onboarding).
+  model?: string;
   tools?: string[];
   tags?: string[];
   metadata?: Record<string, unknown>;
@@ -215,8 +340,10 @@ export type AgentConfig = {
  * Application defaults
  */
 export type AppDefaults = {
-  providerId: string;
-  modelId: string;
+  // Optional to represent an unconfigured install (no providers yet). Both are
+  // set once the first provider is connected during onboarding.
+  providerId?: string;
+  modelId?: string;
   agentId: string;
 };
 
@@ -334,13 +461,51 @@ export type ProviderConfig =
   | GeminiProviderConfig;
 
 /**
+ * A configured messaging channel. WhatsApp is the only type today; the shape
+ * mirrors `whatsappChannelConfigSchema` in packages/config.
+ */
+export type WhatsAppChannelConfig = {
+  type: 'whatsapp';
+  id: string;
+  agentId: string;
+  allowlist?: string[];
+  enabled?: boolean;
+};
+
+export type ChannelConfig = WhatsAppChannelConfig;
+
+/**
  * Application configuration
+ *
+ * `channels` (and `mcpServers`, not modelled here) round-trip through the raw
+ * config JSON; `channels` is typed so the UI can add/remove entries safely.
  */
 export type AppConfig = {
   version: number;
   defaults: AppDefaults;
   providers: ProviderConfig[];
   agents: AgentConfig[];
+  channels?: ChannelConfig[];
+};
+
+/**
+ * Per-agent notice shown when the agent's `model` field was
+ * rewritten to the project default because the provider it pointed
+ * at was disconnected. The notice stays visible until the user
+ * edits the agent or explicitly dismisses it, so the user always
+ * understands *why* the model value changed.
+ */
+export type RewiredAgentNotice = {
+  /** The agent whose `model` was auto-rewired. */
+  agentId: string;
+  /** The provider that was disconnected, for context in the UI. */
+  fromProviderId: string;
+  /** The model value the agent used before the rewire. */
+  fromModel: string;
+  /** The model value the agent was re-pointed to. */
+  toModel: string;
+  /** ISO timestamp of the rewire, for ordering / debugging. */
+  rewiredAt: string;
 };
 
 /**
@@ -446,25 +611,21 @@ export type PulseRun = {
   errorMessage: string | null;
 };
 
-export type ScheduleInput =
-  | { every: '15m' | '30m' | '1h' | '6h' | '12h' | '1d' | '1w' }
-  | { daily: { hour: number; minute: number } }
-  | { cron: string; tz?: string }
-  | { at: string };
+export type {
+  CreatePulseInput as CreatePulseBody,
+  UpdatePulseInput as UpdatePulseBody,
+} from '@openaidy/shared-types';
 
-export type CreatePulseBody = {
-  name: string;
-  prompt: string;
-  schedule: ScheduleInput;
-  agentId?: string;
-  sessionId?: string;
-};
-
-export type UpdatePulseBody = {
-  name?: string;
-  prompt?: string;
-  schedule?: ScheduleInput;
-  status?: 'active' | 'paused' | 'completed' | 'failed';
-  agentId?: string;
-  sessionId?: string;
+/**
+ * Build / runtime info exposed by GET /api/info.
+ * `version` is semver ("0.3.0", no "v"). The UI prepends "v" for display.
+ */
+export type AppInfo = {
+  version: string;
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+  pid: number;
+  startedAt: string;
+  uptimeMs: number;
 };


### PR DESCRIPTION
## Summary

The daily token-usage chart on the **Usage** page used to render each day as a single solid bar showing only the day's total. Users asked to see the contribution of each model inside every bar — i.e. a **stacked bar chart** where each segment is colored per model.

To do this honestly we need per-day × per-model totals, not just per-day and per-model totals. The server didn't expose that breakdown, so any client-side approach would have had to either lie (pro-rate per-day totals using each model's overall share) or invent data. This PR adds the breakdown server-side and consumes it on the client.

## Changes

### Server (`apps/server/src/usage/aggregate.ts`)

- New `UsageByDayAndModel` type (`UsageTotals` + `day`, `providerId`, `modelId`).
- `UsageReport` gains `byDayByModel: UsageByDayAndModel[]`.
- `aggregateUsage()` rolls up per-day × per-model tokens in a single pass using a nested `Map<string, Map<string, …>>` so lookups stay O(1). Output is sorted by day ascending.

### Tests (`apps/server/src/usage/aggregate.test.ts`)

- New `describe('byDayByModel', …)` block with 4 tests:
  - empty rows → empty array
  - one entry per `(day, model)` pair with summed tokens
  - sort by day ascending
  - **invariant**: per-day-by-model totals sum to the per-day total (the property that makes the stacked chart faithful to the totals)

### Web types (`apps/web/src/lib/types.ts`)

- Mirror `UsageByDayAndModel` and the new `byDayByModel` field on `UsageReport`.

### Web chart (`apps/web/src/components/pages/UsagePage.tsx`)

- Replaced `DailyChart` (single `<rect>` per day with `fill-primary`) with `StackedDailyChart`, which paints one `<rect>` per `(day, model)` segment bottom-up.
- Each model gets a stable color from a 10-entry Tailwind palette (`fill-blue-500`, `fill-emerald-500`, …), assigned by descending `totalTokens` so the top spender reads first.
- New legend below the chart: color swatch + `provider/model` key + total tokens. Wraps on narrow viewports.
- Segment tooltips: `2026-01-15 · openai/gpt-4o: 12,345 tokens (47.3% of day)`.
- Min segment height (0.5 px) keeps tiny contributions hoverable; the tooltip shows the real (unfloored) value.
- Chart heading updated to "Tokens per day, by model".

## Why server-side?

A frontend-only approximation would have to pro-rate each day's totals using each model's *overall* share. That works fine when usage is uniform but lies when Model A dominates Mondays and Model B dominates Fridays — exactly the kind of insight the chart is supposed to surface. Adding `byDayByModel` to the aggregation is a small, clean change (one nested Map + one flatten loop) and keeps the chart honest.

## Test plan

- [x] New unit tests pass (`pnpm --filter @openaidy/server test`)
- [ ] Manual: open the Usage page with a populated DB and confirm each bar is segmented by model with the legend matching.
- [ ] Manual: switch range presets (7d / 30d / 90d / all) and confirm bars/legend stay consistent.
- [ ] Manual: empty range → "No usage in this range" fallback still renders.

## Screenshots

Will add before requesting review.

🤖 Generated with [OpenAidy](https://github.com/imzodev/openaidy)