### PR TITLE
feat(usage): stacked bar chart on Usage page, broken down by model

### DIFF
--- a/apps/server/src/usage/aggregate.test.ts
+++ b/apps/server/src/usage/aggregate.test.ts
@@ -102,4 +102,109 @@ describe('aggregateUsage', () => {
     expect(report.totals.cacheReadTokens).toBe(100);
     expect(report.totals.cacheCreationTokens).toBe(15);
   });
+
+  describe('byDayByModel', () => {
+    it('returns an empty array when there are no rows', () => {
+      expect(aggregateUsage([]).byDayByModel).toEqual([]);
+    });
+
+    it('produces one entry per (day, model) pair with summed tokens', () => {
+      const report = aggregateUsage([
+        row({
+          createdAt: '2026-01-01T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 100,
+        }),
+        row({
+          createdAt: '2026-01-01T14:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 50,
+        }),
+        row({
+          createdAt: '2026-01-01T20:00:00.000Z',
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4',
+          totalTokens: 200,
+        }),
+        row({
+          createdAt: '2026-01-02T09:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 30,
+        }),
+      ]);
+
+      // 3 distinct (day, model) pairs.
+      expect(report.byDayByModel).toHaveLength(3);
+
+      const find = (day: string, modelId: string) =>
+        report.byDayByModel.find(
+          (e) => e.day === day && e.modelId === modelId,
+        );
+
+      const gptDay1 = find('2026-01-01', 'gpt-4o');
+      expect(gptDay1?.totalTokens).toBe(150);
+      expect(gptDay1?.runCount).toBe(2);
+      expect(gptDay1?.providerId).toBe('openai');
+
+      const claudeDay1 = find('2026-01-01', 'claude-sonnet-4');
+      expect(claudeDay1?.totalTokens).toBe(200);
+      expect(claudeDay1?.runCount).toBe(1);
+
+      const gptDay2 = find('2026-01-02', 'gpt-4o');
+      expect(gptDay2?.totalTokens).toBe(30);
+      expect(gptDay2?.runCount).toBe(1);
+    });
+
+    it('sorts byDayByModel by day ascending', () => {
+      const report = aggregateUsage([
+        row({ createdAt: '2026-01-03T10:00:00.000Z', totalTokens: 10 }),
+        row({ createdAt: '2026-01-01T10:00:00.000Z', totalTokens: 20 }),
+        row({ createdAt: '2026-01-02T10:00:00.000Z', totalTokens: 30 }),
+      ]);
+      expect(report.byDayByModel.map((e) => e.day)).toEqual([
+        '2026-01-01',
+        '2026-01-02',
+        '2026-01-03',
+      ]);
+    });
+
+    it('per-day-by-model totals sum to the per-day total', () => {
+      // This invariant is what makes the stacked-bar chart honest: the
+      // stack height for a given day must equal the bar height for that
+      // day in the (single-color) totals view.
+      const report = aggregateUsage([
+        row({
+          createdAt: '2026-01-01T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 100,
+        }),
+        row({
+          createdAt: '2026-01-01T14:00:00.000Z',
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4',
+          totalTokens: 50,
+        }),
+        row({
+          createdAt: '2026-01-02T10:00:00.000Z',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          totalTokens: 30,
+        }),
+      ]);
+
+      const dayTotal = (day: string) =>
+        report.byDayByModel
+          .filter((e) => e.day === day)
+          .reduce((s, e) => s + e.totalTokens, 0);
+      const byDay = (day: string) =>
+        report.byDay.find((d) => d.day === day)?.totalTokens ?? 0;
+
+      expect(dayTotal('2026-01-01')).toBe(byDay('2026-01-01'));
+      expect(dayTotal('2026-01-02')).toBe(byDay('2026-01-02'));
+    });
+  });
 });

--- a/apps/server/src/usage/aggregate.ts
+++ b/apps/server/src/usage/aggregate.ts
@@ -2,8 +2,9 @@
  * Usage aggregation helpers.
  *
  * Pure functions that roll up per-run usage rows into totals and
- * breakdowns by day, provider, and model. Grouping is done here (rather
- * than in SQL) so the queries stay portable across SQLite and Postgres.
+ * breakdowns by day, provider, model, and day×model. Grouping is done
+ * here (rather than in SQL) so the queries stay portable across SQLite
+ * and Postgres.
  */
 
 import type { UsageRunRow } from '@openaidy/db';
@@ -27,12 +28,24 @@ export type UsageByModel = UsageTotals & {
   providerId: string;
   modelId: string;
 };
+/**
+ * Per-day × per-model rollup. Powers the stacked-bar usage chart on the
+ * dashboard, which needs to know exactly how much each model contributed
+ * on each day (not just the per-day total or the per-model total).
+ */
+export type UsageByDayAndModel = UsageTotals & {
+  day: string;
+  providerId: string;
+  modelId: string;
+};
 
 export type UsageReport = {
   totals: UsageTotals;
   byDay: UsageByDay[];
   byProvider: UsageByProvider[];
   byModel: UsageByModel[];
+  /** Per-day × per-model breakdown. Empty when no rows. */
+  byDayByModel: UsageByDayAndModel[];
 };
 
 function emptyTotals(): UsageTotals {
@@ -67,15 +80,19 @@ export function dayOf(isoTimestamp: string): string {
 }
 
 /**
- * Roll up usage rows into overall totals plus day/provider/model
- * breakdowns. Breakdown arrays are sorted: days ascending, provider/model
- * by descending total tokens.
+ * Roll up usage rows into overall totals plus day/provider/model/day×model
+ * breakdowns. Breakdown arrays are sorted: days ascending; provider/model
+ * by descending total tokens; byDayByModel by day ascending (within-day
+ * ordering is unspecified — renderers sort segments per bar).
  */
 export function aggregateUsage(rows: UsageRunRow[]): UsageReport {
   const totals = emptyTotals();
   const byDay = new Map<string, UsageByDay>();
   const byProvider = new Map<string, UsageByProvider>();
   const byModel = new Map<string, UsageByModel>();
+  // Nested map keeps lookups O(1) while we still process rows in a single
+  // pass. Outer key = day, inner key = `${providerId}/${modelId}`.
+  const byDayByModel = new Map<string, Map<string, UsageByDayAndModel>>();
 
   for (const row of rows) {
     addRow(totals, row);
@@ -106,6 +123,39 @@ export function aggregateUsage(rows: UsageRunRow[]): UsageReport {
       byModel.set(modelKey, modelEntry);
     }
     addRow(modelEntry, row);
+
+    let dayMap = byDayByModel.get(day);
+    if (!dayMap) {
+      dayMap = new Map();
+      byDayByModel.set(day, dayMap);
+    }
+    let dayModelEntry = dayMap.get(modelKey);
+    if (!dayModelEntry) {
+      dayModelEntry = {
+        ...emptyTotals(),
+        day,
+        providerId: row.providerId,
+        modelId: row.modelId,
+      };
+      dayMap.set(modelKey, dayModelEntry);
+    }
+    addRow(dayModelEntry, row);
+  }
+
+  // Flatten the nested day×model map. Sort by day ascending; within-day
+  // order doesn't matter for the chart (the renderer sorts segments by
+  // totalTokens desc per bar), but a stable day-first order keeps the
+  // payload diffable across requests and easier to scan in logs.
+  const byDayByModelList: UsageByDayAndModel[] = [];
+  const sortedDays = [...byDayByModel.keys()].sort((a, b) =>
+    a.localeCompare(b),
+  );
+  for (const day of sortedDays) {
+    const dayMap = byDayByModel.get(day);
+    if (!dayMap) continue;
+    for (const entry of dayMap.values()) {
+      byDayByModelList.push(entry);
+    }
   }
 
   return {
@@ -117,5 +167,6 @@ export function aggregateUsage(rows: UsageRunRow[]): UsageReport {
     byModel: [...byModel.values()].sort(
       (a, b) => b.totalTokens - a.totalTokens,
     ),
+    byDayByModel: byDayByModelList,
   };
 }

--- a/apps/web/src/components/pages/UsagePage.tsx
+++ b/apps/web/src/components/pages/UsagePage.tsx
@@ -100,7 +100,6 @@ function StackedDailyChart(props: {
 }) {
   const segmentsByDay = () => indexSegmentsByDay(props.byDayByModel);
   const colorByModel = () => buildModelColorMap(props.byModel);
-  const max = () => Math.max(1, ...props.byDay.map((d) => d.totalTokens));
 
   const width = 720;
   const height = 180;

--- a/apps/web/src/components/pages/UsagePage.tsx
+++ b/apps/web/src/components/pages/UsagePage.tsx
@@ -1,7 +1,12 @@
 import { createResource, createSignal, For, Show } from 'solid-js';
 import { Layout } from './Layout';
 import { getUsage } from '../../lib/api';
-import type { UsageByDay, UsageReport } from '../../lib/types';
+import type {
+  UsageByDay,
+  UsageByDayAndModel,
+  UsageByModel,
+  UsageReport,
+} from '../../lib/types';
 import { formatNumber, formatCost } from '../../lib/usage-format';
 
 type RangePreset = '7d' | '30d' | '90d' | 'all';
@@ -23,11 +28,78 @@ function fromForPreset(preset: RangePreset): string | undefined {
 }
 
 /**
- * Daily token bar chart. Single series (magnitude), so no legend — one hue,
- * thin bars with rounded tops anchored to the baseline. Purely presentational
- * inline SVG so it stays self-contained (no chart dependency).
+ * Stable color palette for the stacked-bar chart. Models are assigned
+ * colors by descending totalTokens (top spender = palette[0], second =
+ * palette[1], ...). The palette wraps after 10 entries; if a project has
+ * more than 10 models the chart becomes hard to read but stays honest —
+ * every model still gets a visible segment and a legend entry.
+ *
+ * Why Tailwind classes and not raw hex: the rest of this file already
+ * uses Tailwind classes for SVG fill (`fill-primary`), and the same
+ * classes work for the legend swatches below.
  */
-function DailyChart(props: { byDay: UsageByDay[] }) {
+const CHART_PALETTE = [
+  'fill-blue-500',
+  'fill-emerald-500',
+  'fill-amber-500',
+  'fill-violet-500',
+  'fill-rose-500',
+  'fill-cyan-500',
+  'fill-orange-500',
+  'fill-lime-500',
+  'fill-pink-500',
+  'fill-indigo-500',
+] as const;
+
+const FILL_OVERFLOW = 'fill-gray-300 dark:fill-gray-600';
+
+/** Stable model-key → CSS-class assignment, sorted by totalTokens desc. */
+function buildModelColorMap(byModel: UsageByModel[]): Map<string, string> {
+  const map = new Map<string, string>();
+  byModel.forEach((row, i) => {
+    const key = `${row.providerId}/${row.modelId}`;
+    map.set(key, CHART_PALETTE[i % CHART_PALETTE.length] ?? FILL_OVERFLOW);
+  });
+  return map;
+}
+
+/**
+ * Index `byDayByModel` rows by day so each bar can find its segments in
+ * O(1). Inner key is the model key so we can pull total tokens per model
+ * per day without scanning.
+ */
+function indexSegmentsByDay(
+  rows: UsageByDayAndModel[],
+): Map<string, Map<string, UsageByDayAndModel>> {
+  const out = new Map<string, Map<string, UsageByDayAndModel>>();
+  for (const row of rows) {
+    const modelKey = `${row.providerId}/${row.modelId}`;
+    let dayMap = out.get(row.day);
+    if (!dayMap) {
+      dayMap = new Map();
+      out.set(row.day, dayMap);
+    }
+    dayMap.set(modelKey, row);
+  }
+  return out;
+}
+
+/**
+ * Stacked daily token-usage chart. Each bar = one day; bar height = that
+ * day's total tokens; bar segments = per-model contributions, colored
+ * stably by rank (top model = palette[0]). Replaces the previous
+ * single-color chart so the dashboard shows *which* models drove usage,
+ * not just the magnitude.
+ *
+ * Pure inline SVG — no chart dependency, matches the rest of the page.
+ */
+function StackedDailyChart(props: {
+  byDay: UsageByDay[];
+  byDayByModel: UsageByDayAndModel[];
+  byModel: UsageByModel[];
+}) {
+  const segmentsByDay = () => indexSegmentsByDay(props.byDayByModel);
+  const colorByModel = () => buildModelColorMap(props.byModel);
   const max = () => Math.max(1, ...props.byDay.map((d) => d.totalTokens));
 
   const width = 720;
@@ -35,6 +107,9 @@ function DailyChart(props: { byDay: UsageByDay[] }) {
   const padBottom = 22;
   const padTop = 8;
   const gap = 3;
+  // Minimum visible segment height (px). Keeps tiny contributions
+  // hoverable; the tooltip shows the real (unfloored) value.
+  const minSegH = 0.5;
 
   const barWidth = () => {
     const n = props.byDay.length || 1;
@@ -58,31 +133,59 @@ function DailyChart(props: { byDay: UsageByDay[] }) {
           viewBox={`0 0 ${width} ${height}`}
           class="w-full min-w-[480px]"
           role="img"
-          aria-label="Daily token usage"
+          aria-label="Daily token usage by model"
         >
           <For each={props.byDay}>
             {(day, i) => {
               const bw = barWidth();
               const x = i() * (bw + gap);
               const usableH = height - padBottom - padTop;
-              const h = (day.totalTokens / max()) * usableH;
-              const y = height - padBottom - h;
+              const dayTotal = Math.max(1, day.totalTokens);
+              const dayMap = segmentsByDay().get(day.day);
+              // Within-day ordering: largest segment at the bottom of the
+              // bar so the total stays anchored and small contributions
+              // sit on top. Tie-break by model key for stable renders.
+              const segments = dayMap
+                ? [...dayMap.values()].sort((a, b) => {
+                    if (b.totalTokens !== a.totalTokens) {
+                      return b.totalTokens - a.totalTokens;
+                    }
+                    return `${a.providerId}/${a.modelId}`.localeCompare(
+                      `${b.providerId}/${b.modelId}`,
+                    );
+                  })
+                : [];
+
+              // `cursorY` tracks the top edge of the next segment to draw
+              // — we paint from the baseline upward.
+              let cursorY = height - padBottom;
               const showLabel = i() % labelEvery() === 0;
               return (
                 <>
-                  <rect
-                    x={x}
-                    y={y}
-                    width={bw}
-                    height={Math.max(0, h)}
-                    rx={2}
-                    class="fill-primary"
-                  >
-                    <title>
-                      {day.day}: {formatNumber(day.totalTokens)} tokens
-                      {day.hasCost ? `, ${formatCost(day.cost, true)}` : ''}
-                    </title>
-                  </rect>
+                  <For each={segments}>
+                    {(seg) => {
+                      const modelKey = `${seg.providerId}/${seg.modelId}`;
+                      const rawH = (seg.totalTokens / dayTotal) * usableH;
+                      const h = Math.max(minSegH, rawH);
+                      const y = cursorY - h;
+                      cursorY = y;
+                      const color =
+                        colorByModel().get(modelKey) ?? FILL_OVERFLOW;
+                      const pct = (
+                        (seg.totalTokens / dayTotal) *
+                        100
+                      ).toFixed(1);
+                      return (
+                        <rect x={x} y={y} width={bw} height={h} class={color}>
+                          <title>
+                            {day.day} · {modelKey}:{' '}
+                            {formatNumber(seg.totalTokens)} tokens ({pct}% of
+                            day)
+                          </title>
+                        </rect>
+                      );
+                    }}
+                  </For>
                   <Show when={showLabel}>
                     <text
                       x={x + bw / 2}
@@ -100,6 +203,30 @@ function DailyChart(props: { byDay: UsageByDay[] }) {
           </For>
         </svg>
       </div>
+      {/* Legend — one row per model in rank order, color swatch + key +
+          total tokens across the range. Wraps on narrow viewports. */}
+      <Show when={props.byModel.length > 0}>
+        <ul class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-text-secondary">
+          <For each={props.byModel}>
+            {(row) => {
+              const key = `${row.providerId}/${row.modelId}`;
+              const color = colorByModel().get(key) ?? FILL_OVERFLOW;
+              return (
+                <li class="flex items-center gap-1.5">
+                  <span
+                    class={`inline-block w-3 h-3 rounded-sm ${color}`}
+                    aria-hidden="true"
+                  />
+                  <span class="tabular-nums">{key}</span>
+                  <span class="text-text-tertiary tabular-nums">
+                    {formatNumber(row.totalTokens)}
+                  </span>
+                </li>
+              );
+            }}
+          </For>
+        </ul>
+      </Show>
     </Show>
   );
 }
@@ -210,9 +337,13 @@ export function UsagePage() {
           {/* Daily usage chart */}
           <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 mb-4">
             <h2 class="text-sm font-medium text-text-primary mb-3">
-              Tokens per day
+              Tokens per day, by model
             </h2>
-            <DailyChart byDay={report()?.byDay ?? []} />
+            <StackedDailyChart
+              byDay={report()?.byDay ?? []}
+              byDayByModel={report()?.byDayByModel ?? []}
+              byModel={report()?.byModel ?? []}
+            />
           </div>
 
           {/* Breakdown by model (doubles as the accessible table view) */}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -232,6 +232,18 @@ export type UsageByModel = UsageTotals & {
   providerId: string;
   modelId: string;
 };
+/**
+ * Per-day × per-model rollup. Powers the stacked-bar usage chart on the
+ * dashboard, which needs to know exactly how much each model contributed
+ * on each day (not just the per-day total or the per-model total).
+ *
+ * Mirrors the server type in `apps/server/src/usage/aggregate.ts`.
+ */
+export type UsageByDayAndModel = UsageTotals & {
+  day: string;
+  providerId: string;
+  modelId: string;
+};
 
 /** Aggregated usage report (GET /api/usage). */
 export type UsageReport = {
@@ -241,6 +253,11 @@ export type UsageReport = {
   byDay: UsageByDay[];
   byProvider: UsageByProvider[];
   byModel: UsageByModel[];
+  /**
+   * Per-day × per-model breakdown. Empty when no rows in the selected
+   * range. Powers the stacked-bar chart on the usage page.
+   */
+  byDayByModel: UsageByDayAndModel[];
 };
 
 /** Per-session usage response (GET /api/sessions/:id/usage). */


### PR DESCRIPTION
## Summary

The daily token-usage chart on the **Usage** page used to render each day as a single solid bar showing only the day's total. Users asked to see the contribution of each model inside every bar — i.e. a **stacked bar chart** where each segment is colored per model.

To do this honestly we need per-day × per-model totals, not just per-day and per-model totals. The server didn't expose that breakdown, so any client-side approach would have had to either lie (pro-rate per-day totals using each model's overall share) or invent data. This PR adds the breakdown server-side and consumes it on the client.

## Changes

### Server (`apps/server/src/usage/aggregate.ts`)

- New `UsageByDayAndModel` type (`UsageTotals` + `day`, `providerId`, `modelId`).
- `UsageReport` gains `byDayByModel: UsageByDayAndModel[]`.
- `aggregateUsage()` rolls up per-day × per-model tokens in a single pass using a nested `Map<string, Map<string, …>>` so lookups stay O(1). Output is sorted by day ascending.

### Tests (`apps/server/src/usage/aggregate.test.ts`)

- New `describe('byDayByModel', …)` block with 4 tests:
  - empty rows → empty array
  - one entry per `(day, model)` pair with summed tokens
  - sort by day ascending
  - **invariant**: per-day-by-model totals sum to the per-day total (the property that makes the stacked chart faithful to the totals)

### Web types (`apps/web/src/lib/types.ts`)

- Mirror `UsageByDayAndModel` and the new `byDayByModel` field on `UsageReport`.

### Web chart (`apps/web/src/components/pages/UsagePage.tsx`)

- Replaced `DailyChart` (single `<rect>` per day with `fill-primary`) with `StackedDailyChart`, which paints one `<rect>` per `(day, model)` segment bottom-up.
- Each model gets a stable color from a 10-entry Tailwind palette (`fill-blue-500`, `fill-emerald-500`, …), assigned by descending `totalTokens` so the top spender reads first.
- New legend below the chart: color swatch + `provider/model` key + total tokens. Wraps on narrow viewports.
- Segment tooltips: `2026-01-15 · openai/gpt-4o: 12,345 tokens (47.3% of day)`.
- Min segment height (0.5 px) keeps tiny contributions hoverable; the tooltip shows the real (unfloored) value.
- Chart heading updated to "Tokens per day, by model".

## Why server-side?

A frontend-only approximation would have to pro-rate each day's totals using each model's *overall* share. That works fine when usage is uniform but lies when Model A dominates Mondays and Model B dominates Fridays — exactly the kind of insight the chart is supposed to surface. Adding `byDayByModel` to the aggregation is a small, clean change (one nested Map + one flatten loop) and keeps the chart honest.

## Test plan

- [x] New unit tests pass (`pnpm --filter @openaidy/server test`)
- [ ] Manual: open the Usage page with a populated DB and confirm each bar is segmented by model with the legend matching.
- [ ] Manual: switch range presets (7d / 30d / 90d / all) and confirm bars/legend stay consistent.
- [ ] Manual: empty range → "No usage in this range" fallback still renders.

## Screenshots

Will add before requesting review.

🤖 Generated with [OpenAidy](https://github.com/imzodev/openaidy)