### PR TITLE
feat(sessions): cap oversized tool results before they enter model context

### DIFF
--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -351,6 +351,9 @@ describe('SessionMessageService.updateSessionTitle', () => {
 /** Build a streaming-capable service wired to a scripted invokeStream mock. */
 function makeStreamingService(opts: {
   maxToolRounds: number;
+  maxToolOutputChars?: number;
+  /** Custom executor for the 'echo' tool (e.g. to return an oversized result). */
+  echoExecute?: () => Promise<{ ok: true; content: string }>;
   invokeStream: (request: {
     tools?: unknown[];
   }) => AsyncGenerator<unknown, void, unknown>;
@@ -358,7 +361,7 @@ function makeStreamingService(opts: {
   const agents = new AgentRegistry();
   agents.replaceAll([makeAgent(['echo'])]);
   const builtinTools = new BuiltinToolRegistry();
-  builtinTools.register(makeTool('echo'));
+  builtinTools.register(makeTool('echo', opts.echoExecute));
 
   const invokeStream = vi.fn(opts.invokeStream);
 
@@ -377,6 +380,9 @@ function makeStreamingService(opts: {
     agents,
     builtinTools,
     maxToolRounds: opts.maxToolRounds,
+    ...(opts.maxToolOutputChars !== undefined && {
+      maxToolOutputChars: opts.maxToolOutputChars,
+    }),
   });
 
   return { service, invokeStream };
@@ -459,5 +465,94 @@ describe('SessionMessageService — agentic loop round exhaustion', () => {
     if (!result.ok) return;
     expect(result.assistantMessage.content.trim().length).toBeGreaterThan(0);
     expect(result.assistantMessage.content.toLowerCase()).toContain('continue');
+  });
+});
+
+// ============================================================================
+// Agentic tool-call loop — tool-output context cap (issue #436)
+// ============================================================================
+
+describe('SessionMessageService — tool-output context cap', () => {
+  it('truncates an oversized tool result in the model context but persists it in full', async () => {
+    const HUGE = 'X'.repeat(500);
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 2,
+      maxToolOutputChars: 100,
+      echoExecute: async () => ({ ok: true as const, content: HUGE }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          // Final round: capture what the model actually sees, then answer.
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Cap');
+    const sessionId = (session as { id: string }).id;
+    const result = await submit(service, sessionId);
+    expect(result.ok).toBe(true);
+
+    // The context copy the model received is truncated with a notice.
+    const contextToolMsg = finalRoundMessages.find((m) => m.role === 'tool');
+    expect(contextToolMsg).toBeDefined();
+    expect(contextToolMsg!.content).toContain('truncated for context');
+    expect(contextToolMsg!.content).not.toContain(HUGE);
+    // Cap (100) + the notice — well under the raw 500 chars.
+    expect(contextToolMsg!.content.length).toBeLessThan(HUGE.length);
+
+    // The persisted transcript keeps the full, untruncated result.
+    const persisted = await service.listMessages(sessionId);
+    const persistedToolMsg = (
+      persisted as Array<{ role: string; content: string }>
+    ).find((m) => m.role === 'tool');
+    expect(persistedToolMsg).toBeDefined();
+    expect(persistedToolMsg!.content).toBe(HUGE);
+  });
+
+  it('leaves a tool result under the cap untouched', async () => {
+    const SMALL = 'ok';
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 2,
+      maxToolOutputChars: 100,
+      echoExecute: async () => ({ ok: true as const, content: SMALL }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('No cap');
+    await submit(service, (session as { id: string }).id);
+
+    const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
+    expect(toolMsg?.content).toBe(SMALL);
+    expect(toolMsg?.content).not.toContain('truncated');
   });
 });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -98,6 +98,7 @@ export class SessionMessageService {
   private readonly attachments: AttachmentService | undefined;
   private readonly modelPricing: Record<string, ModelPricing> | undefined;
   private readonly maxToolRounds: number;
+  private readonly maxToolOutputChars: number;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -126,6 +127,7 @@ export class SessionMessageService {
     this.attachments = options.attachments;
     this.modelPricing = options.modelPricing;
     this.maxToolRounds = options.maxToolRounds ?? 25;
+    this.maxToolOutputChars = options.maxToolOutputChars ?? 24_000;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -151,6 +153,34 @@ export class SessionMessageService {
     if (!controller) return false;
     controller.abort();
     return true;
+  }
+
+  /**
+   * Cap the copy of a tool result that is fed back into the model context.
+   *
+   * A single oversized tool result (broad MCP search responses are the usual
+   * culprit — builtin read/fetch already self-cap) can balloon the request to
+   * the model's context limit, which degrades tool-calling and causes the run
+   * to stall (see the agentic-loop round-exhaustion analysis). We truncate the
+   * *context* copy only; the full result is still persisted to the DB so the
+   * UI and history keep it intact. Cross-run history replay is trimmed
+   * separately.
+   */
+  private capToolOutputForContext(content: string, toolName: string): string {
+    const cap = this.maxToolOutputChars;
+    if (content.length <= cap) return content;
+    const omitted = content.length - cap;
+    this.logger?.warn(
+      { toolName, originalChars: content.length, cap },
+      'Tool output exceeded context cap — truncated the copy sent to the model',
+    );
+    return (
+      content.slice(0, cap) +
+      `\n\n[Tool output truncated for context: showing ${cap} of ` +
+      `${content.length} characters (${omitted} omitted). The full result is ` +
+      `preserved in the transcript. If you need more, narrow the query, ` +
+      `request a specific section/line range, or paginate.]`
+    );
   }
 
   /**
@@ -1712,9 +1742,12 @@ export class SessionMessageService {
                 }
               }
 
+              // Feed the model a size-capped copy (the full result was just
+              // persisted above). Keeps one broad tool result from ballooning
+              // the context and stalling the run (issue #436).
               loopMessages.push({
                 role: 'tool',
-                content: toolContent,
+                content: this.capToolOutputForContext(toolContent, tc.name),
                 toolCallId: tc.id,
                 ...(toolIsError ? { isError: true } : {}),
               } as Message);

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -133,6 +133,14 @@ export type SessionMessageServiceOptions = {
    * to 25. Exposed mainly so tests can drive the exhaustion path cheaply.
    */
   maxToolRounds?: number;
+  /**
+   * Max characters of a single tool result that are fed back into the model
+   * context. Oversized results (e.g. broad MCP search responses) are truncated
+   * with a notice before entering the loop history, to keep the context from
+   * ballooning and degrading the model. The full result is still persisted for
+   * the UI/history. Defaults to 24000 (~6k tokens).
+   */
+  maxToolOutputChars?: number;
   repositories?:
     | {
         sessions: SessionsStore;


### PR DESCRIPTION
Closes #436.

## Problem

A single oversized tool result can balloon the request to the model's context limit, degrading tool-calling and stalling the run — the root cause behind the round-exhaustion symptom fixed in #435. In the diagnosed session, one `github` search result was **159KB** and the prompt reached **~1M tokens**.

Tool-output truncation existed only **per-tool and inconsistently**: `web_fetch`/`exec`/`read` self-cap, but **MCP tool results were injected verbatim** — there was no central limit on what any tool could push into the loop history.

## Change

`apps/server/src/sessions/service.ts`: truncate the copy of a tool result fed back into the model context to a configurable `maxToolOutputChars` (default **24000**, ~6k tokens), with a clear notice:

> `[Tool output truncated for context: showing 24000 of 159000 characters (135000 omitted). The full result is preserved in the transcript. If you need more, narrow the query, request a specific section/line range, or paginate.]`

Key design decisions:
- **Context copy only.** The full result is still persisted to the DB, so the **UI and history keep it intact**. This matches the issue's scope ("before it enters model context"); cross-run history replay trimming is the separate follow-up #438.
- **Applied at the single append point** where both builtin and MCP results enter loop history — so the previously-uncapped MCP path is now covered.
- **Configurable** via a new `maxToolOutputChars` service option (mirrors the `maxToolRounds` pattern), so it's tunable and testable. Tuning empirically is what #440 (per-round token observability) is for.

## Tests (`service.test.ts`)

- Oversized (500-char) tool result with cap 100: the **model context** copy is truncated with the notice and does **not** contain the full blob, while the **persisted** transcript message keeps the full 500 chars.
- A result under the cap passes through untouched (no notice).
- All existing session + integration tests still pass (20 unit, 14 integration).

## Verification

- `service.test.ts`: 20 pass · `routes/sessions.test.ts`: 14 pass · typecheck + ESLint clean.

## Notes

- Commits authored under `imzodev` (large `service.ts` can't be pushed byte-safely via MCP); PR opened via MCP (agentjetson). Content is byte-identical to the reviewed local commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)