### PR TITLE
feat(sessions): compact loop context to a token budget to prevent stalls

### DIFF
--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -352,6 +352,7 @@ describe('SessionMessageService.updateSessionTitle', () => {
 function makeStreamingService(opts: {
   maxToolRounds: number;
   maxToolOutputChars?: number;
+  maxContextTokens?: number;
   /** Custom executor for the 'echo' tool (e.g. to return an oversized result). */
   echoExecute?: () => Promise<{ ok: true; content: string }>;
   invokeStream: (request: {
@@ -382,6 +383,9 @@ function makeStreamingService(opts: {
     maxToolRounds: opts.maxToolRounds,
     ...(opts.maxToolOutputChars !== undefined && {
       maxToolOutputChars: opts.maxToolOutputChars,
+    }),
+    ...(opts.maxContextTokens !== undefined && {
+      maxContextTokens: opts.maxContextTokens,
     }),
   });
 
@@ -554,5 +558,103 @@ describe('SessionMessageService — tool-output context cap', () => {
     const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
     expect(toolMsg?.content).toBe(SMALL);
     expect(toolMsg?.content).not.toContain('truncated');
+  });
+});
+
+// ============================================================================
+// Agentic tool-call loop — context-window compaction (issue #437)
+// ============================================================================
+
+describe('SessionMessageService — context-window compaction', () => {
+  it('elides older tool-result bodies in the model context when over the token budget', async () => {
+    const BIG = 'Y'.repeat(400); // > the 200-char elide threshold
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      // Tiny budget so accumulated tool output must be compacted…
+      maxContextTokens: 20,
+      // …but the per-result cap is high, so #436 truncation is NOT what fires.
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Compact');
+    const sessionId = (session as { id: string }).id;
+    const result = await submit(service, sessionId);
+    expect(result.ok).toBe(true);
+
+    // At least one older tool result was collapsed to the elision notice…
+    const toolMsgs = finalRoundMessages.filter((m) => m.role === 'tool');
+    const elided = toolMsgs.filter((m) =>
+      m.content.includes('elided to fit context'),
+    );
+    expect(elided.length).toBeGreaterThan(0);
+    // …and elided by #437 (compaction), not #436 (per-result truncation).
+    expect(elided[0]!.content).not.toContain('truncated for context');
+
+    // The persisted transcript keeps every tool result in full.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBeGreaterThan(0);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
+  });
+
+  it('leaves history untouched when under the token budget', async () => {
+    const SMALL = 'z'.repeat(300);
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 2,
+      maxContextTokens: 1_000_000, // effectively unlimited
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: SMALL }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('No compact');
+    await submit(service, (session as { id: string }).id);
+
+    const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
+    expect(toolMsg?.content).toBe(SMALL);
+    expect(toolMsg?.content).not.toContain('elided');
   });
 });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -99,6 +99,7 @@ export class SessionMessageService {
   private readonly modelPricing: Record<string, ModelPricing> | undefined;
   private readonly maxToolRounds: number;
   private readonly maxToolOutputChars: number;
+  private readonly maxContextTokens: number;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -128,6 +129,7 @@ export class SessionMessageService {
     this.modelPricing = options.modelPricing;
     this.maxToolRounds = options.maxToolRounds ?? 25;
     this.maxToolOutputChars = options.maxToolOutputChars ?? 24_000;
+    this.maxContextTokens = options.maxContextTokens ?? 100_000;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -181,6 +183,63 @@ export class SessionMessageService {
       `preserved in the transcript. If you need more, narrow the query, ` +
       `request a specific section/line range, or paginate.]`
     );
+  }
+
+  /**
+   * Rough token estimate for a set of messages (~4 chars/token plus a small
+   * per-message and per-tool-call overhead). Good enough to decide *when* to
+   * compact; we deliberately avoid a real tokenizer dependency on the hot path.
+   */
+  private estimateTokens(messages: Message[]): number {
+    let chars = 0;
+    for (const m of messages) {
+      chars += (m.content?.length ?? 0) + 8; // + role/framing overhead
+      const toolCalls = (
+        m as { toolCalls?: Array<{ arguments?: string; name?: string }> }
+      ).toolCalls;
+      if (toolCalls) {
+        for (const tc of toolCalls) {
+          chars += (tc.arguments?.length ?? 0) + (tc.name?.length ?? 0) + 16;
+        }
+      }
+    }
+    return Math.ceil(chars / 4);
+  }
+
+  /**
+   * Keep the loop history within `maxContextTokens` by eliding the *bodies* of
+   * the oldest tool results (issue #437). Recent tool results — the model's
+   * working set — are preserved; only prior, already-consumed outputs are
+   * collapsed to a short notice. Assistant/user/system turns and the
+   * tool_call↔tool_result pairing are never touched (only a tool message's
+   * `content` shrinks), so the request stays provider-valid. Mutates in place
+   * so the elision persists across subsequent rounds. Returns the count elided.
+   *
+   * The full results remain in the persisted transcript; this only shapes what
+   * is re-sent to the model.
+   */
+  private compactContextInPlace(messages: Message[]): number {
+    const budget = this.maxContextTokens;
+    if (this.estimateTokens(messages) <= budget) return 0;
+
+    const ELISION_PREFIX = '[Earlier tool output elided to fit context:';
+    const MIN_ELIDE_CHARS = 200; // not worth collapsing tiny results
+    let elided = 0;
+
+    // Oldest-first: the earliest tool results are the least likely to still
+    // matter to the current step.
+    for (const m of messages) {
+      if (this.estimateTokens(messages) <= budget) break;
+      if (m.role !== 'tool') continue;
+      const content = m.content ?? '';
+      if (content.startsWith(ELISION_PREFIX)) continue; // already elided
+      if (content.length <= MIN_ELIDE_CHARS) continue;
+      (m as { content: string }).content =
+        `${ELISION_PREFIX} ${content.length} characters omitted. The full ` +
+        `result is preserved in the transcript.]`;
+      elided++;
+    }
+    return elided;
   }
 
   /**
@@ -1243,6 +1302,26 @@ export class SessionMessageService {
             'Agentic loop hit MAX_TOOL_ROUNDS — forcing a final text response without tools',
           );
         }
+
+        // Keep the request within the input-token budget: elide the oldest
+        // tool-result bodies before sending (issue #437). Unbounded history is
+        // the root cause behind the round-exhaustion/stall symptom — a single
+        // run here reached ~1M prompt tokens on MiniMax-M3 and degraded.
+        const elided = this.compactContextInPlace(loopMessages);
+        if (elided > 0) {
+          this.logger?.warn(
+            {
+              sessionId: input.sessionId,
+              runId: run.id,
+              round,
+              elided,
+              budgetTokens: this.maxContextTokens,
+              estTokens: this.estimateTokens(loopMessages),
+            },
+            'Compacted context — elided oldest tool outputs to fit the token budget',
+          );
+        }
+
         const modelRequest: ModelRequest = {
           model: modelId,
           messages: loopMessages,

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -141,6 +141,15 @@ export type SessionMessageServiceOptions = {
    * the UI/history. Defaults to 24000 (~6k tokens).
    */
   maxToolOutputChars?: number;
+  /**
+   * Approximate input-token budget for the agentic loop. Before each model
+   * call, if the running message history is estimated to exceed this, the
+   * oldest tool-result bodies are elided (their tool_call/result pairing is
+   * preserved) until it fits — keeping a large or long conversation from
+   * degrading tool-calling or overflowing the model's window. The full
+   * results remain in the persisted transcript. Defaults to 100000.
+   */
+  maxContextTokens?: number;
   repositories?:
     | {
         sessions: SessionsStore;


### PR DESCRIPTION
Closes #437. **Stacked on #442** (base branch is `feat/central-tool-output-cap`) — review/merge #442 first; GitHub will retarget this to `main` once #442 lands. The diff shown here is only the #437-specific changes.

## Problem

Unbounded context growth is the root cause behind the agentic-loop stall symptom (PR #435 fixed the *trigger*, #442/#436 capped a *single* tool result). A diagnosed run reached **~1M prompt tokens** on MiniMax-M3 and degraded into empty/malformed tool calls. Nothing bounded the *cumulative* history within a run.

## Change (`apps/server/src/sessions/service.ts`)

Before each model call in the agentic loop:
1. **Estimate** the request's tokens (~4 chars/token + small per-message/per-tool-call overhead — deliberately no tokenizer dependency on the hot path).
2. If over `maxContextTokens` (new service option, **default 100000**), **elide the bodies of the oldest tool results** — oldest-first, so the model's recent working set is preserved — until it fits.

Safety properties:
- Only a **tool message's `content`** shrinks (replaced with `[Earlier tool output elided to fit context: N characters omitted…]`). The **tool_call↔tool_result pairing** and all assistant/user/system turns are untouched → the request stays provider-valid.
- Elision mutates the in-loop history in place (persists across rounds, so later rounds stay bounded), but the **full results remain in the DB transcript** — only what's re-sent to the model shrinks.
- Distinct from #436: that caps a *single* result at ingest (`truncated for context`); this bounds the *cumulative* history (`elided to fit context`). They compose.

## Why not model-aware yet

The issue asks to track each model's context window. The openai-compatible `getModel` (MiniMax's family) **doesn't report a `contextWindow`** and falls back to a network call for unknown models — so a live lookup is neither reliable nor cheap per-message. I used a conservative, configurable default instead (which the issue explicitly allows) and left config-driven per-model budgets (`appModelConfigSchema.contextWindow`) as a follow-up.

## Tests (`service.test.ts`)

- Over-budget: older tool-result bodies are elided in the **model context** (via #437, not #436), while the **persisted transcript keeps every result in full**.
- Under-budget: history passes through untouched (no elision).
- 22 unit + 14 integration pass; typecheck + ESLint clean.

## Notes

- Commits authored under `imzodev` (large `service.ts` can't be pushed byte-safely via MCP); PR opened via MCP (agentjetson). Byte-identical to the reviewed local commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)