### PR TITLE
feat(sessions): trim stale prior-run tool outputs when replaying history

### DIFF
--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -353,6 +353,7 @@ function makeStreamingService(opts: {
   maxToolRounds: number;
   maxToolOutputChars?: number;
   maxContextTokens?: number;
+  historyToolResultsKept?: number;
   /** Custom executor for the 'echo' tool (e.g. to return an oversized result). */
   echoExecute?: () => Promise<{ ok: true; content: string }>;
   invokeStream: (request: {
@@ -386,6 +387,9 @@ function makeStreamingService(opts: {
     }),
     ...(opts.maxContextTokens !== undefined && {
       maxContextTokens: opts.maxContextTokens,
+    }),
+    ...(opts.historyToolResultsKept !== undefined && {
+      historyToolResultsKept: opts.historyToolResultsKept,
     }),
   });
 
@@ -656,5 +660,78 @@ describe('SessionMessageService — context-window compaction', () => {
     const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
     expect(toolMsg?.content).toBe(SMALL);
     expect(toolMsg?.content).not.toContain('elided');
+  });
+});
+
+// ============================================================================
+// Cross-run history — stale tool-output trimming (issue #438)
+// ============================================================================
+
+describe('SessionMessageService — stale history tool-output trimming', () => {
+  it('summarizes older prior-run tool results on replay but keeps the most recent full', async () => {
+    const BIG = 'H'.repeat(600); // > the 500-char summarize threshold
+    let replayedMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      historyToolResultsKept: 1, // keep only the most recent tool result full
+      maxContextTokens: 10_000_000, // don't let #437 (budget) interfere
+      maxToolOutputChars: 100_000, // don't let #436 (per-result cap) interfere
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        const msgs =
+          (request as { messages?: Array<{ role: string; content: string }> })
+            .messages ?? [];
+        const lastUser = [...msgs].reverse().find((m) => m.role === 'user');
+        // Second submit: capture the replayed history and answer immediately.
+        if (lastUser?.content.includes('inspect')) {
+          replayedMessages = msgs;
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+          return;
+        }
+        // First submit: chain tool calls to populate two prior tool results.
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('History');
+    const sessionId = (session as { id: string }).id;
+
+    // Submit 1: produces two tool results (rounds 0 and 1), persisted.
+    await submit(service, sessionId, 'populate the task');
+    // Submit 2: replays history — trimming should apply.
+    await submit(service, sessionId, 'inspect now');
+
+    const toolMsgs = replayedMessages.filter((m) => m.role === 'tool');
+    expect(toolMsgs.length).toBe(2);
+    // Oldest is summarized…
+    expect(toolMsgs[0]!.content).toContain('Prior tool result elided');
+    expect(toolMsgs[0]!.content).not.toBe(BIG);
+    // …most recent kept full.
+    expect(toolMsgs[1]!.content).toBe(BIG);
+
+    // Transcript keeps both results in full regardless.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBe(2);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
   });
 });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -100,6 +100,7 @@ export class SessionMessageService {
   private readonly maxToolRounds: number;
   private readonly maxToolOutputChars: number;
   private readonly maxContextTokens: number;
+  private readonly historyToolResultsKept: number;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -130,6 +131,7 @@ export class SessionMessageService {
     this.maxToolRounds = options.maxToolRounds ?? 25;
     this.maxToolOutputChars = options.maxToolOutputChars ?? 24_000;
     this.maxContextTokens = options.maxContextTokens ?? 100_000;
+    this.historyToolResultsKept = options.historyToolResultsKept ?? 10;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -218,6 +220,46 @@ export class SessionMessageService {
    * The full results remain in the persisted transcript; this only shapes what
    * is re-sent to the model.
    */
+  /**
+   * When rebuilding a session's history for a new run, summarize the bodies of
+   * older tool results so a long multi-run session doesn't re-send every large
+   * tool output on every turn (issue #438). Unlike the per-round budget guard
+   * (#437, which only fires when *over* the token budget), this always keeps
+   * the request lean — the most-recent `historyToolResultsKept` tool results
+   * stay full (the model's likely working set on a "continue"), older ones are
+   * collapsed to a short notice. Only a tool message's `content` shrinks, so
+   * the tool_call↔tool_result pairing stays provider-valid; the full result
+   * remains in the persisted transcript. Mutates in place; returns count.
+   *
+   * The short summaries it writes fall under the #437 elide threshold, so the
+   * two passes compose without re-processing each other's output.
+   */
+  private trimStaleHistoryToolOutputs(messages: Message[]): number {
+    const keepRecent = this.historyToolResultsKept;
+    const MIN_SUMMARIZE_CHARS = 500; // leave small results alone
+    const PREFIX = '[Prior tool result elided from context:';
+
+    const toolIndexes: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i]!.role === 'tool') toolIndexes.push(i);
+    }
+    if (toolIndexes.length <= keepRecent) return 0;
+
+    const oldCount = toolIndexes.length - keepRecent;
+    let trimmed = 0;
+    for (let j = 0; j < oldCount; j++) {
+      const m = messages[toolIndexes[j]!]!;
+      const content = m.content ?? '';
+      if (content.startsWith(PREFIX)) continue;
+      if (content.length <= MIN_SUMMARIZE_CHARS) continue;
+      (m as { content: string }).content =
+        `${PREFIX} ${content.length} characters from an earlier turn omitted. ` +
+        `The full result is preserved in the transcript.]`;
+      trimmed++;
+    }
+    return trimmed;
+  }
+
   private compactContextInPlace(messages: Message[]): number {
     const budget = this.maxContextTokens;
     if (this.estimateTokens(messages) <= budget) return 0;
@@ -1176,6 +1218,22 @@ export class SessionMessageService {
         role: msgRole as 'system' | 'user',
         content: msgContent,
       } as Message);
+    }
+
+    // Summarize older tool-result bodies from prior turns so a long session
+    // doesn't re-send every large output each run (issue #438). Keeps the most
+    // recent results full; the full bodies stay in the persisted transcript.
+    const trimmedHistory = this.trimStaleHistoryToolOutputs(historyMessages);
+    if (trimmedHistory > 0) {
+      this.logger?.info(
+        {
+          sessionId: input.sessionId,
+          runId: run.id,
+          trimmed: trimmedHistory,
+          keptRecent: this.historyToolResultsKept,
+        },
+        'Trimmed stale tool outputs from replayed history',
+      );
     }
 
     // 5. Build tool definitions (needed for system prompt and invocation)

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -150,6 +150,15 @@ export type SessionMessageServiceOptions = {
    * results remain in the persisted transcript. Defaults to 100000.
    */
   maxContextTokens?: number;
+  /**
+   * How many of the most-recent tool results to replay in full when
+   * reconstructing a session's history for a new run. Older tool-result bodies
+   * from prior turns are summarized (their tool_call pairing is preserved), so
+   * a long multi-run session doesn't re-send every large tool output on every
+   * turn — a cost/latency win even when the request is under `maxContextTokens`.
+   * The full results remain in the persisted transcript. Defaults to 10.
+   */
+  historyToolResultsKept?: number;
   repositories?:
     | {
         sessions: SessionsStore;


### PR DESCRIPTION
Closes #438. **Stacked on #443 → #442** (base is `feat/context-window-compaction`). Merge order: **#442 → #443 → this**; GitHub retargets to `main` as each lands. Diff shown is only the #438-specific changes.

## Problem

Each new run replays the **entire** session history, so every large tool output from a prior turn is re-sent on every subsequent run. In the diagnosed session, **run 2 reached ~1.05M prompt tokens** replaying run 1's outputs.

The per-round budget guard (#437) only fires when the request is *over* the token budget. A long session sitting *under* budget still pays to re-send full stale tool bodies every turn — pure cost/latency waste. This is the non-redundant gap #438 fills.

## Change (`apps/server/src/sessions/service.ts`)

When reconstructing history for a new run, summarize the bodies of **older** tool results:
- Keep the most recent `historyToolResultsKept` tool results **full** (new option, **default 10**) — the likely working set on a "continue".
- Collapse older ones over 500 chars to `[Prior tool result elided from context: N characters … omitted]`.
- Only a tool message's `content` shrinks → tool_call↔result pairing stays provider-valid; full results remain in the persisted transcript.

## How it composes with #436/#437

Three passes, non-overlapping by construction:
- **#436** caps a *single* result at ingest (`truncated for context`).
- **#438** (this) trims *old prior-run* results at reconstruction, always-on (`elided from context`).
- **#437** elides *oldest* results per-round only when *over budget* (`elided to fit context`).

#438's summaries are short (< #437's 500-char elide threshold), so #437 skips them — no double-processing.

## Tests (`service.test.ts`)

- Two-submit flow: submit 1 populates two prior-run tool results; submit 2's replayed request has the **older** one summarized and the **most recent** kept full, while the **persisted transcript keeps both in full**. (`maxContextTokens`/`maxToolOutputChars` set high so only #438 fires.)
- 23 unit + 14 integration pass; typecheck + ESLint clean.

## Notes

- Commits under `imzodev` (large `service.ts` isn't byte-safe via MCP); PR opened via MCP (agentjetson). Byte-identical to the reviewed local commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)