### PR TITLE
fix(sessions): land context compaction + stale-history trim on main (recover #443/#444)

### DIFF
--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -352,6 +352,8 @@ describe('SessionMessageService.updateSessionTitle', () => {
 function makeStreamingService(opts: {
   maxToolRounds: number;
   maxToolOutputChars?: number;
+  maxContextTokens?: number;
+  historyToolResultsKept?: number;
   /** Custom executor for the 'echo' tool (e.g. to return an oversized result). */
   echoExecute?: () => Promise<{ ok: true; content: string }>;
   invokeStream: (request: {
@@ -382,6 +384,12 @@ function makeStreamingService(opts: {
     maxToolRounds: opts.maxToolRounds,
     ...(opts.maxToolOutputChars !== undefined && {
       maxToolOutputChars: opts.maxToolOutputChars,
+    }),
+    ...(opts.maxContextTokens !== undefined && {
+      maxContextTokens: opts.maxContextTokens,
+    }),
+    ...(opts.historyToolResultsKept !== undefined && {
+      historyToolResultsKept: opts.historyToolResultsKept,
     }),
   });
 
@@ -554,5 +562,176 @@ describe('SessionMessageService — tool-output context cap', () => {
     const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
     expect(toolMsg?.content).toBe(SMALL);
     expect(toolMsg?.content).not.toContain('truncated');
+  });
+});
+
+// ============================================================================
+// Agentic tool-call loop — context-window compaction (issue #437)
+// ============================================================================
+
+describe('SessionMessageService — context-window compaction', () => {
+  it('elides older tool-result bodies in the model context when over the token budget', async () => {
+    const BIG = 'Y'.repeat(400); // > the 200-char elide threshold
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      // Tiny budget so accumulated tool output must be compacted…
+      maxContextTokens: 20,
+      // …but the per-result cap is high, so #436 truncation is NOT what fires.
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Compact');
+    const sessionId = (session as { id: string }).id;
+    const result = await submit(service, sessionId);
+    expect(result.ok).toBe(true);
+
+    // At least one older tool result was collapsed to the elision notice…
+    const toolMsgs = finalRoundMessages.filter((m) => m.role === 'tool');
+    const elided = toolMsgs.filter((m) =>
+      m.content.includes('elided to fit context'),
+    );
+    expect(elided.length).toBeGreaterThan(0);
+    // …and elided by #437 (compaction), not #436 (per-result truncation).
+    expect(elided[0]!.content).not.toContain('truncated for context');
+
+    // The persisted transcript keeps every tool result in full.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBeGreaterThan(0);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
+  });
+
+  it('leaves history untouched when under the token budget', async () => {
+    const SMALL = 'z'.repeat(300);
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 2,
+      maxContextTokens: 1_000_000, // effectively unlimited
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: SMALL }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('No compact');
+    await submit(service, (session as { id: string }).id);
+
+    const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
+    expect(toolMsg?.content).toBe(SMALL);
+    expect(toolMsg?.content).not.toContain('elided');
+  });
+});
+
+// ============================================================================
+// Cross-run history — stale tool-output trimming (issue #438)
+// ============================================================================
+
+describe('SessionMessageService — stale history tool-output trimming', () => {
+  it('summarizes older prior-run tool results on replay but keeps the most recent full', async () => {
+    const BIG = 'H'.repeat(600); // > the 500-char summarize threshold
+    let replayedMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      historyToolResultsKept: 1, // keep only the most recent tool result full
+      maxContextTokens: 10_000_000, // don't let #437 (budget) interfere
+      maxToolOutputChars: 100_000, // don't let #436 (per-result cap) interfere
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        const msgs =
+          (request as { messages?: Array<{ role: string; content: string }> })
+            .messages ?? [];
+        const lastUser = [...msgs].reverse().find((m) => m.role === 'user');
+        // Second submit: capture the replayed history and answer immediately.
+        if (lastUser?.content.includes('inspect')) {
+          replayedMessages = msgs;
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+          return;
+        }
+        // First submit: chain tool calls to populate two prior tool results.
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('History');
+    const sessionId = (session as { id: string }).id;
+
+    // Submit 1: produces two tool results (rounds 0 and 1), persisted.
+    await submit(service, sessionId, 'populate the task');
+    // Submit 2: replays history — trimming should apply.
+    await submit(service, sessionId, 'inspect now');
+
+    const toolMsgs = replayedMessages.filter((m) => m.role === 'tool');
+    expect(toolMsgs.length).toBe(2);
+    // Oldest is summarized…
+    expect(toolMsgs[0]!.content).toContain('Prior tool result elided');
+    expect(toolMsgs[0]!.content).not.toBe(BIG);
+    // …most recent kept full.
+    expect(toolMsgs[1]!.content).toBe(BIG);
+
+    // Transcript keeps both results in full regardless.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBe(2);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
   });
 });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -99,6 +99,8 @@ export class SessionMessageService {
   private readonly modelPricing: Record<string, ModelPricing> | undefined;
   private readonly maxToolRounds: number;
   private readonly maxToolOutputChars: number;
+  private readonly maxContextTokens: number;
+  private readonly historyToolResultsKept: number;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -128,6 +130,8 @@ export class SessionMessageService {
     this.modelPricing = options.modelPricing;
     this.maxToolRounds = options.maxToolRounds ?? 25;
     this.maxToolOutputChars = options.maxToolOutputChars ?? 24_000;
+    this.maxContextTokens = options.maxContextTokens ?? 100_000;
+    this.historyToolResultsKept = options.historyToolResultsKept ?? 10;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -181,6 +185,103 @@ export class SessionMessageService {
       `preserved in the transcript. If you need more, narrow the query, ` +
       `request a specific section/line range, or paginate.]`
     );
+  }
+
+  /**
+   * Rough token estimate for a set of messages (~4 chars/token plus a small
+   * per-message and per-tool-call overhead). Good enough to decide *when* to
+   * compact; we deliberately avoid a real tokenizer dependency on the hot path.
+   */
+  private estimateTokens(messages: Message[]): number {
+    let chars = 0;
+    for (const m of messages) {
+      chars += (m.content?.length ?? 0) + 8; // + role/framing overhead
+      const toolCalls = (
+        m as { toolCalls?: Array<{ arguments?: string; name?: string }> }
+      ).toolCalls;
+      if (toolCalls) {
+        for (const tc of toolCalls) {
+          chars += (tc.arguments?.length ?? 0) + (tc.name?.length ?? 0) + 16;
+        }
+      }
+    }
+    return Math.ceil(chars / 4);
+  }
+
+  /**
+   * Keep the loop history within `maxContextTokens` by eliding the *bodies* of
+   * the oldest tool results (issue #437). Recent tool results — the model's
+   * working set — are preserved; only prior, already-consumed outputs are
+   * collapsed to a short notice. Assistant/user/system turns and the
+   * tool_call↔tool_result pairing are never touched (only a tool message's
+   * `content` shrinks), so the request stays provider-valid. Mutates in place
+   * so the elision persists across subsequent rounds. Returns the count elided.
+   *
+   * The full results remain in the persisted transcript; this only shapes what
+   * is re-sent to the model.
+   */
+  /**
+   * When rebuilding a session's history for a new run, summarize the bodies of
+   * older tool results so a long multi-run session doesn't re-send every large
+   * tool output on every turn (issue #438). Unlike the per-round budget guard
+   * (#437, which only fires when *over* the token budget), this always keeps
+   * the request lean — the most-recent `historyToolResultsKept` tool results
+   * stay full (the model's likely working set on a "continue"), older ones are
+   * collapsed to a short notice. Only a tool message's `content` shrinks, so
+   * the tool_call↔tool_result pairing stays provider-valid; the full result
+   * remains in the persisted transcript. Mutates in place; returns count.
+   *
+   * The short summaries it writes fall under the #437 elide threshold, so the
+   * two passes compose without re-processing each other's output.
+   */
+  private trimStaleHistoryToolOutputs(messages: Message[]): number {
+    const keepRecent = this.historyToolResultsKept;
+    const MIN_SUMMARIZE_CHARS = 500; // leave small results alone
+    const PREFIX = '[Prior tool result elided from context:';
+
+    const toolIndexes: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i]!.role === 'tool') toolIndexes.push(i);
+    }
+    if (toolIndexes.length <= keepRecent) return 0;
+
+    const oldCount = toolIndexes.length - keepRecent;
+    let trimmed = 0;
+    for (let j = 0; j < oldCount; j++) {
+      const m = messages[toolIndexes[j]!]!;
+      const content = m.content ?? '';
+      if (content.startsWith(PREFIX)) continue;
+      if (content.length <= MIN_SUMMARIZE_CHARS) continue;
+      (m as { content: string }).content =
+        `${PREFIX} ${content.length} characters from an earlier turn omitted. ` +
+        `The full result is preserved in the transcript.]`;
+      trimmed++;
+    }
+    return trimmed;
+  }
+
+  private compactContextInPlace(messages: Message[]): number {
+    const budget = this.maxContextTokens;
+    if (this.estimateTokens(messages) <= budget) return 0;
+
+    const ELISION_PREFIX = '[Earlier tool output elided to fit context:';
+    const MIN_ELIDE_CHARS = 200; // not worth collapsing tiny results
+    let elided = 0;
+
+    // Oldest-first: the earliest tool results are the least likely to still
+    // matter to the current step.
+    for (const m of messages) {
+      if (this.estimateTokens(messages) <= budget) break;
+      if (m.role !== 'tool') continue;
+      const content = m.content ?? '';
+      if (content.startsWith(ELISION_PREFIX)) continue; // already elided
+      if (content.length <= MIN_ELIDE_CHARS) continue;
+      (m as { content: string }).content =
+        `${ELISION_PREFIX} ${content.length} characters omitted. The full ` +
+        `result is preserved in the transcript.]`;
+      elided++;
+    }
+    return elided;
   }
 
   /**
@@ -1119,6 +1220,22 @@ export class SessionMessageService {
       } as Message);
     }
 
+    // Summarize older tool-result bodies from prior turns so a long session
+    // doesn't re-send every large output each run (issue #438). Keeps the most
+    // recent results full; the full bodies stay in the persisted transcript.
+    const trimmedHistory = this.trimStaleHistoryToolOutputs(historyMessages);
+    if (trimmedHistory > 0) {
+      this.logger?.info(
+        {
+          sessionId: input.sessionId,
+          runId: run.id,
+          trimmed: trimmedHistory,
+          keptRecent: this.historyToolResultsKept,
+        },
+        'Trimmed stale tool outputs from replayed history',
+      );
+    }
+
     // 5. Build tool definitions (needed for system prompt and invocation)
     const mcpTools = this.buildMcpTools(agentId);
     const nativeToolDefs = this.buildNativeToolDefinitions(agentId);
@@ -1243,6 +1360,26 @@ export class SessionMessageService {
             'Agentic loop hit MAX_TOOL_ROUNDS — forcing a final text response without tools',
           );
         }
+
+        // Keep the request within the input-token budget: elide the oldest
+        // tool-result bodies before sending (issue #437). Unbounded history is
+        // the root cause behind the round-exhaustion/stall symptom — a single
+        // run here reached ~1M prompt tokens on MiniMax-M3 and degraded.
+        const elided = this.compactContextInPlace(loopMessages);
+        if (elided > 0) {
+          this.logger?.warn(
+            {
+              sessionId: input.sessionId,
+              runId: run.id,
+              round,
+              elided,
+              budgetTokens: this.maxContextTokens,
+              estTokens: this.estimateTokens(loopMessages),
+            },
+            'Compacted context — elided oldest tool outputs to fit the token budget',
+          );
+        }
+
         const modelRequest: ModelRequest = {
           model: modelId,
           messages: loopMessages,

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -141,6 +141,24 @@ export type SessionMessageServiceOptions = {
    * the UI/history. Defaults to 24000 (~6k tokens).
    */
   maxToolOutputChars?: number;
+  /**
+   * Approximate input-token budget for the agentic loop. Before each model
+   * call, if the running message history is estimated to exceed this, the
+   * oldest tool-result bodies are elided (their tool_call/result pairing is
+   * preserved) until it fits — keeping a large or long conversation from
+   * degrading tool-calling or overflowing the model's window. The full
+   * results remain in the persisted transcript. Defaults to 100000.
+   */
+  maxContextTokens?: number;
+  /**
+   * How many of the most-recent tool results to replay in full when
+   * reconstructing a session's history for a new run. Older tool-result bodies
+   * from prior turns are summarized (their tool_call pairing is preserved), so
+   * a long multi-run session doesn't re-send every large tool output on every
+   * turn — a cost/latency win even when the request is under `maxContextTokens`.
+   * The full results remain in the persisted transcript. Defaults to 10.
+   */
+  historyToolResultsKept?: number;
   repositories?:
     | {
         sessions: SessionsStore;


### PR DESCRIPTION
## What happened

PRs #443 and #444 were **stacked** (each based on the previous branch, not `main`). All three were merged in quick succession, but GitHub never retargeted the stacked bases to `main` first — so:

- **#442** (base `main`) → merged into `main` ✓
- **#443** (base `feat/central-tool-output-cap`) → merged into that branch, **not main** ✗
- **#444** (base `feat/context-window-compaction`) → merged into that branch, **not main** ✗

Result: `main` has only the tool-output cap (#442); the context compaction and stale-history trim never reached it.

## This PR

Reconstitutes the two missing changes on top of `main`:
- **#443** — token-budget context compaction (`maxContextTokens`, `estimateTokens`, `compactContextInPlace`)
- **#444** — stale prior-run tool-output trimming (`historyToolResultsKept`, `trimStaleHistoryToolOutputs`)

Taken verbatim from `feat/context-window-compaction` (the fully-stacked branch that contained all three). **Purely additive** (+334 lines, 0 deletions), confined to `sessions/service.ts`, its types, and tests — no behavior change vs. the already-reviewed/merged stacked PRs; it only relocates their approved diffs to `main`.

## Verification

- All three feature methods present in `service.ts`; `maxContextTokens` + `historyToolResultsKept` options wired.
- Typecheck clean · 23 unit tests pass (`service.test.ts`).

## After merge

The stale branches (`feat/central-tool-output-cap`, `feat/context-window-compaction`, `feat/trim-stale-history`) can be deleted. To avoid this next time: merge stacked PRs strictly bottom-up and let GitHub retarget each base to `main` before merging the next — or avoid stacking and open each against `main` once its parent lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)