### PR TITLE
feat(sessions): retry degenerate empty turns before falling back

### DIFF
--- a/apps/server/src/providers/infrastructure/openai-compatible/adapter.test.ts
+++ b/apps/server/src/providers/infrastructure/openai-compatible/adapter.test.ts
@@ -768,6 +768,107 @@ describe('OpenAICompatibleProvider', () => {
       }
     });
   });
+
+  // Pins the streaming tool-call parse behavior (issue #439 audit). The
+  // adapter accumulates `delta.tool_calls` by index and emits them before
+  // stream.finished; a `finish_reason: tool_calls` with no tool-call deltas
+  // correctly yields NO tool_call event (a genuine provider quirk the session
+  // loop recovers from via retry, not a parser bug).
+  describe('invokeStream tool-call parsing', () => {
+    const request: ModelRequest = {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'weather in SF?' }],
+      tools: [
+        {
+          name: 'get_weather',
+          description: 'Get weather',
+          parameters: { type: 'object', properties: {} },
+        },
+      ],
+    };
+
+    async function collect(chunks: unknown[]) {
+      const mockStream = (async function* () {
+        for (const c of chunks) yield c;
+      })();
+      mockCreateCompletion.mockResolvedValueOnce(mockStream);
+      const provider = createOpenAICompatibleProvider({ apiKey: 'test-key' });
+      const events: Array<{ type: string; [k: string]: unknown }> = [];
+      for await (const event of provider.invokeStream(request)) {
+        if (event.ok) events.push(event.value as { type: string });
+      }
+      return events;
+    }
+
+    it('assembles incremental tool-call deltas into one tool_call', async () => {
+      const events = await collect([
+        {
+          id: 'c',
+          model: 'gpt-4',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'get_weather', arguments: '{"ci' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: 'c',
+          model: 'gpt-4',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  { index: 0, function: { arguments: 'ty":"SF"}' } },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: 'c',
+          model: 'gpt-4',
+          choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+        },
+      ]);
+
+      const toolCalls = events.filter((e) => e.type === 'stream.tool_call');
+      expect(toolCalls).toHaveLength(1);
+      const tc = toolCalls[0]!.toolCall as { name: string; arguments: string };
+      expect(tc.name).toBe('get_weather');
+      expect(tc.arguments).toBe('{"city":"SF"}');
+      const finished = events.find((e) => e.type === 'stream.finished');
+      expect(finished?.finishReason).toBe('tool_calls');
+    });
+
+    it('emits no tool_call when finish_reason is tool_calls but no deltas arrive (degenerate turn)', async () => {
+      const events = await collect([
+        {
+          id: 'c',
+          model: 'gpt-4',
+          choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+        },
+      ]);
+
+      expect(events.filter((e) => e.type === 'stream.tool_call')).toHaveLength(
+        0,
+      );
+      const finished = events.find((e) => e.type === 'stream.finished');
+      expect(finished?.finishReason).toBe('tool_calls');
+    });
+  });
 });
 
 describe('Factory functions', () => {

--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -352,6 +352,8 @@ describe('SessionMessageService.updateSessionTitle', () => {
 function makeStreamingService(opts: {
   maxToolRounds: number;
   maxToolOutputChars?: number;
+  maxContextTokens?: number;
+  historyToolResultsKept?: number;
   /** Custom executor for the 'echo' tool (e.g. to return an oversized result). */
   echoExecute?: () => Promise<{ ok: true; content: string }>;
   invokeStream: (request: {
@@ -382,6 +384,12 @@ function makeStreamingService(opts: {
     maxToolRounds: opts.maxToolRounds,
     ...(opts.maxToolOutputChars !== undefined && {
       maxToolOutputChars: opts.maxToolOutputChars,
+    }),
+    ...(opts.maxContextTokens !== undefined && {
+      maxContextTokens: opts.maxContextTokens,
+    }),
+    ...(opts.historyToolResultsKept !== undefined && {
+      historyToolResultsKept: opts.historyToolResultsKept,
     }),
   });
 
@@ -554,5 +562,176 @@ describe('SessionMessageService — tool-output context cap', () => {
     const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
     expect(toolMsg?.content).toBe(SMALL);
     expect(toolMsg?.content).not.toContain('truncated');
+  });
+});
+
+// ============================================================================
+// Agentic tool-call loop — context-window compaction (issue #437)
+// ============================================================================
+
+describe('SessionMessageService — context-window compaction', () => {
+  it('elides older tool-result bodies in the model context when over the token budget', async () => {
+    const BIG = 'Y'.repeat(400); // > the 200-char elide threshold
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      // Tiny budget so accumulated tool output must be compacted…
+      maxContextTokens: 20,
+      // …but the per-result cap is high, so #436 truncation is NOT what fires.
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Compact');
+    const sessionId = (session as { id: string }).id;
+    const result = await submit(service, sessionId);
+    expect(result.ok).toBe(true);
+
+    // At least one older tool result was collapsed to the elision notice…
+    const toolMsgs = finalRoundMessages.filter((m) => m.role === 'tool');
+    const elided = toolMsgs.filter((m) =>
+      m.content.includes('elided to fit context'),
+    );
+    expect(elided.length).toBeGreaterThan(0);
+    // …and elided by #437 (compaction), not #436 (per-result truncation).
+    expect(elided[0]!.content).not.toContain('truncated for context');
+
+    // The persisted transcript keeps every tool result in full.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBeGreaterThan(0);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
+  });
+
+  it('leaves history untouched when under the token budget', async () => {
+    const SMALL = 'z'.repeat(300);
+    let finalRoundMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 2,
+      maxContextTokens: 1_000_000, // effectively unlimited
+      maxToolOutputChars: 100_000,
+      echoExecute: async () => ({ ok: true as const, content: SMALL }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          finalRoundMessages =
+            (request as { messages?: Array<{ role: string; content: string }> })
+              .messages ?? [];
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('No compact');
+    await submit(service, (session as { id: string }).id);
+
+    const toolMsg = finalRoundMessages.find((m) => m.role === 'tool');
+    expect(toolMsg?.content).toBe(SMALL);
+    expect(toolMsg?.content).not.toContain('elided');
+  });
+});
+
+// ============================================================================
+// Cross-run history — stale tool-output trimming (issue #438)
+// ============================================================================
+
+describe('SessionMessageService — stale history tool-output trimming', () => {
+  it('summarizes older prior-run tool results on replay but keeps the most recent full', async () => {
+    const BIG = 'H'.repeat(600); // > the 500-char summarize threshold
+    let replayedMessages: Array<{ role: string; content: string }> = [];
+
+    const { service } = makeStreamingService({
+      maxToolRounds: 3,
+      historyToolResultsKept: 1, // keep only the most recent tool result full
+      maxContextTokens: 10_000_000, // don't let #437 (budget) interfere
+      maxToolOutputChars: 100_000, // don't let #436 (per-result cap) interfere
+      echoExecute: async () => ({ ok: true as const, content: BIG }),
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        const msgs =
+          (request as { messages?: Array<{ role: string; content: string }> })
+            .messages ?? [];
+        const lastUser = [...msgs].reverse().find((m) => m.role === 'user');
+        // Second submit: capture the replayed history and answer immediately.
+        if (lastUser?.content.includes('inspect')) {
+          replayedMessages = msgs;
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+          return;
+        }
+        // First submit: chain tool calls to populate two prior tool results.
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: {
+              id: `tc_${Math.random()}`,
+              name: 'echo',
+              arguments: {},
+            },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('History');
+    const sessionId = (session as { id: string }).id;
+
+    // Submit 1: produces two tool results (rounds 0 and 1), persisted.
+    await submit(service, sessionId, 'populate the task');
+    // Submit 2: replays history — trimming should apply.
+    await submit(service, sessionId, 'inspect now');
+
+    const toolMsgs = replayedMessages.filter((m) => m.role === 'tool');
+    expect(toolMsgs.length).toBe(2);
+    // Oldest is summarized…
+    expect(toolMsgs[0]!.content).toContain('Prior tool result elided');
+    expect(toolMsgs[0]!.content).not.toBe(BIG);
+    // …most recent kept full.
+    expect(toolMsgs[1]!.content).toBe(BIG);
+
+    // Transcript keeps both results in full regardless.
+    const persisted = (await service.listMessages(sessionId)) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const persistedTool = persisted.filter((m) => m.role === 'tool');
+    expect(persistedTool.length).toBe(2);
+    for (const m of persistedTool) expect(m.content).toBe(BIG);
   });
 });

--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -735,3 +735,57 @@ describe('SessionMessageService — stale history tool-output trimming', () => {
     for (const m of persistedTool) expect(m.content).toBe(BIG);
   });
 });
+
+// ============================================================================
+// Agentic loop — degenerate empty-turn retry (issue #439)
+// ============================================================================
+
+describe('SessionMessageService — degenerate empty-turn retry', () => {
+  it('retries a finish_reason=tool_calls turn that emits no tool call and no content, then recovers', async () => {
+    let calls = 0;
+    const { service, invokeStream } = makeStreamingService({
+      maxToolRounds: 3,
+      invokeStream: async function* () {
+        const n = calls++;
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (n === 0) {
+          // Degenerate: signals tool_calls but streams nothing parseable.
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          yield ok({ type: 'stream.content_delta', delta: 'recovered' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Retry');
+    const result = await submit(service, (session as { id: string }).id);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Recovered on the retry — a real answer, not the fallback message.
+    expect(result.assistantMessage.content).toBe('recovered');
+    // Original + one retry (retry does not consume a tool round).
+    expect(invokeStream).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back after exhausting retries when the turn stays degenerate', async () => {
+    const { service, invokeStream } = makeStreamingService({
+      maxToolRounds: 5,
+      invokeStream: async function* () {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+      },
+    });
+
+    const session = await service.createSession('Retry exhausted');
+    const result = await submit(service, (session as { id: string }).id);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Never loops forever: original + MAX_EMPTY_TURN_RETRIES (2) = 3 calls.
+    expect(invokeStream).toHaveBeenCalledTimes(3);
+    // Then the #435 fallback keeps the user unblocked.
+    expect(result.assistantMessage.content.toLowerCase()).toContain('continue');
+  });
+});

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -99,6 +99,8 @@ export class SessionMessageService {
   private readonly modelPricing: Record<string, ModelPricing> | undefined;
   private readonly maxToolRounds: number;
   private readonly maxToolOutputChars: number;
+  private readonly maxContextTokens: number;
+  private readonly historyToolResultsKept: number;
   // In-memory counter for ONBOARDING messages per session
   // Key: sessionId, Value: remaining count (2 = first message + first response)
   private readonly onboardingCounter = new Map<string, number>();
@@ -128,6 +130,8 @@ export class SessionMessageService {
     this.modelPricing = options.modelPricing;
     this.maxToolRounds = options.maxToolRounds ?? 25;
     this.maxToolOutputChars = options.maxToolOutputChars ?? 24_000;
+    this.maxContextTokens = options.maxContextTokens ?? 100_000;
+    this.historyToolResultsKept = options.historyToolResultsKept ?? 10;
 
     if (options.repositories) {
       this.sessionsRepo = options.repositories.sessions;
@@ -181,6 +185,103 @@ export class SessionMessageService {
       `preserved in the transcript. If you need more, narrow the query, ` +
       `request a specific section/line range, or paginate.]`
     );
+  }
+
+  /**
+   * Rough token estimate for a set of messages (~4 chars/token plus a small
+   * per-message and per-tool-call overhead). Good enough to decide *when* to
+   * compact; we deliberately avoid a real tokenizer dependency on the hot path.
+   */
+  private estimateTokens(messages: Message[]): number {
+    let chars = 0;
+    for (const m of messages) {
+      chars += (m.content?.length ?? 0) + 8; // + role/framing overhead
+      const toolCalls = (
+        m as { toolCalls?: Array<{ arguments?: string; name?: string }> }
+      ).toolCalls;
+      if (toolCalls) {
+        for (const tc of toolCalls) {
+          chars += (tc.arguments?.length ?? 0) + (tc.name?.length ?? 0) + 16;
+        }
+      }
+    }
+    return Math.ceil(chars / 4);
+  }
+
+  /**
+   * Keep the loop history within `maxContextTokens` by eliding the *bodies* of
+   * the oldest tool results (issue #437). Recent tool results — the model's
+   * working set — are preserved; only prior, already-consumed outputs are
+   * collapsed to a short notice. Assistant/user/system turns and the
+   * tool_call↔tool_result pairing are never touched (only a tool message's
+   * `content` shrinks), so the request stays provider-valid. Mutates in place
+   * so the elision persists across subsequent rounds. Returns the count elided.
+   *
+   * The full results remain in the persisted transcript; this only shapes what
+   * is re-sent to the model.
+   */
+  /**
+   * When rebuilding a session's history for a new run, summarize the bodies of
+   * older tool results so a long multi-run session doesn't re-send every large
+   * tool output on every turn (issue #438). Unlike the per-round budget guard
+   * (#437, which only fires when *over* the token budget), this always keeps
+   * the request lean — the most-recent `historyToolResultsKept` tool results
+   * stay full (the model's likely working set on a "continue"), older ones are
+   * collapsed to a short notice. Only a tool message's `content` shrinks, so
+   * the tool_call↔tool_result pairing stays provider-valid; the full result
+   * remains in the persisted transcript. Mutates in place; returns count.
+   *
+   * The short summaries it writes fall under the #437 elide threshold, so the
+   * two passes compose without re-processing each other's output.
+   */
+  private trimStaleHistoryToolOutputs(messages: Message[]): number {
+    const keepRecent = this.historyToolResultsKept;
+    const MIN_SUMMARIZE_CHARS = 500; // leave small results alone
+    const PREFIX = '[Prior tool result elided from context:';
+
+    const toolIndexes: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i]!.role === 'tool') toolIndexes.push(i);
+    }
+    if (toolIndexes.length <= keepRecent) return 0;
+
+    const oldCount = toolIndexes.length - keepRecent;
+    let trimmed = 0;
+    for (let j = 0; j < oldCount; j++) {
+      const m = messages[toolIndexes[j]!]!;
+      const content = m.content ?? '';
+      if (content.startsWith(PREFIX)) continue;
+      if (content.length <= MIN_SUMMARIZE_CHARS) continue;
+      (m as { content: string }).content =
+        `${PREFIX} ${content.length} characters from an earlier turn omitted. ` +
+        `The full result is preserved in the transcript.]`;
+      trimmed++;
+    }
+    return trimmed;
+  }
+
+  private compactContextInPlace(messages: Message[]): number {
+    const budget = this.maxContextTokens;
+    if (this.estimateTokens(messages) <= budget) return 0;
+
+    const ELISION_PREFIX = '[Earlier tool output elided to fit context:';
+    const MIN_ELIDE_CHARS = 200; // not worth collapsing tiny results
+    let elided = 0;
+
+    // Oldest-first: the earliest tool results are the least likely to still
+    // matter to the current step.
+    for (const m of messages) {
+      if (this.estimateTokens(messages) <= budget) break;
+      if (m.role !== 'tool') continue;
+      const content = m.content ?? '';
+      if (content.startsWith(ELISION_PREFIX)) continue; // already elided
+      if (content.length <= MIN_ELIDE_CHARS) continue;
+      (m as { content: string }).content =
+        `${ELISION_PREFIX} ${content.length} characters omitted. The full ` +
+        `result is preserved in the transcript.]`;
+      elided++;
+    }
+    return elided;
   }
 
   /**
@@ -1119,6 +1220,22 @@ export class SessionMessageService {
       } as Message);
     }
 
+    // Summarize older tool-result bodies from prior turns so a long session
+    // doesn't re-send every large output each run (issue #438). Keeps the most
+    // recent results full; the full bodies stay in the persisted transcript.
+    const trimmedHistory = this.trimStaleHistoryToolOutputs(historyMessages);
+    if (trimmedHistory > 0) {
+      this.logger?.info(
+        {
+          sessionId: input.sessionId,
+          runId: run.id,
+          trimmed: trimmedHistory,
+          keptRecent: this.historyToolResultsKept,
+        },
+        'Trimmed stale tool outputs from replayed history',
+      );
+    }
+
     // 5. Build tool definitions (needed for system prompt and invocation)
     const mcpTools = this.buildMcpTools(agentId);
     const nativeToolDefs = this.buildNativeToolDefinitions(agentId);
@@ -1243,6 +1360,26 @@ export class SessionMessageService {
             'Agentic loop hit MAX_TOOL_ROUNDS — forcing a final text response without tools',
           );
         }
+
+        // Keep the request within the input-token budget: elide the oldest
+        // tool-result bodies before sending (issue #437). Unbounded history is
+        // the root cause behind the round-exhaustion/stall symptom — a single
+        // run here reached ~1M prompt tokens on MiniMax-M3 and degraded.
+        const elided = this.compactContextInPlace(loopMessages);
+        if (elided > 0) {
+          this.logger?.warn(
+            {
+              sessionId: input.sessionId,
+              runId: run.id,
+              round,
+              elided,
+              budgetTokens: this.maxContextTokens,
+              estTokens: this.estimateTokens(loopMessages),
+            },
+            'Compacted context — elided oldest tool outputs to fit the token budget',
+          );
+        }
+
         const modelRequest: ModelRequest = {
           model: modelId,
           messages: loopMessages,

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -1337,6 +1337,14 @@ export class SessionMessageService {
       // many tool calls (read files, search, fetch), so keep this generous —
       // a low cap makes the agent run out of rounds mid-task and stop.
       const MAX_TOOL_ROUNDS = this.maxToolRounds;
+      // Bounded recovery for degenerate turns: some providers (MiniMax under
+      // heavy context) occasionally report finish_reason `tool_calls` while
+      // emitting no parseable tool call and no content. That would otherwise
+      // fall straight through to the empty-message fallback and stall the run.
+      // Retry the turn a few times first — it's usually transient. Counted
+      // across the whole run so a persistently-broken turn can't loop forever.
+      const MAX_EMPTY_TURN_RETRIES = 2;
+      let emptyTurnRetries = 0;
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         // On the final permitted round, stop offering tools so the model is
         // forced to turn what it has gathered into a text answer. Without this,
@@ -1506,6 +1514,30 @@ export class SessionMessageService {
             errorCode,
             errorMessage,
           );
+        }
+
+        // Degenerate-turn recovery (#439): the model signaled it wanted tools
+        // but emitted no parseable tool call AND no text. Nothing was appended
+        // to loopMessages, so re-invoking replays the same request — usually
+        // enough to recover, since sampling varies. Doesn't consume a tool
+        // round (round is restored); bounded by MAX_EMPTY_TURN_RETRIES.
+        const degenerateEmptyTurn =
+          finalFinishReason === 'tool_calls' &&
+          toolCalls.length === 0 &&
+          accumulatedContent.trim() === '';
+        if (degenerateEmptyTurn && emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+          emptyTurnRetries++;
+          this.logger?.warn(
+            {
+              sessionId: input.sessionId,
+              runId: run.id,
+              round,
+              retry: emptyTurnRetries,
+            },
+            'Model signaled tool_calls but returned none — retrying the turn',
+          );
+          round--; // retry this round without consuming the budget
+          continue;
         }
 
         // If the model made tool calls, execute them and continue the loop

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -141,6 +141,24 @@ export type SessionMessageServiceOptions = {
    * the UI/history. Defaults to 24000 (~6k tokens).
    */
   maxToolOutputChars?: number;
+  /**
+   * Approximate input-token budget for the agentic loop. Before each model
+   * call, if the running message history is estimated to exceed this, the
+   * oldest tool-result bodies are elided (their tool_call/result pairing is
+   * preserved) until it fits — keeping a large or long conversation from
+   * degrading tool-calling or overflowing the model's window. The full
+   * results remain in the persisted transcript. Defaults to 100000.
+   */
+  maxContextTokens?: number;
+  /**
+   * How many of the most-recent tool results to replay in full when
+   * reconstructing a session's history for a new run. Older tool-result bodies
+   * from prior turns are summarized (their tool_call pairing is preserved), so
+   * a long multi-run session doesn't re-send every large tool output on every
+   * turn — a cost/latency win even when the request is under `maxContextTokens`.
+   * The full results remain in the persisted transcript. Defaults to 10.
+   */
+  historyToolResultsKept?: number;
   repositories?:
     | {
         sessions: SessionsStore;


### PR DESCRIPTION
Closes #439.

> **Note:** built on top of #445's content (context-mgmt on main). This PR's diff is only the #439 changes; merge after #445 lands and it applies cleanly to `main`.

## Part 1 — retry (the fix)

When a turn returns `finish_reason: tool_calls` but **no parseable tool call and no content** (the seq-33 degenerate turn — MiniMax under heavy context occasionally does this), #435 only substituted a fallback message, leaving the user to re-prompt "continue".

Now the loop **retries the turn** up to `MAX_EMPTY_TURN_RETRIES` (2) first. Nothing was appended to the history on a degenerate turn, so re-invoking replays the same request and sampling variance usually recovers. Properties:
- Retries **don't consume a tool round** (the round index is restored).
- Bounded **per-run**, so a persistently-broken turn can't loop forever.
- The #435 empty-message fallback remains the final safety net after retries are exhausted.

## Part 2 — parser audit (the "rule out or fix" ask)

Audited the openai-compatible streaming mapper (`adapter.ts`). **It's correct** for standard OpenAI SSE tool-call streaming: it accumulates `delta.tool_calls` by index and emits them before `stream.finished`. A `finish_reason: tool_calls` with no tool-call deltas genuinely yields no tool call — that's **provider misbehavior, not a parse bug**, and is exactly what the Part 1 retry recovers from. No speculative adapter change; instead added **fixture tests** pinning both shapes so the behavior can't silently regress.

## Tests

- `service.test.ts` (+2): recovers on retry (real answer, 2 invocations); stays degenerate → bounded to 3 total invocations then falls back.
- `adapter.test.ts` (+2 fixtures): incremental `delta.tool_calls` assemble into one tool call; `finish_reason: tool_calls` with no deltas emits **no** tool_call.
- 25 session unit + 33 adapter + 14 integration pass; typecheck + ESLint clean.

## Notes

- Commits under `imzodev` (large `service.ts` isn't byte-safe via MCP); PR opened via MCP (agentjetson). Byte-identical to the reviewed local commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)