### PR TITLE
feat(sessions): per-round + per-run context/token observability

### DIFF
--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -367,6 +367,13 @@ function makeStreamingService(opts: {
 
   const invokeStream = vi.fn(opts.invokeStream);
 
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
   const service = new SessionMessageService({
     providers: {
       registry: {
@@ -379,6 +386,7 @@ function makeStreamingService(opts: {
         invokeStream,
       } as unknown as ModelInvocationService,
     },
+    logger: logger as unknown as import('fastify').FastifyBaseLogger,
     agents,
     builtinTools,
     maxToolRounds: opts.maxToolRounds,
@@ -393,7 +401,7 @@ function makeStreamingService(opts: {
     }),
   });
 
-  return { service, invokeStream };
+  return { service, invokeStream, logger };
 }
 
 async function submit(
@@ -787,5 +795,85 @@ describe('SessionMessageService — degenerate empty-turn retry', () => {
     expect(invokeStream).toHaveBeenCalledTimes(3);
     // Then the #435 fallback keeps the user unblocked.
     expect(result.assistantMessage.content.toLowerCase()).toContain('continue');
+  });
+});
+
+// ============================================================================
+// Agentic loop — context observability (issue #440)
+// ============================================================================
+
+describe('SessionMessageService — context observability', () => {
+  it('logs per-round context size and a per-run context summary', async () => {
+    const { service, logger } = makeStreamingService({
+      maxToolRounds: 3,
+      invokeStream: async function* (request) {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        if (request.tools && request.tools.length > 0) {
+          yield ok({
+            type: 'stream.tool_call',
+            toolCall: { id: 'tc_1', name: 'echo', arguments: {} },
+          });
+          yield ok({
+            type: 'stream.usage',
+            usage: { promptTokens: 123, completionTokens: 5, totalTokens: 128 },
+          });
+          yield ok({ type: 'stream.finished', finishReason: 'tool_calls' });
+        } else {
+          yield ok({ type: 'stream.content_delta', delta: 'done' });
+          yield ok({ type: 'stream.finished', finishReason: 'stop' });
+        }
+      },
+    });
+
+    const session = await service.createSession('Obs');
+    const result = await submit(service, (session as { id: string }).id);
+    expect(result.ok).toBe(true);
+
+    // Per-round debug log fired at least once.
+    const roundLogs = logger.debug.mock.calls.filter(
+      (c) => c[1] === 'Agentic loop round context size',
+    );
+    expect(roundLogs.length).toBeGreaterThan(0);
+    expect(roundLogs[0]![0]).toMatchObject({
+      round: expect.any(Number),
+      estTokens: expect.any(Number),
+      messageCount: expect.any(Number),
+    });
+
+    // Exactly one per-run summary, with the fields needed to tune the caps.
+    const summaryLogs = logger.info.mock.calls.filter(
+      (c) => c[1] === 'Agentic run context summary',
+    );
+    expect(summaryLogs).toHaveLength(1);
+    const summary = summaryLogs[0]![0] as {
+      roundsUsed: number;
+      peakPromptTokens: number;
+      peakEstTokens: number;
+      compactionFired: boolean;
+    };
+    expect(summary.roundsUsed).toBeGreaterThan(0);
+    expect(summary.peakPromptTokens).toBe(123); // captured from stream.usage
+    expect(summary.peakEstTokens).toBeGreaterThan(0);
+    expect(summary.compactionFired).toBe(false);
+  });
+
+  it('warns when a round nears the token budget', async () => {
+    const { service, logger } = makeStreamingService({
+      maxToolRounds: 2,
+      maxContextTokens: 10, // tiny, so even the system prompt is "near" it
+      invokeStream: async function* () {
+        yield ok({ type: 'stream.started', providerId: 'mock', model: 'mock' });
+        yield ok({ type: 'stream.content_delta', delta: 'done' });
+        yield ok({ type: 'stream.finished', finishReason: 'stop' });
+      },
+    });
+
+    const session = await service.createSession('Near budget');
+    await submit(service, (session as { id: string }).id);
+
+    const nearWarnings = logger.warn.mock.calls.filter(
+      (c) => c[1] === 'Agentic loop request nearing the context token budget',
+    );
+    expect(nearWarnings.length).toBeGreaterThan(0);
   });
 });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -1345,6 +1345,14 @@ export class SessionMessageService {
       // across the whole run so a persistently-broken turn can't loop forever.
       const MAX_EMPTY_TURN_RETRIES = 2;
       let emptyTurnRetries = 0;
+      // Per-run observability (#440): track how close each round runs to the
+      // token budget and whether the safety mechanisms fired, so the caps
+      // (#436/#437) can be tuned from real data rather than guesswork.
+      const SOFT_BUDGET_FRACTION = 0.8;
+      let roundsUsed = 0;
+      let peakEstTokens = 0;
+      let peakPromptTokens = 0;
+      let compactionFired = false;
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         // On the final permitted round, stop offering tools so the model is
         // forced to turn what it has gathered into a text answer. Without this,
@@ -1375,6 +1383,7 @@ export class SessionMessageService {
         // run here reached ~1M prompt tokens on MiniMax-M3 and degraded.
         const elided = this.compactContextInPlace(loopMessages);
         if (elided > 0) {
+          compactionFired = true;
           this.logger?.warn(
             {
               sessionId: input.sessionId,
@@ -1385,6 +1394,44 @@ export class SessionMessageService {
               estTokens: this.estimateTokens(loopMessages),
             },
             'Compacted context — elided oldest tool outputs to fit the token budget',
+          );
+        }
+
+        // Per-round context observability (#440). Logged at debug (frequent);
+        // a warn fires only when the request is nearing the budget, so tuning
+        // signals stand out in the logs.
+        roundsUsed = round + 1;
+        const roundEstTokens = this.estimateTokens(loopMessages);
+        if (roundEstTokens > peakEstTokens) peakEstTokens = roundEstTokens;
+        let largestToolResultChars = 0;
+        for (const m of loopMessages) {
+          if (m.role === 'tool') {
+            const len = m.content?.length ?? 0;
+            if (len > largestToolResultChars) largestToolResultChars = len;
+          }
+        }
+        this.logger?.debug(
+          {
+            sessionId: input.sessionId,
+            runId: run.id,
+            round,
+            estTokens: roundEstTokens,
+            messageCount: loopMessages.length,
+            largestToolResultChars,
+            budgetTokens: this.maxContextTokens,
+          },
+          'Agentic loop round context size',
+        );
+        if (roundEstTokens > this.maxContextTokens * SOFT_BUDGET_FRACTION) {
+          this.logger?.warn(
+            {
+              sessionId: input.sessionId,
+              runId: run.id,
+              round,
+              estTokens: roundEstTokens,
+              budgetTokens: this.maxContextTokens,
+            },
+            'Agentic loop request nearing the context token budget',
           );
         }
 
@@ -1468,6 +1515,11 @@ export class SessionMessageService {
               finalUsage.promptTokens += value.usage.promptTokens;
               finalUsage.completionTokens += value.usage.completionTokens;
               finalUsage.totalTokens += value.usage.totalTokens;
+              // Track the largest single-round *actual* prompt size (#440) —
+              // the provider's count, more accurate than our char estimate.
+              if (value.usage.promptTokens > peakPromptTokens) {
+                peakPromptTokens = value.usage.promptTokens;
+              }
               if (value.usage.cacheReadTokens !== undefined) {
                 finalUsage.cacheReadTokens += value.usage.cacheReadTokens;
                 sawCacheTokens = true;
@@ -2009,6 +2061,22 @@ export class SessionMessageService {
       // 9. Update session's agentId to reflect the agent that just ran
       // This allows the session to "remember" which agent was last used
       await this.updateSessionAgentId(input.sessionId, agentId);
+
+      // Per-run context summary (#440): one line to see how hard this run
+      // pushed the budget and whether the safety mechanisms engaged.
+      this.logger?.info(
+        {
+          sessionId: input.sessionId,
+          runId: run.id,
+          roundsUsed,
+          maxRounds: this.maxToolRounds,
+          peakEstTokens,
+          peakPromptTokens,
+          budgetTokens: this.maxContextTokens,
+          compactionFired,
+        },
+        'Agentic run context summary',
+      );
 
       return { ok: true, userMessage, assistantMessage, run: updatedRun! };
     } catch (error) {


### PR DESCRIPTION
Closes #440.

> Based on #439's changes (branched off `feat/retry-empty-turns`), PR against `main`. Merge #446 (#439) first; this then applies cleanly. The retry code appears in this diff only until #446 lands.

## Why

The safety mechanisms shipped in this batch — the tool-output cap (#436) and compaction budget (#437) — use fixed defaults chosen conservatively. There was no visibility into how close real runs actually get to the budget, so those caps could only be tuned by guesswork. This adds that visibility.

## What (`apps/server/src/sessions/service.ts`)

Purely additive logging via the existing `estimateTokens` helper — **no behavior change** to the loop:

- **Per round (`debug`)** — `Agentic loop round context size`: estimated prompt tokens, message count, largest single tool-result size, budget.
- **Per round (`warn`)** — `Agentic loop request nearing the context token budget`: fires when the request crosses **80%** of the budget. Distinct standout signal from the compaction warn (which fires only once *over* budget).
- **Per run (`info`)** — `Agentic run context summary`: `roundsUsed`, `peakEstTokens`, `peakPromptTokens` (the *actual* provider count from `stream.usage`, more accurate than the estimate), `compactionFired`, `budgetTokens`.

## Tests (`service.test.ts`, +2)

- Asserts the per-round debug log and exactly one per-run summary fire, with the summary carrying `roundsUsed`/`peakPromptTokens` (123, captured from a mocked `stream.usage`)/`compactionFired`.
- Asserts the near-budget warn fires when a tiny budget is crossed.
- 27 session unit + 14 integration pass; typecheck + ESLint clean.

## Notes

- Commits under `imzodev` (large `service.ts` isn't byte-safe via MCP); PR opened via MCP (agentjetson). Byte-identical to the reviewed local commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)