### PR TITLE
feat(web): surface paused-mid-task runs with a one-click Continue

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,6 +57,7 @@ import {
 import { ProviderOnboarding } from './components/onboarding/ProviderOnboarding';
 import type { ChoicesEvent } from '@openaidy/shared-types';
 import { ChoicesCard } from './components/ChoicesCard';
+import { PausedRunNotice } from './components/PausedRunNotice';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
 import './index.css';
 
@@ -760,6 +761,19 @@ function AppContent(props: AppContentProps) {
     return data.items || [];
   };
 
+  // The latest run "paused" mid-task: it succeeded but with finish_reason
+  // `tool_calls`, meaning the agent wanted to keep going (hit its step limit
+  // or a degenerate empty turn). Surface a resume affordance instead of
+  // letting it look complete. Runs come back newest-first. Hidden while
+  // streaming or when a choices prompt is pending (mutually exclusive UIs).
+  const isPausedMidTask = (): boolean => {
+    if (isStreaming() || currentChoices()) return false;
+    const latest = runs()[0];
+    return (
+      latest?.status === 'succeeded' && latest?.finishReason === 'tool_calls'
+    );
+  };
+
   const agents = (): Agent[] => {
     return agentsQuery.data?.items || [];
   };
@@ -1039,6 +1053,11 @@ function AppContent(props: AppContentProps) {
                     }}
                   />
                 )}
+              </Show>
+              <Show when={isPausedMidTask()}>
+                <PausedRunNotice
+                  onContinue={() => handleSubmit('continue', selectedAgentId())}
+                />
               </Show>
               <RunList
                 runs={runs()}

--- a/apps/web/src/components/PausedRunNotice.test.tsx
+++ b/apps/web/src/components/PausedRunNotice.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, screen } from '@solidjs/testing-library';
+import { PausedRunNotice } from './PausedRunNotice';
+
+describe('PausedRunNotice', () => {
+  it('renders the paused state with a continue affordance', () => {
+    render(() => <PausedRunNotice onContinue={() => {}} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(
+      screen.getByText(/agent stopped before finishing/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /continue/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('fires onContinue when the Continue button is clicked', () => {
+    const onContinue = vi.fn();
+    render(() => <PausedRunNotice onContinue={onContinue} />);
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PausedRunNotice.tsx
+++ b/apps/web/src/components/PausedRunNotice.tsx
@@ -1,0 +1,41 @@
+import { PauseCircle, PlayCircle } from 'lucide-solid';
+
+export type PausedRunNoticeProps = {
+  /** Send a "continue" turn to resume where the agent left off. */
+  onContinue: () => void;
+};
+
+/**
+ * Shown when the latest run finished with finish_reason `tool_calls` — the
+ * agent wanted to keep going but the turn ended (hit its step limit, or a
+ * degenerate empty turn). Without this, such a run looks complete and the
+ * user has to guess that they need to type "continue". Surfaces an explicit
+ * paused state with a one-click resume.
+ */
+export function PausedRunNotice(props: PausedRunNoticeProps) {
+  return (
+    <div
+      role="status"
+      class="mx-4 my-2 flex items-center gap-3 rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 shadow-sm"
+    >
+      <PauseCircle class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+      <div class="flex-1 min-w-0">
+        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
+          Paused — the agent stopped before finishing
+        </p>
+        <p class="text-xs text-amber-700 dark:text-amber-300/80">
+          It reached its step limit for that turn. Continue to pick up where it
+          left off.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => props.onContinue()}
+        class="flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium px-3 py-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500"
+      >
+        <PlayCircle class="w-4 h-4" />
+        Continue
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #441. Based on `main` (independent of the loop-internals PRs).

## Problem

A run that finishes with `status: succeeded` but `finish_reason: tool_calls` means the agent **wanted to keep going** — it hit its step limit or a degenerate empty turn. The UI rendered it as normally complete, so a paused-mid-task run looked finished and the user had to guess they needed to type "continue". This is the exact surface behind the original *"the agent didn't finish, I had to tell it to continue"* report.

## Change (frontend)

- **`PausedRunNotice.tsx`** (new): an amber "Paused — the agent stopped before finishing" banner with a one-click **Continue** button (theme-aware, `role="status"`).
- **`App.tsx`**: a derived `isPausedMidTask()` — true when the latest run (`runs()[0]`, newest-first) is `succeeded` + `finishReason === 'tool_calls'`, and hidden while streaming or when a choices prompt is pending (mutually exclusive UIs). Renders the banner between the conversation and the composer; **Continue** submits a `"continue"` turn through the existing `handleSubmit` path.

`finishReason` is already persisted on `session_runs` and exposed on the frontend `SessionRun` type, so no backend/API change. This single signal covers both paused cases (step-limit exhaustion and the #435/#439 empty-turn fallback both mark the run `finish_reason: tool_calls`).

## Tests

- `PausedRunNotice.test.tsx` (+2): renders the paused state + Continue affordance; clicking Continue fires `onContinue` once.
- Web typecheck clean; `App.test.tsx` still passes (6/9, 3 pre-existing skips); ESLint clean on changed files.

## Manual check suggestion

Trigger a run that exhausts the step limit (or set a low `maxToolRounds`), confirm the banner appears once the run settles, and that Continue resumes and the banner disappears while streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)