### PR TITLE
feat(usage): show token usage & cost in task execution history rows

### DIFF
--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -51,9 +51,22 @@ export const usageRoutes: FastifyPluginAsync<UsageRoutesOptions> = async (
    * request — so the sessions list can show usage without an N+1 fan-out of
    * `/sessions/:id/usage`. Returned as a map keyed by session id; sessions
    * with no usage yet are simply absent.
+   *
+   * Query params:
+   *   sessionIds — optional comma-separated list to filter to specific
+   *   sessions (avoids fetching the full map when only a few are needed,
+   *   e.g. for task execution history rows).
    */
-  app.get('/usage/sessions', async () => {
-    const rows = await sessionService.getUsageBySession();
+  app.get('/usage/sessions', async (request) => {
+    const query = request.query as { sessionIds?: string };
+    const sessionIds = query.sessionIds
+      ? query.sessionIds
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
+
+    const rows = await sessionService.getUsageBySession(sessionIds);
     const usageBySession: Record<
       string,
       import('@openaidy/db').SessionUsageTotals

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -638,12 +638,16 @@ export class SessionMessageService {
    * Per-session usage totals for every session with succeeded runs, in one
    * query. Used to show usage on the sessions list without an N+1 fan-out.
    * Empty when no DB store.
+   *
+   * @param sessionIds Optional list to filter to specific sessions only.
    */
-  async getUsageBySession(): Promise<
+  async getUsageBySession(
+    sessionIds?: string[],
+  ): Promise<
     Array<import('@openaidy/db').SessionUsageTotals & { sessionId: string }>
   > {
     if (this.runsRepo) {
-      return this.runsRepo.getUsageBySession();
+      return this.runsRepo.getUsageBySession(sessionIds);
     }
     return [];
   }

--- a/apps/web/src/components/pages/TaskExecutionsPage.tsx
+++ b/apps/web/src/components/pages/TaskExecutionsPage.tsx
@@ -5,14 +5,20 @@
  * the Schedule tab "View execution history" link.
  */
 
-import { createResource, createSignal, For, Show } from 'solid-js';
+import { createResource, createSignal, createMemo, For, Show } from 'solid-js';
 import { listTaskExecutions, getTaskSchedule } from '../../lib/api-tasks';
+import { getUsageBySessionIds } from '../../lib/api';
+import {
+  formatTokensCompact,
+  formatCost,
+  formatNumber,
+} from '../../lib/usage-format';
 import type {
   TaskExecutionHistoryStatus,
   ExecutionSubtaskSummary,
 } from '../../lib/types';
 import { ScheduleDisplay } from '../common/ScheduleDisplay';
-import { ArrowLeft, AlertCircle, ExternalLink } from 'lucide-solid';
+import { ArrowLeft, AlertCircle, ExternalLink, Zap } from 'lucide-solid';
 
 const STATUS_COLORS: Record<TaskExecutionHistoryStatus, string> = {
   planned: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
@@ -63,6 +69,25 @@ export function TaskExecutionsPage(props: TaskExecutionsPageProps) {
         offset: page * PAGE_SIZE,
         ...(status ? { status } : {}),
       });
+    },
+  );
+
+  // Collect all session IDs from the visible execution rows so we can
+  // fetch their usage in a single batched call (avoids N+1).
+  const visibleSessionIds = createMemo(() => {
+    const items = data()?.items ?? [];
+    const ids: string[] = [];
+    for (const ex of items) {
+      if (ex.sessionId) ids.push(ex.sessionId);
+    }
+    return ids;
+  });
+
+  const [usageMap] = createResource(
+    () => visibleSessionIds(),
+    async (ids) => {
+      if (ids.length === 0) return {};
+      return getUsageBySessionIds(ids);
     },
   );
 
@@ -226,17 +251,38 @@ export function TaskExecutionsPage(props: TaskExecutionsPageProps) {
                           </span>
                         }
                       >
-                        <button
-                          type="button"
-                          onClick={() =>
-                            ex.sessionId && props.onOpenSession?.(ex.sessionId)
-                          }
-                          class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs"
-                          title="View session"
-                        >
-                          <ExternalLink class="w-3.5 h-3.5" />
-                          View
-                        </button>
+                        {(sid) => {
+                          const usage = () => usageMap()?.[sid()] ?? null;
+                          return (
+                            <div class="flex flex-col gap-0.5">
+                              <button
+                                type="button"
+                                onClick={() => props.onOpenSession?.(sid())}
+                                class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs"
+                                title="View session"
+                              >
+                                <ExternalLink class="w-3.5 h-3.5" />
+                                View
+                              </button>
+                              <Show when={usage()}>
+                                {(u) => (
+                                  <span
+                                    class="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400"
+                                    title={`${formatNumber(u().totalTokens)} tokens across ${u().runCount} run(s)${u().hasCost ? ` · ~$${u().cost.toFixed(4)}` : ''}`}
+                                  >
+                                    <Zap class="w-3 h-3" />
+                                    {formatTokensCompact(u().totalTokens)}{' '}
+                                    tokens
+                                    <Show when={u().hasCost}>
+                                      <span aria-hidden="true">·</span>
+                                      {formatCost(u().cost, u().hasCost)}
+                                    </Show>
+                                  </span>
+                                )}
+                              </Show>
+                            </div>
+                          );
+                        }}
                       </Show>
                     </td>
                     <td class="px-4 py-3">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -589,6 +589,27 @@ export async function getUsageBySession(): Promise<
 }
 
 /**
+ * Fetch usage totals for a specific set of session IDs. Avoids fetching
+ * the full usage map when only a few sessions are needed (e.g. for task
+ * execution history rows). Gracefully degrades to an empty map on error.
+ */
+export async function getUsageBySessionIds(
+  sessionIds: string[],
+): Promise<Record<string, import('./types').UsageTotals>> {
+  if (sessionIds.length === 0) return {};
+  const params = new URLSearchParams();
+  params.set('sessionIds', sessionIds.join(','));
+  const response = await apiFetch(
+    `${API_BASE}/api/usage/sessions?${params.toString()}`,
+  );
+  if (!response.ok) return {};
+  const body = (await response.json()) as {
+    usageBySession?: Record<string, import('./types').UsageTotals>;
+  };
+  return body.usageBySession ?? {};
+}
+
+/**
  * Fetch aggregated usage across all sessions, optionally within a date
  * range (ISO strings; `to` exclusive).
  */

--- a/packages/db/src/repositories/session-runs.ts
+++ b/packages/db/src/repositories/session-runs.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, gte, lt, sql } from 'drizzle-orm';
+import { eq, and, desc, gte, lt, sql, inArray } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import type { DatabaseClient } from '../client';
 import * as schema from '../schema/sessions';
@@ -401,10 +401,17 @@ export class SessionRunsRepository {
    * Postgres. Sessions with no succeeded runs are simply absent from the
    * result. Lets the UI show per-session usage on the whole list without an
    * N+1 fan-out of {@link getSessionUsage} calls.
+   *
+   * @param sessionIds Optional — when provided, only these sessions are
+   * included (useful for task execution history rows etc.).
    */
-  async getUsageBySession(): Promise<
-    Array<SessionUsageTotals & { sessionId: string }>
-  > {
+  async getUsageBySession(
+    sessionIds?: string[],
+  ): Promise<Array<SessionUsageTotals & { sessionId: string }>> {
+    const conditions = [eq(schema.sessionRuns.status, 'succeeded')];
+    if (sessionIds && sessionIds.length > 0) {
+      conditions.push(inArray(schema.sessionRuns.sessionId, sessionIds));
+    }
     const rows = await this.db
       .select({
         sessionId: schema.sessionRuns.sessionId,
@@ -416,7 +423,7 @@ export class SessionRunsRepository {
         cost: schema.sessionRuns.cost,
       })
       .from(schema.sessionRuns)
-      .where(eq(schema.sessionRuns.status, 'succeeded'));
+      .where(and(...conditions));
 
     type Row = {
       sessionId: string;


### PR DESCRIPTION
Closes #434.

## Problem

The execution history table for recurring task schedules (`TaskExecutionsPage`) showed a "View" button in the Session column but no token usage or cost data. To see how much a scheduled run cost, users had to open each session individually.

## Changes

### Backend

- **`GET /api/usage/sessions`** now accepts an optional `?sessionIds=a,b,c` query parameter to filter results to specific sessions. When omitted, returns all sessions (existing behavior unchanged).
- **`SessionRunsRepository.getUsageBySession(sessionIds?)`** — accepts optional `sessionIds` array, uses `inArray` filter when provided.
- **`SessionMessageService.getUsageBySession(sessionIds?)`** — passes the filter through.

### Frontend

- **`getUsageBySessionIds(ids)`** (`api.ts`) — new helper that calls the extended endpoint with the session IDs filter.
- **`TaskExecutionsPage`** — collects session IDs from visible execution rows via `createMemo`, fetches their usage in a single batched call via `createResource`, and renders `formatTokensCompact` + `formatCost` below the "View" button in the Session column. Degrades gracefully when usage data is absent (no crash, no broken layout).

### Design decisions

- **No N+1**: the batched `?sessionIds` approach fetches all needed usage in one request, reusing the existing aggregation logic.
- **Graceful degradation**: if the endpoint returns an error or a session has no usage yet, the badge simply doesn't render — the row stays intact.
- **Reuses existing helpers**: `formatTokensCompact`, `formatCost`, `formatNumber` from `lib/usage-format` — same formatting as `SessionsPage`.
- **SessionsPage untouched**: the filter opt-in for task/subtask sessions remains as-is (intentional per issue spec).

## Files changed

| File | Change |
|------|--------|
| `packages/db/src/repositories/session-runs.ts` | `getUsageBySession()` accepts optional `sessionIds` filter |
| `apps/server/src/sessions/service.ts` | Passes `sessionIds` through to repo |
| `apps/server/src/routes/usage.ts` | `GET /usage/sessions` accepts `?sessionIds` query param |
| `apps/web/src/lib/api.ts` | New `getUsageBySessionIds()` helper |
| `apps/web/src/components/pages/TaskExecutionsPage.tsx` | Batched usage fetch + badge render in Session column |