### PR TITLE
feat(chat): resume in-progress run stream after reconnect / backgrounding

### DIFF
--- a/apps/server/src/websocket/gateway-config.test.ts
+++ b/apps/server/src/websocket/gateway-config.test.ts
@@ -39,6 +39,7 @@ const mockServices = {
   },
   runEvents: {
     subscribe: () => () => {},
+    subscribeAll: () => () => {},
     emit: () => {},
   },
   bootstrapAdmin: undefined,

--- a/apps/server/src/websocket/handlers/session-streaming.test.ts
+++ b/apps/server/src/websocket/handlers/session-streaming.test.ts
@@ -8,8 +8,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SessionHandler } from './session';
 import { StreamManager } from '../streaming';
 import { ConnectionManager } from '../connection-manager';
+import { RunStreamBuffer } from '../run-stream-buffer';
 import type { SessionMessageService } from '../../sessions/service';
-import type { RunEventEmitter } from '../../dispatch/events';
+import { RunEventEmitter } from '../../dispatch/events';
 import type { SubscriptionManager } from '../subscriptions';
 import type { FastifyBaseLogger } from 'fastify';
 import type { HandlerContext } from '../index';
@@ -676,6 +677,107 @@ describe('SessionHandler - auto-rename session after first run', () => {
     expect(mockLoggerForRename.warn).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 'session-1' }),
       'Auto-rename session failed (non-fatal)',
+    );
+  });
+});
+
+// ============================================================================
+// handleResumeStream — resume an in-progress run after reconnect (issue #450)
+// ============================================================================
+
+describe('SessionHandler.handleResumeStream', () => {
+  const makeContext = (streamManager: StreamManager): HandlerContext =>
+    ({
+      connectionManager: {} as unknown as ConnectionManager,
+      services: {} as unknown,
+      logger: mockLogger,
+      streamManager,
+    }) as unknown as HandlerContext;
+
+  it('returns active: false when there is no in-progress run', () => {
+    const emitter = new RunEventEmitter();
+    const buffer = new RunStreamBuffer(emitter);
+    buffer.start();
+    const streamManager = {
+      subscribeToRun: vi.fn(),
+    } as unknown as StreamManager;
+
+    const handler = new SessionHandler(
+      {} as unknown as SessionMessageService,
+      mockLogger,
+      streamManager,
+      emitter,
+      undefined,
+      buffer,
+    );
+
+    const req = createWSMessage('session.stream.resume', { sessionId: 's1' });
+    const res = handler.handleResumeStream(
+      'conn-1',
+      req as unknown as Parameters<typeof handler.handleResumeStream>[1],
+      makeContext(streamManager),
+    );
+
+    expect(res.type).toBe('session.stream.resume');
+    expect(res.payload.active).toBe(false);
+    expect(streamManager.subscribeToRun).not.toHaveBeenCalled();
+  });
+
+  it('subscribes the connection and returns the live snapshot when a run is in flight', () => {
+    const emitter = new RunEventEmitter();
+    const buffer = new RunStreamBuffer(emitter);
+    buffer.start();
+
+    emitter.emitStarted({
+      runId: 'run-9',
+      sessionId: 's1',
+      agentId: 'default',
+      providerId: 'minimax',
+      modelId: 'MiniMax-M3',
+    });
+    emitter.emitDelta({
+      runId: 'run-9',
+      sessionId: 's1',
+      agentId: 'default',
+      content: 'partial answer',
+    });
+    emitter.emitToolCall({
+      runId: 'run-9',
+      sessionId: 's1',
+      agentId: 'default',
+      toolCall: { id: 'tc1', name: 'search', arguments: {} },
+    });
+
+    const streamManager = {
+      subscribeToRun: vi.fn(),
+    } as unknown as StreamManager;
+
+    const handler = new SessionHandler(
+      {} as unknown as SessionMessageService,
+      mockLogger,
+      streamManager,
+      emitter,
+      undefined,
+      buffer,
+    );
+
+    const req = createWSMessage('session.stream.resume', { sessionId: 's1' });
+    const res = handler.handleResumeStream(
+      'conn-1',
+      req as unknown as Parameters<typeof handler.handleResumeStream>[1],
+      makeContext(streamManager),
+    );
+
+    expect(res.payload.active).toBe(true);
+    expect(res.payload.runId).toBe('run-9');
+    expect(res.payload.content).toBe('partial answer');
+    expect(res.payload.toolCalls).toEqual([
+      { id: 'tc1', name: 'search', arguments: {} },
+    ]);
+    // Subscribed so live deltas continue flowing to this connection.
+    expect(streamManager.subscribeToRun).toHaveBeenCalledWith(
+      'run-9',
+      'conn-1',
     );
   });
 });

--- a/apps/server/src/websocket/handlers/session.test.ts
+++ b/apps/server/src/websocket/handlers/session.test.ts
@@ -585,7 +585,11 @@ describe('registerSessionHandlers', () => {
 
     registerSessionHandlers(mockRouter, handler);
 
-    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(9);
+    expect(mockRouter.registerHandler).toHaveBeenCalledTimes(10);
+    expect(mockRouter.registerHandler).toHaveBeenCalledWith(
+      'session.stream.resume',
+      expect.any(Function),
+    );
     expect(mockRouter.registerHandler).toHaveBeenCalledWith(
       'session.create',
       expect.any(Function),

--- a/apps/server/src/websocket/handlers/session.ts
+++ b/apps/server/src/websocket/handlers/session.ts
@@ -8,6 +8,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { SessionMessageService } from '../../sessions/service';
 import type { StreamManager } from '../streaming';
 import type { SubscriptionManager } from '../subscriptions';
+import type { RunStreamBuffer } from '../run-stream-buffer';
 import type { RunEventEmitter } from '../../dispatch/events';
 import type { HandlerContext } from '../index';
 import {
@@ -25,6 +26,8 @@ import {
   type SessionRunsRequest,
   type SessionToolCancelRequest,
   type SessionRunCancelRequest,
+  type SessionStreamResumeRequest,
+  type SessionStreamResumeResponse,
   type SessionCreatedResponse,
   type SessionMessageResponse,
   type SessionMessagesResponse,
@@ -52,6 +55,7 @@ export class SessionHandler {
     private streamManager?: StreamManager,
     private runEvents?: RunEventEmitter,
     private subscriptionManager?: SubscriptionManager,
+    private runStreamBuffer?: RunStreamBuffer,
   ) {}
 
   /**
@@ -427,6 +431,61 @@ export class SessionHandler {
   ): Promise<void> {
     const { runId } = request.payload;
     this.sessionService.cancelRun(runId);
+  }
+
+  /**
+   * Handle session.stream.resume — a reconnected / re-foregrounded client asks
+   * for the live state of any in-progress run on this session (issue #450).
+   *
+   * If a run is in flight we (a) subscribe this connection to its live events
+   * and (b) return a snapshot of what has streamed so far. This is done
+   * synchronously (no await between the snapshot read and the return) so no
+   * delta can interleave: the snapshot is delivered before any subsequent live
+   * delta, and the client rehydrates by *replacing* its content with the
+   * snapshot and then appending live deltas as usual. If no run is active,
+   * `active: false` tells the client to fall back to refetching persisted
+   * messages.
+   */
+  handleResumeStream(
+    connectionId: string,
+    request: SessionStreamResumeRequest,
+    _context: HandlerContext,
+  ): SessionStreamResumeResponse {
+    const { sessionId } = request.payload;
+
+    const snapshot = this.runStreamBuffer?.getActiveForSession(sessionId);
+    if (!snapshot || !this.streamManager) {
+      return createWSMessage(
+        'session.stream.resume',
+        { sessionId, active: false },
+        request.id,
+      ) as SessionStreamResumeResponse;
+    }
+
+    // Subscribe first so every delta emitted after this synchronous block is
+    // delivered live; the snapshot below captures everything up to now.
+    this.streamManager.subscribeToRun(snapshot.runId, connectionId);
+
+    this.logger.info(
+      { sessionId, runId: snapshot.runId, connectionId },
+      'Resumed in-progress run stream',
+    );
+
+    return createWSMessage(
+      'session.stream.resume',
+      {
+        sessionId,
+        active: true,
+        runId: snapshot.runId,
+        agentId: snapshot.agentId,
+        providerId: snapshot.providerId,
+        modelId: snapshot.modelId,
+        content: snapshot.content,
+        toolCalls: snapshot.toolCalls,
+        ...(snapshot.activity && { activity: snapshot.activity }),
+      },
+      request.id,
+    ) as SessionStreamResumeResponse;
   }
 
   /**
@@ -908,6 +967,7 @@ export function createSessionHandler(
   streamManager?: StreamManager,
   runEvents?: RunEventEmitter,
   subscriptionManager?: SubscriptionManager,
+  runStreamBuffer?: RunStreamBuffer,
 ): SessionHandler {
   return new SessionHandler(
     sessionService,
@@ -915,6 +975,7 @@ export function createSessionHandler(
     streamManager,
     runEvents,
     subscriptionManager,
+    runStreamBuffer,
   );
 }
 
@@ -1014,6 +1075,18 @@ export function registerSessionHandlers(
 
   router.registerHandler('session.run.cancel', (connId, msg, ctx) =>
     handler.handleRunCancel(connId, msg as SessionRunCancelRequest, ctx),
+  );
+
+  router.registerHandler(
+    'session.stream.resume',
+    (connId, msg, ctx) =>
+      Promise.resolve(
+        handler.handleResumeStream(
+          connId,
+          msg as SessionStreamResumeRequest,
+          ctx,
+        ),
+      ) as Promise<WSResponse>,
   );
 }
 

--- a/apps/server/src/websocket/index.test.ts
+++ b/apps/server/src/websocket/index.test.ts
@@ -43,6 +43,7 @@ const mockServices = {
   },
   runEvents: {
     subscribe: () => () => {},
+    subscribeAll: () => () => {},
     emit: () => {},
   },
   bootstrapAdmin: undefined,

--- a/apps/server/src/websocket/index.ts
+++ b/apps/server/src/websocket/index.ts
@@ -52,6 +52,7 @@ import { PairingService } from './pairing-service';
 import { NodeRegistry } from './node-registry';
 import { PresenceManager } from './presence-manager';
 import { StreamManager } from './streaming';
+import { RunStreamBuffer } from './run-stream-buffer';
 import { SubscriptionManager } from './subscriptions';
 import { AuthMiddleware } from './middleware/auth';
 
@@ -86,6 +87,7 @@ const MESSAGE_CAPABILITIES: Partial<Record<string, string[]>> = {
   'session.unsubscribe': [WS_CAPABILITIES.SESSIONS_READ],
   'session.tool.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
   'session.run.cancel': [WS_CAPABILITIES.SESSIONS_WRITE],
+  'session.stream.resume': [WS_CAPABILITIES.SESSIONS_READ],
   'agent.list': [WS_CAPABILITIES.AGENTS_READ],
   'agent.get': [WS_CAPABILITIES.AGENTS_READ],
   'provider.list': [WS_CAPABILITIES.PROVIDERS_READ],
@@ -190,6 +192,7 @@ export type WebSocketGateway = {
   configHandler: ConfigHandler;
   presenceHandler: PresenceHandler;
   streamManager: StreamManager;
+  runStreamBuffer: RunStreamBuffer;
   subscriptionManager: SubscriptionManager;
   nodeRegistry: NodeRegistry;
   pairingService: PairingService;
@@ -246,6 +249,9 @@ function createGateway(
     connectionManager,
     fastify.log,
   );
+  // Accumulates in-progress run stream state so reconnecting/foregrounded
+  // clients can resume instead of seeing a stalled UI (issue #450).
+  const runStreamBuffer = new RunStreamBuffer(fastify.services.runEvents);
 
   // Create handlers with streaming support
   const sessionHandler = new SessionHandler(
@@ -254,6 +260,7 @@ function createGateway(
     streamManager,
     fastify.services.runEvents,
     subscriptionManager,
+    runStreamBuffer,
   );
   const agentHandler = new AgentHandler(fastify.services.agents, fastify.log);
   const providerHandler = new ProviderHandler(
@@ -618,12 +625,14 @@ function createGateway(
     configHandler,
     presenceHandler,
     streamManager,
+    runStreamBuffer,
     subscriptionManager,
     nodeRegistry,
     pairingService,
     presenceManager,
     shutdown: async () => {
       streamManager.stop();
+      runStreamBuffer.stop();
       subscriptionManager.cleanup();
       nodeRegistry.clear();
       pairingService.destroy();
@@ -678,6 +687,8 @@ export const websocketGatewayPlugin: FastifyPluginAsync<
 
   // Start the stream manager
   gateway.streamManager.start();
+  // Start buffering in-progress run streams for resume-on-reconnect (#450).
+  gateway.runStreamBuffer.start();
 
   // Store gateway in app
   fastify.decorate('websocketGateway', gateway);

--- a/apps/server/src/websocket/integration/session-integration.test.ts
+++ b/apps/server/src/websocket/integration/session-integration.test.ts
@@ -661,12 +661,13 @@ describe('Session Integration Tests', () => {
       expect(messageRouter.hasHandler('session.runs')).toBe(true);
       expect(messageRouter.hasHandler('session.tool.cancel')).toBe(true);
       expect(messageRouter.hasHandler('session.run.cancel')).toBe(true);
+      expect(messageRouter.hasHandler('session.stream.resume')).toBe(true);
     });
 
-    it('should have exactly 9 session handlers', () => {
+    it('should have exactly 10 session handlers', () => {
       const types = messageRouter.getHandlerTypes();
       const sessionHandlers = types.filter((t) => t.startsWith('session.'));
-      expect(sessionHandlers).toHaveLength(9);
+      expect(sessionHandlers).toHaveLength(10);
     });
   });
 

--- a/apps/server/src/websocket/run-stream-buffer.test.ts
+++ b/apps/server/src/websocket/run-stream-buffer.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RunEventEmitter } from '../dispatch/events';
+import { RunStreamBuffer } from './run-stream-buffer';
+
+const SESSION = 'sess-1';
+const RUN = 'run-1';
+const AGENT = 'default';
+
+function started(emitter: RunEventEmitter) {
+  emitter.emitStarted({
+    runId: RUN,
+    sessionId: SESSION,
+    agentId: AGENT,
+    providerId: 'minimax',
+    modelId: 'MiniMax-M3',
+  });
+}
+
+describe('RunStreamBuffer', () => {
+  let emitter: RunEventEmitter;
+  let buffer: RunStreamBuffer;
+
+  beforeEach(() => {
+    emitter = new RunEventEmitter();
+    buffer = new RunStreamBuffer(emitter);
+    buffer.start();
+  });
+
+  it('has nothing to resume before a run starts', () => {
+    expect(buffer.getActiveForSession(SESSION)).toBeUndefined();
+    expect(buffer.size).toBe(0);
+  });
+
+  it('accumulates content, tool calls and activity while a run streams', () => {
+    started(emitter);
+    emitter.emitDelta({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      content: 'Hello ',
+    });
+    emitter.emitDelta({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      content: 'world',
+    });
+    emitter.emitToolCall({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      toolCall: { id: 'tc1', name: 'search', arguments: { q: 'x' } },
+    });
+    emitter.emitActivity({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      phase: 'running_tool',
+      toolName: 'search',
+      elapsedMs: 1200,
+    });
+
+    const snap = buffer.getActiveForSession(SESSION);
+    expect(snap).toBeDefined();
+    expect(snap!.runId).toBe(RUN);
+    expect(snap!.providerId).toBe('minimax');
+    expect(snap!.modelId).toBe('MiniMax-M3');
+    // Content is the FULL accumulated text (chunks concatenated).
+    expect(snap!.content).toBe('Hello world');
+    expect(snap!.toolCalls).toHaveLength(1);
+    expect(snap!.toolCalls[0]).toMatchObject({ id: 'tc1', name: 'search' });
+    expect(snap!.activity).toEqual({
+      phase: 'running_tool',
+      toolName: 'search',
+      elapsedMs: 1200,
+    });
+  });
+
+  it('drops the buffer when the run completes', () => {
+    started(emitter);
+    emitter.emitDelta({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      content: 'partial',
+    });
+    expect(buffer.getActiveForSession(SESSION)).toBeDefined();
+
+    emitter.emitCompleted({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      finishReason: 'stop',
+    });
+
+    expect(buffer.getActiveForSession(SESSION)).toBeUndefined();
+    expect(buffer.getRun(RUN)).toBeUndefined();
+    expect(buffer.size).toBe(0);
+  });
+
+  it('drops the buffer on failure, cancellation, and choices (suspension)', () => {
+    for (const emitTerminal of [
+      () =>
+        emitter.emitFailed({
+          runId: RUN,
+          sessionId: SESSION,
+          agentId: AGENT,
+          errorCode: 'boom',
+          errorMessage: 'x',
+        }),
+      () =>
+        emitter.emitRunCancelled({
+          runId: RUN,
+          sessionId: SESSION,
+          agentId: AGENT,
+        }),
+      () =>
+        emitter.emitChoices({
+          runId: RUN,
+          sessionId: SESSION,
+          agentId: AGENT,
+          choices: ['a', 'b'],
+        }),
+    ]) {
+      started(emitter);
+      expect(buffer.getActiveForSession(SESSION)).toBeDefined();
+      emitTerminal();
+      expect(buffer.getActiveForSession(SESSION)).toBeUndefined();
+    }
+  });
+
+  it('ignores deltas for a run that never started (no snapshot created)', () => {
+    emitter.emitDelta({
+      runId: 'ghost',
+      sessionId: SESSION,
+      agentId: AGENT,
+      content: 'orphan',
+    });
+    expect(buffer.getActiveForSession(SESSION)).toBeUndefined();
+    expect(buffer.size).toBe(0);
+  });
+
+  it('stops accumulating after stop()', () => {
+    buffer.stop();
+    started(emitter);
+    emitter.emitDelta({
+      runId: RUN,
+      sessionId: SESSION,
+      agentId: AGENT,
+      content: 'ignored',
+    });
+    expect(buffer.getActiveForSession(SESSION)).toBeUndefined();
+  });
+});

--- a/apps/server/src/websocket/run-stream-buffer.ts
+++ b/apps/server/src/websocket/run-stream-buffer.ts
@@ -1,0 +1,155 @@
+/**
+ * Run Stream Buffer
+ *
+ * Accumulates the live streamed state of in-progress runs (content, tool calls,
+ * latest activity) keyed by runId, so a client that reconnects — or returns
+ * from a backgrounded tab / screen-off phone — can resume the stream instead of
+ * seeing a stalled, empty UI until the run finishes (issue #450).
+ *
+ * The run itself keeps executing server-side regardless of the socket; this
+ * buffer just captures what streamed so far. It is memory-only and short-lived:
+ * an entry exists only while its run is in flight and is dropped as soon as the
+ * run reaches a terminal event (completed / failed / cancelled / choices).
+ */
+
+import type { RunEvent, RunEventEmitter } from '../dispatch/events';
+
+export type BufferedToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+export type BufferedActivity = {
+  phase: 'thinking' | 'running_tool';
+  toolName?: string;
+  elapsedMs: number;
+};
+
+export type BufferedRunSnapshot = {
+  runId: string;
+  sessionId: string;
+  agentId: string;
+  providerId: string;
+  modelId: string;
+  /** Full accumulated assistant text so far (NOT a delta). */
+  content: string;
+  toolCalls: BufferedToolCall[];
+  activity?: BufferedActivity;
+};
+
+export class RunStreamBuffer {
+  /** runId -> snapshot */
+  private readonly runs = new Map<string, BufferedRunSnapshot>();
+  /** sessionId -> active runId (one in-flight run per session at a time) */
+  private readonly sessionToRun = new Map<string, string>();
+  private unsubscribe: (() => void) | undefined = undefined;
+
+  constructor(private readonly runEvents: RunEventEmitter) {}
+
+  /** Begin accumulating from the run event stream. */
+  start(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.runEvents.subscribeAll((event) =>
+      this.handle(event),
+    );
+  }
+
+  /** Stop accumulating and drop all buffered state. */
+  stop(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    this.runs.clear();
+    this.sessionToRun.clear();
+  }
+
+  private handle(event: RunEvent): void {
+    switch (event.type) {
+      case 'run.started': {
+        this.runs.set(event.runId, {
+          runId: event.runId,
+          sessionId: event.sessionId,
+          agentId: event.agentId,
+          providerId: (event.data.providerId as string) ?? 'default',
+          modelId: (event.data.modelId as string) ?? 'default',
+          content: '',
+          toolCalls: [],
+        });
+        this.sessionToRun.set(event.sessionId, event.runId);
+        break;
+      }
+      case 'run.delta': {
+        const snap = this.runs.get(event.runId);
+        if (!snap) break;
+        // delta events carry the chunk in both `delta` and `content`.
+        snap.content +=
+          (event.data.delta as string | undefined) ??
+          (event.data.content as string | undefined) ??
+          '';
+        break;
+      }
+      case 'run.tool_call': {
+        const snap = this.runs.get(event.runId);
+        if (!snap) break;
+        const tc = event.data.toolCall as BufferedToolCall | undefined;
+        if (tc) snap.toolCalls.push(tc);
+        break;
+      }
+      case 'run.activity': {
+        const snap = this.runs.get(event.runId);
+        if (!snap) break;
+        snap.activity = {
+          phase: event.data.phase as BufferedActivity['phase'],
+          elapsedMs: event.data.elapsedMs as number,
+          ...(event.data.toolName !== undefined && {
+            toolName: event.data.toolName as string,
+          }),
+        };
+        break;
+      }
+      // Terminal events: the run is over (or suspended awaiting the user), so
+      // there is nothing left to resume — drop the buffer. The client learns
+      // the outcome from the live terminal event or a fresh message fetch.
+      case 'run.completed':
+      case 'run.failed':
+      case 'run.cancelled':
+      case 'session.run.choices': {
+        this.drop(event.runId, event.sessionId);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private drop(runId: string, sessionId: string): void {
+    this.runs.delete(runId);
+    if (this.sessionToRun.get(sessionId) === runId) {
+      this.sessionToRun.delete(sessionId);
+    }
+  }
+
+  /** The in-flight run for a session, if any. */
+  getActiveForSession(sessionId: string): BufferedRunSnapshot | undefined {
+    const runId = this.sessionToRun.get(sessionId);
+    return runId ? this.runs.get(runId) : undefined;
+  }
+
+  /** A specific run's snapshot, if still in flight. */
+  getRun(runId: string): BufferedRunSnapshot | undefined {
+    return this.runs.get(runId);
+  }
+
+  /** Number of runs currently buffered (for tests / diagnostics). */
+  get size(): number {
+    return this.runs.size;
+  }
+}
+
+export function createRunStreamBuffer(
+  runEvents: RunEventEmitter,
+): RunStreamBuffer {
+  return new RunStreamBuffer(runEvents);
+}
+
+export default RunStreamBuffer;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import {
   createSession,
   listMessages,
   submitMessageStreaming,
+  resumeSessionStream,
   listAgents,
   listRuns,
   getSession,
@@ -372,7 +373,7 @@ function AppContent(props: AppContentProps) {
     // the watchdog.
     wsClient
       .subscribeToSession(sessionId)
-      .then(() => reconcileStreamState())
+      .then(() => void resumeOrReconcile())
       .catch((err: Error) => {
         console.error('Failed to subscribe to session:', err);
         setSubmitError(err.message);
@@ -411,7 +412,7 @@ function AppContent(props: AppContentProps) {
   onMount(() => {
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        reconcileStreamState();
+        void resumeOrReconcile();
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
@@ -647,6 +648,49 @@ function AppContent(props: AppContentProps) {
     queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
     queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
     processQueue();
+  };
+
+  // On reconnect / tab-foreground, first ask the server whether a run is still
+  // streaming for this session (issue #450). If so, rehydrate the live UI from
+  // the server's snapshot — content, tool calls, activity — instead of clearing
+  // to a stalled state; live `session.stream.*` events then continue on the
+  // resubscribed run. Only when there's nothing to resume do we fall back to
+  // the plain clear-and-refetch of `reconcileStreamState`.
+  const resumeOrReconcile = async () => {
+    const sessionId = selectedSessionId();
+    if (!sessionId) return;
+
+    const resume = await resumeSessionStream(sessionId).catch(() => null);
+
+    // Bail if the user switched sessions while we awaited.
+    if (selectedSessionId() !== sessionId) return;
+
+    if (resume?.active && resume.runId) {
+      clearStreamWatchdog();
+      setCurrentRunId(resume.runId);
+      setIsStreaming(true);
+      setStreamingContent(resume.content ?? '');
+      setStreamingToolCalls(
+        (resume.toolCalls ?? []).map((tc) => ({
+          id: tc.id,
+          name: tc.name,
+          input: tc.arguments,
+          output: '',
+        })),
+      );
+      setRunActivity(resume.activity ? { ...resume.activity } : undefined);
+      setPendingUserMessage(undefined);
+      // Pull the persisted user message (and any finished prior runs) without
+      // disturbing the live streaming state we just restored; the assistant
+      // message is not persisted until the run ends.
+      queryClient.invalidateQueries({ queryKey: ['messages', sessionId] });
+      queryClient.invalidateQueries({ queryKey: ['runs', sessionId] });
+      // Re-arm the idle guard in case we also missed the end event.
+      armStreamWatchdog();
+      return;
+    }
+
+    reconcileStreamState();
   };
 
   // Actually dispatch a message and begin a streaming run.

--- a/apps/web/src/lib/ws-api.ts
+++ b/apps/web/src/lib/ws-api.ts
@@ -295,6 +295,52 @@ export async function submitMessageStreaming(
   );
 }
 
+/**
+ * Snapshot of an in-progress run's live stream, returned by
+ * {@link resumeSessionStream}. `active: false` means there is nothing to resume.
+ */
+export type ResumeStreamResult = {
+  active: boolean;
+  runId?: string;
+  agentId?: string;
+  providerId?: string;
+  modelId?: string;
+  content?: string;
+  toolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }>;
+  activity?: {
+    phase: 'thinking' | 'running_tool';
+    toolName?: string;
+    elapsedMs: number;
+  };
+};
+
+/**
+ * Ask the server for the live state of any in-progress run on this session so a
+ * reconnected / re-foregrounded client can resume streaming instead of showing
+ * a stalled UI (issue #450). WS-only — returns null if there's no live socket
+ * (the caller then falls back to refetching persisted messages).
+ */
+export async function resumeSessionStream(
+  sessionId: string,
+): Promise<ResumeStreamResult | null> {
+  const client = activeClient;
+  if (!client || !client.isConnected()) return null;
+  try {
+    const response = await client.sendRequest<{
+      type: string;
+      payload: ResumeStreamResult & { sessionId: string };
+    }>('session.stream.resume', { sessionId });
+    if (response?.type !== 'session.stream.resume') return null;
+    return response.payload;
+  } catch {
+    return null;
+  }
+}
+
 export async function listAgents(): Promise<{ items: Agent[] }> {
   return withWebSocketFallback(
     async (client) => {

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -616,6 +616,49 @@ export type SessionMessageStreamAck = WSMessage<
   }
 >;
 
+/**
+ * Request to resume the live stream of an in-progress run after a dropped or
+ * backgrounded connection. The client sends the sessionId; the server looks up
+ * any active run for that session and replies with a snapshot of what has
+ * streamed so far, then continues delivering live `session.stream.*` events.
+ */
+export type SessionStreamResumeRequest = WSMessage<
+  'session.stream.resume',
+  {
+    sessionId: string;
+  }
+>;
+
+/**
+ * Snapshot response for a resume request. `active: false` means there is no
+ * in-progress run to resume (the client should fall back to refetching
+ * persisted messages). When `active: true`, the remaining fields describe the
+ * run's streamed state so far, which the client uses to rehydrate its
+ * streaming UI (content is the full accumulated text, NOT a delta).
+ */
+export type SessionStreamResumeResponse = WSMessage<
+  'session.stream.resume',
+  {
+    sessionId: string;
+    active: boolean;
+    runId?: string;
+    agentId?: string;
+    providerId?: string;
+    modelId?: string;
+    content?: string;
+    toolCalls?: Array<{
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }>;
+    activity?: {
+      phase: 'thinking' | 'running_tool';
+      toolName?: string;
+      elapsedMs: number;
+    };
+  }
+>;
+
 // ============================================================================
 // Agent Types
 // ============================================================================
@@ -997,6 +1040,7 @@ export type WSRequest =
   | SessionUnsubscribeRequest
   | SessionToolCancelRequest
   | SessionRunCancelRequest
+  | SessionStreamResumeRequest
   | SessionMessagesRequest
   | SessionRunsRequest
   | AgentListRequest
@@ -1025,6 +1069,7 @@ export type WSResponse =
   | SessionCreatedResponse
   | SessionMessageResponse
   | SessionMessageStreamAck
+  | SessionStreamResumeResponse
   | SessionMessagesResponse
   | SessionRunsResponse
   | SessionGetResponse
@@ -1074,6 +1119,7 @@ const REQUEST_TYPES: Set<string> = new Set([
   'session.unsubscribe',
   'session.tool.cancel',
   'session.run.cancel',
+  'session.stream.resume',
   'agent.list',
   'agent.get',
   'provider.list',
@@ -1112,6 +1158,7 @@ const RESPONSE_TYPES: Set<string> = new Set([
   'session.stream.usage',
   'session.stream.end',
   'session.stream.error',
+  'session.stream.resume',
   'session.updated',
   'agent.list',
   'agent.get',


### PR DESCRIPTION
Closes #450.

## Problem

Backgrounding the tab (desktop) or turning off the screen (mobile) drops the WebSocket. The run keeps executing server-side, but its stream deltas are fire-and-forget with no buffer, and on return the client cleared its streaming state and refetched persisted messages — which don't include the still-in-progress answer. Result: a stalled-looking UI until the run finished, then the whole answer at once.

## Fix — the robust option from the issue: buffer + replay on resubscribe

### Server
- **`RunStreamBuffer`** (new): subscribes to the global run-event stream and accumulates each in-flight run's snapshot — full accumulated content, tool calls, latest activity — keyed by `runId` and indexed by `sessionId`. Entries are dropped on any terminal event (completed / failed / cancelled / choices).
- **`session.stream.resume`** request: given a `sessionId`, if a run is in flight it (a) subscribes the connection to the live run and (b) returns the snapshot. This is done **synchronously** (no `await` between snapshot read and return) so no delta can interleave — the snapshot is delivered before any subsequent live delta. Returns `active: false` when there's nothing to resume.
- Wired the buffer into the gateway lifecycle (start/stop) and gave the new message `SESSIONS_READ` capability.

### Client
- **`resumeSessionStream()`** issues the new request over WS.
- On reconnect (session (re)subscribe) **and** tab-foreground, `resumeOrReconcile()` tries resume first: if a run is active it **rehydrates** the live UI (content / tool calls / activity, replacing not appending, and re-arms the idle watchdog) so live deltas continue appending normally. It falls back to the old clear-and-refetch (`reconcileStreamState`) only when there's nothing to resume.

This also fixes the full-reload case (client doesn't need to remember the runId — it resumes by `sessionId`).

## Correctness notes
- Delta events carry the chunk (client appends); the buffer accumulates chunks into full content, and resume delivers a **snapshot** via request/response (client replaces), so there's no dup/gap with the append-based live stream. The subscribe-then-snapshot happens in one synchronous block, so ordering is race-free.
- Only tool-call metadata is replayed, not live `exec_output` stdout history (the tool call itself is restored); noted as a minor follow-up if needed.

## Tests
- `run-stream-buffer.test.ts` (6): accumulation, terminal-event cleanup, orphan-delta ignore, stop().
- `handleResumeStream` handler tests (2): `active: false` when idle; snapshot + `subscribeToRun` when in flight.
- Updated handler-count assertions and added `subscribeAll` to mock `runEvents` in the websocket suite.
- Full websocket suite (1003) + shared-types (210) pass; server/web/shared typecheck + lint clean.

## Manual check
Send a message that streams for a while, background the tab / lock the phone, return — the partial answer should reappear and keep streaming, instead of a stalled UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)