### PR TITLE
chore(release): bump version to 0.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Release **v0.3.8**. Bumps root `package.json` 0.3.7 → 0.3.8.

Once merged, pushing the `v0.3.8` tag triggers `release.yml` (gate → npm publish → GitHub Release with auto-generated notes covering all 14 commits since v0.3.7).

## Included since v0.3.7
- feat(chat): resume in-progress run stream after reconnect/backgrounding (#453)
- feat(usage): show token usage & cost in task execution history rows (#449)
- feat(web): surface paused-mid-task runs with a one-click Continue (#448)
- feat(sessions): per-round + per-run context/token observability (#447)
- feat(sessions): retry degenerate empty turns before falling back (#446)
- fix(sessions): land context-window compaction + stale-history trim on main (#445)
- feat(sessions): cap oversized tool results before they enter model context (#442)
- fix(sessions): stop the agentic loop from ending silently on round exhaustion (#435)
- feat(usage): stacked bar chart on Usage page, broken down by model (#433)
- ci: adopt Turborepo for caching + smoke check on push to main (#431)
- fix(addons): stop leaking the master auth token into addon iframes (#430)
- feat(skills): addon-ui-components cookbook skill + card-for-repeated-blocks rule (#426)
- fix(addons): don't force CORS mode on external addon scripts (#425)

🤖 Generated with [Claude Code](https://claude.com/claude-code)