### PR TITLE
fix(addons): don't time out long-running agent invocations in the SDK

### DIFF
--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -15,7 +15,7 @@
 (function (global) {
   'use strict';
 
-  var SDK_VERSION = '0.3.0';
+  var SDK_VERSION = '0.3.1';
   console.log('[OpenAidy SDK] v' + SDK_VERSION + ' loaded');
 
   let _apiBase = null;
@@ -83,8 +83,18 @@
     }
   });
 
-  // Send a proxied API request through the parent
-  function request(method, path, body) {
+  // Default timeout for quick proxied calls (list/get/storage). Kept short so
+  // a genuinely lost response surfaces fast rather than hanging the UI.
+  var DEFAULT_REQUEST_TIMEOUT_MS = 15000;
+  // Timeout for agent-invoking calls (invokeAgent, sendMessage). These block on
+  // a full LLM run server-side and routinely take 30s–150s+, so the short
+  // default would reject a request that actually succeeds. A generous ceiling
+  // still guards against a truly hung run / lost response.
+  var AGENT_REQUEST_TIMEOUT_MS = 300000; // 5 minutes
+
+  // Send a proxied API request through the parent. `timeoutMs` overrides the
+  // default for long-running calls.
+  function request(method, path, body, timeoutMs) {
     return new Promise(function (resolve, reject) {
       if (!_ready) {
         return reject(
@@ -106,13 +116,12 @@
         },
         '*',
       );
-      // Timeout after 15s
       setTimeout(function () {
         if (_pendingRequests.has(requestId)) {
           _pendingRequests.delete(requestId);
           reject(new Error('[OpenAidy SDK] Request timed out: ' + path));
         }
-      }, 15000);
+      }, timeoutMs || DEFAULT_REQUEST_TIMEOUT_MS);
     });
   }
 
@@ -301,10 +310,12 @@
       return request('GET', '/api/addon-proxy/sessions');
     },
     sendMessage: function (sessionId, content, agentId) {
+      // Runs the agent to completion server-side — allow the long timeout.
       return request(
         'POST',
         '/api/addon-proxy/sessions/' + sessionId + '/messages',
         { content: content, agentId: agentId },
+        AGENT_REQUEST_TIMEOUT_MS,
       );
     },
     getSession: function (sessionId) {
@@ -316,10 +327,16 @@
       return request('GET', '/api/addon-proxy/agents');
     },
     invokeAgent: function (agentId, input, context) {
-      return request('POST', '/api/addon-proxy/agents/' + agentId + '/invoke', {
-        input: input,
-        context: context ?? {},
-      });
+      // Blocks on a full LLM run server-side — allow the long timeout.
+      return request(
+        'POST',
+        '/api/addon-proxy/agents/' + agentId + '/invoke',
+        {
+          input: input,
+          context: context ?? {},
+        },
+        AGENT_REQUEST_TIMEOUT_MS,
+      );
     },
 
     // ── Config ────────────────────────────────────────────────────────────
@@ -1668,8 +1685,10 @@
     },
 
     // ── Raw request (escape hatch) ────────────────────────────────────────
-    request: function (method, path, body) {
-      return request(method, path, body);
+    // `timeoutMs` is optional; omit for the default. Pass a larger value for
+    // any custom endpoint that runs an agent / other long operation.
+    request: function (method, path, body, timeoutMs) {
+      return request(method, path, body, timeoutMs);
     },
   };
 


### PR DESCRIPTION
## Problem

Addons that call `sdk.invokeAgent()` (or `sdk.sendMessage()`) intermittently fail with:

```
Error: [OpenAidy SDK] Request timed out: /api/addon-proxy/agents/<id>/invoke
```

even though the agent **finishes successfully**.

## Root cause

The addon SDK's `request()` helper (`apps/server/src/sdk/openaidy-sdk.js`) rejected **every** proxied call after a hardcoded **15s**. But `invokeAgent` and `sendMessage` block on a full LLM run server-side — `ProxyAgentService.invoke` / `submitMessageStreaming` `await` completion before responding.

Confirmed against the reported `trend2short:shorts-scriptwriter` session — every run **succeeded** but ran well past 15s:

| Run | Duration | Status |
|-----|----------|--------|
| 1 | 17s | ✅ succeeded |
| 2 | 116s | ✅ succeeded |
| 3 | 154s | ✅ succeeded |

So the SDK gave up at 15s and threw "Request timed out" (and spent the tokens anyway); when the real response arrived via the parent's un-timed `fetch`, the pending request had already been deleted, so it was silently dropped.

## Fix

Make the timeout per-call in `request(method, path, body, timeoutMs?)`:
- **Quick calls** (list / get / config / storage) keep the **15s** default — a lost response still surfaces fast.
- **Agent-invoking calls** (`invokeAgent`, `sendMessage`) get a **5-minute** ceiling, enough for real LLM runs while still guarding against a genuinely hung run / lost response.
- The raw `sdk.request()` escape hatch accepts an optional `timeoutMs` too.
- Bumps the SDK version string `0.3.0` → `0.3.1`.

## Tests / verification
- Existing SDK-parsing test (`component-manifest.test.ts`) still passes; ESLint clean.
- No unit-test harness exists for the SDK's browser-side `request()` timing (postMessage/DOM IIFE), consistent with prior SDK changes; behavioral verification is by re-running the addon (the 116s/154s runs should now surface their result instead of a timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)