### PR TITLE
feat(chat): add copy buttons for messages and code blocks (#452)

### DIFF
--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -15,7 +15,7 @@
 (function (global) {
   'use strict';
 
-  var SDK_VERSION = '0.3.0';
+  var SDK_VERSION = '0.3.1';
   console.log('[OpenAidy SDK] v' + SDK_VERSION + ' loaded');
 
   let _apiBase = null;
@@ -83,8 +83,18 @@
     }
   });
 
-  // Send a proxied API request through the parent
-  function request(method, path, body) {
+  // Default timeout for quick proxied calls (list/get/storage). Kept short so
+  // a genuinely lost response surfaces fast rather than hanging the UI.
+  var DEFAULT_REQUEST_TIMEOUT_MS = 15000;
+  // Timeout for agent-invoking calls (invokeAgent, sendMessage). These block on
+  // a full LLM run server-side and routinely take 30s–150s+, so the short
+  // default would reject a request that actually succeeds. A generous ceiling
+  // still guards against a truly hung run / lost response.
+  var AGENT_REQUEST_TIMEOUT_MS = 300000; // 5 minutes
+
+  // Send a proxied API request through the parent. `timeoutMs` overrides the
+  // default for long-running calls.
+  function request(method, path, body, timeoutMs) {
     return new Promise(function (resolve, reject) {
       if (!_ready) {
         return reject(
@@ -106,13 +116,12 @@
         },
         '*',
       );
-      // Timeout after 15s
       setTimeout(function () {
         if (_pendingRequests.has(requestId)) {
           _pendingRequests.delete(requestId);
           reject(new Error('[OpenAidy SDK] Request timed out: ' + path));
         }
-      }, 15000);
+      }, timeoutMs || DEFAULT_REQUEST_TIMEOUT_MS);
     });
   }
 
@@ -301,10 +310,12 @@
       return request('GET', '/api/addon-proxy/sessions');
     },
     sendMessage: function (sessionId, content, agentId) {
+      // Runs the agent to completion server-side — allow the long timeout.
       return request(
         'POST',
         '/api/addon-proxy/sessions/' + sessionId + '/messages',
         { content: content, agentId: agentId },
+        AGENT_REQUEST_TIMEOUT_MS,
       );
     },
     getSession: function (sessionId) {
@@ -316,10 +327,16 @@
       return request('GET', '/api/addon-proxy/agents');
     },
     invokeAgent: function (agentId, input, context) {
-      return request('POST', '/api/addon-proxy/agents/' + agentId + '/invoke', {
-        input: input,
-        context: context ?? {},
-      });
+      // Blocks on a full LLM run server-side — allow the long timeout.
+      return request(
+        'POST',
+        '/api/addon-proxy/agents/' + agentId + '/invoke',
+        {
+          input: input,
+          context: context ?? {},
+        },
+        AGENT_REQUEST_TIMEOUT_MS,
+      );
     },
 
     // ── Config ────────────────────────────────────────────────────────────
@@ -1668,8 +1685,10 @@
     },
 
     // ── Raw request (escape hatch) ────────────────────────────────────────
-    request: function (method, path, body) {
-      return request(method, path, body);
+    // `timeoutMs` is optional; omit for the default. Pass a larger value for
+    // any custom endpoint that runs an agent / other long operation.
+    request: function (method, path, body, timeoutMs) {
+      return request(method, path, body, timeoutMs);
     },
   };
 

--- a/apps/web/src/components/ChatView.test.tsx
+++ b/apps/web/src/components/ChatView.test.tsx
@@ -20,6 +20,7 @@ vi.mock('lucide-solid', () => ({
   Pencil: () => <span data-testid="pencil" />,
   X: () => <span data-testid="x" />,
   Check: () => <span data-testid="check" />,
+  Copy: () => <span data-testid="copy" />,
   CircleStop: () => <span data-testid="circle-stop" />,
   Ban: () => <span data-testid="ban" />,
 }));
@@ -55,6 +56,37 @@ describe('ChatView', () => {
     expect(
       screen.getByText('Hello, user! How can I help?'),
     ).toBeInTheDocument();
+  });
+
+  describe('message copy buttons', () => {
+    it('renders a copy button for every non-empty message', () => {
+      render(() => <ChatView messages={mockMessages} isLoading={false} />);
+      const buttons = screen.getAllByRole('button', { name: 'Copy' });
+      expect(buttons).toHaveLength(mockMessages.length);
+    });
+
+    it('omits the copy button for empty messages', () => {
+      render(() => (
+        <ChatView
+          messages={[{ ...mockMessages[0], content: '' }, mockMessages[1]]}
+          isLoading={false}
+        />
+      ));
+      const buttons = screen.getAllByRole('button', { name: 'Copy' });
+      expect(buttons).toHaveLength(1);
+    });
+
+    it('copies the full message content when the button is clicked', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      render(() => <ChatView messages={mockMessages} isLoading={false} />);
+      const buttons = screen.getAllByRole('button', { name: 'Copy' });
+      fireEvent.click(buttons[0]);
+      expect(writeText).toHaveBeenCalledWith('Hello, assistant!');
+    });
   });
 
   it('should show loading state', () => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -17,6 +17,7 @@ import { AttachmentList } from './AttachmentList';
 import { QueuedMessageCard } from './QueuedMessageCard';
 import { RunActivityBadge } from './RunActivityBadge';
 import type { RunActivityPhase } from './RunActivityBadge';
+import { CopyButton } from './ui/CopyButton';
 
 type StreamingToolCall = {
   id: string;
@@ -219,6 +220,11 @@ export function ChatView(props: ChatViewProps) {
                     <span class="text-xs text-text-tertiary">
                       {new Date(message.createdAt).toLocaleTimeString()}
                     </span>
+                    <Show when={message.content}>
+                      <span class="ml-auto">
+                        <CopyButton text={message.content} />
+                      </span>
+                    </Show>
                   </div>
                   <Show
                     when={

--- a/apps/web/src/components/MessageContent.test.tsx
+++ b/apps/web/src/components/MessageContent.test.tsx
@@ -12,6 +12,8 @@ vi.mock('lucide-solid', () => ({
   Brain: () => <span data-testid="brain" />,
   ChevronDown: () => <span data-testid="chevron-down" />,
   ChevronRight: () => <span data-testid="chevron-right" />,
+  Copy: () => <span data-testid="copy" />,
+  Check: () => <span data-testid="check" />,
 }));
 
 describe('parseThinking', () => {
@@ -137,5 +139,18 @@ describe('MessageContent', () => {
     expect(buttons).toHaveLength(2);
     expect(screen.getByText('mid')).toBeInTheDocument();
     expect(screen.getByText('end')).toBeInTheDocument();
+  });
+
+  it('renders fenced code blocks via the CodeBlock wrapper with a copy button', () => {
+    const { container } = render(() => (
+      <MessageContent content={'```js\nconsole.log("hi");\n```'} />
+    ));
+    expect(container.querySelector('pre code')?.textContent).toBe(
+      'console.log("hi");',
+    );
+    expect(
+      container.querySelector('button[aria-label="Copy code"]'),
+    ).toBeInTheDocument();
+    expect(container).toHaveTextContent('js');
   });
 });

--- a/apps/web/src/components/MessageContent.tsx
+++ b/apps/web/src/components/MessageContent.tsx
@@ -6,7 +6,9 @@
 
 import { Show, For } from 'solid-js';
 import { marked } from 'marked';
+import type { Token, TokensList } from 'marked';
 import { parseThinking, ThinkingBlock } from './ThinkingBlock';
+import { CodeBlock } from './ui/CodeBlock';
 
 type MessageContentProps = { content: string };
 
@@ -27,6 +29,51 @@ function isMarkdown(text: string): boolean {
   return markdownPatterns.some((pattern) => pattern.test(text));
 }
 
+type Segment =
+  | { kind: 'html'; html: string }
+  | { kind: 'code'; code: string; language?: string };
+
+/**
+ * Tokenize markdown into an ordered list of segments. Fenced code blocks
+ * become Solid-rendered CodeBlock elements; every other top-level token is
+ * serialized to HTML via marked's default renderer.
+ */
+function tokenizeMarkdown(text: string): Segment[] {
+  const tokens = marked.lexer(text) as TokensList;
+  const segments: Segment[] = [];
+  let buffer: Token[] = [];
+
+  const flushBuffer = () => {
+    if (buffer.length === 0) return;
+    const html = marked.parser(buffer) as string;
+    if (html) segments.push({ kind: 'html', html });
+    buffer = [];
+  };
+
+  for (const token of tokens) {
+    if (token.type === 'code') {
+      flushBuffer();
+      const codeToken = token as Token & {
+        type: 'code';
+        text: string;
+        lang?: string;
+      };
+      segments.push({
+        kind: 'code',
+        code: codeToken.text.replace(/\n$/, ''),
+        language: codeToken.lang || undefined,
+      });
+    } else if (token.type === 'space') {
+      // Skip — marked.parser handles inter-block spacing.
+      continue;
+    } else {
+      buffer.push(token);
+    }
+  }
+  flushBuffer();
+  return segments;
+}
+
 export function MessageContent(props: MessageContentProps) {
   const parts = () => parseThinking(props.content);
 
@@ -38,13 +85,8 @@ export function MessageContent(props: MessageContentProps) {
           fallback={
             <div class="text-text-secondary text-md break-words">
               {isMarkdown((part as { type: 'text'; text: string }).text) ? (
-                <div
-                  class="prose prose-sm dark:prose-invert max-w-none"
-                  innerHTML={
-                    marked.parse(
-                      (part as { type: 'text'; text: string }).text,
-                    ) as string
-                  }
+                <MarkdownBody
+                  text={(part as { type: 'text'; text: string }).text}
                 />
               ) : (
                 <p class="whitespace-pre-wrap">
@@ -60,5 +102,33 @@ export function MessageContent(props: MessageContentProps) {
         </Show>
       )}
     </For>
+  );
+}
+
+function MarkdownBody(props: { text: string }) {
+  const segments = () => tokenizeMarkdown(props.text);
+
+  return (
+    <div class="prose prose-sm dark:prose-invert max-w-none">
+      <For each={segments()}>
+        {(segment) => (
+          <Show
+            when={segment.kind === 'code'}
+            fallback={
+              <span
+                innerHTML={(segment as { kind: 'html'; html: string }).html}
+              />
+            }
+          >
+            <CodeBlock
+              code={(segment as { kind: 'code'; code: string }).code}
+              language={
+                (segment as { kind: 'code'; language?: string }).language
+              }
+            />
+          </Show>
+        )}
+      </For>
+    </div>
   );
 }

--- a/apps/web/src/components/ui/CodeBlock.test.tsx
+++ b/apps/web/src/components/ui/CodeBlock.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@solidjs/testing-library';
+import { CodeBlock } from './CodeBlock';
+
+vi.mock('lucide-solid', () => ({
+  Copy: () => <span data-testid="copy" />,
+  Check: () => <span data-testid="check" />,
+}));
+
+afterEach(() => cleanup());
+
+describe('CodeBlock', () => {
+  it('renders the code body inside a <pre><code>', () => {
+    const { container } = render(() => (
+      <CodeBlock code={'console.log("hi")'} language="js" />
+    ));
+    expect(container.querySelector('pre code')?.textContent).toBe(
+      'console.log("hi")',
+    );
+  });
+
+  it('shows the language label when a language is provided', () => {
+    const { container } = render(() => (
+      <CodeBlock code="x = 1" language="python" />
+    ));
+    expect(container).toHaveTextContent('python');
+  });
+
+  it('omits the language label when none is provided', () => {
+    const { container } = render(() => <CodeBlock code="x = 1" />);
+    const label = container.querySelector(
+      '.uppercase.tracking-wide',
+    ) as HTMLElement | null;
+    expect(label).toBeNull();
+  });
+
+  it('exposes a copy button targeting the code body', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const { container } = render(() => (
+      <CodeBlock code={'echo "hi"'} language="sh" />
+    ));
+    const btn = container.querySelector('button')!;
+    expect(btn.getAttribute('aria-label')).toBe('Copy code');
+  });
+});

--- a/apps/web/src/components/ui/CodeBlock.tsx
+++ b/apps/web/src/components/ui/CodeBlock.tsx
@@ -1,0 +1,32 @@
+import { Show } from 'solid-js';
+import { CopyButton } from './CopyButton';
+
+export type CodeBlockProps = {
+  code: string;
+  language?: string;
+};
+
+/**
+ * CodeBlock
+ *
+ * Renders a fenced code snippet with a copy-to-clipboard affordance in the
+ * top-right corner. The button copies only the code body, never the language
+ * label.
+ */
+export function CodeBlock(props: CodeBlockProps) {
+  return (
+    <div class="relative group my-2">
+      <div class="absolute top-2 right-2 z-10">
+        <CopyButton text={props.code} label="Copy code" />
+      </div>
+      <Show when={props.language}>
+        <div class="absolute top-2 left-2 z-10 text-[10px] uppercase tracking-wide text-text-tertiary bg-black/5 dark:bg-white/10 rounded px-1.5 py-0.5 pointer-events-none">
+          {props.language}
+        </div>
+      </Show>
+      <pre class="bg-gray-900 text-gray-100 dark:bg-gray-950 rounded-md p-3 pt-7 overflow-x-auto text-sm">
+        <code class={`language-${props.language ?? 'text'}`}>{props.code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/CopyButton.test.tsx
+++ b/apps/web/src/components/ui/CopyButton.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@solidjs/testing-library';
+import { CopyButton } from './CopyButton';
+
+vi.mock('lucide-solid', () => ({
+  Copy: () => <span data-testid="copy" />,
+  Check: () => <span data-testid="check" />,
+}));
+
+describe('CopyButton', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  let execCommand: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    document.execCommand =
+      execCommand as unknown as typeof document.execCommand;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('copies text via the async clipboard API when clicked', async () => {
+    const { container } = render(() => <CopyButton text="hello world" />);
+    const btn = container.querySelector('button')!;
+    fireEvent.click(btn);
+    // Allow the async handler to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith('hello world');
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('switches the icon to Check after copy', async () => {
+    const { container } = render(() => <CopyButton text="x" />);
+    expect(container.querySelector('[data-testid="copy"]')).toBeInTheDocument();
+    fireEvent.click(container.querySelector('button')!);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="copy"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reverts to the Copy icon after 2 seconds', async () => {
+    const { container } = render(() => <CopyButton text="x" />);
+    fireEvent.click(container.querySelector('button')!);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).toBeInTheDocument();
+    vi.advanceTimersByTime(2_000);
+    expect(container.querySelector('[data-testid="copy"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to execCommand when the clipboard API throws', async () => {
+    writeText.mockRejectedValueOnce(new Error('blocked'));
+    const { container } = render(() => <CopyButton text="fallback" />);
+    fireEvent.click(container.querySelector('button')!);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not toggle the icon if both clipboard and fallback fail', async () => {
+    writeText.mockRejectedValueOnce(new Error('blocked'));
+    execCommand.mockReturnValueOnce(false);
+    const { container } = render(() => <CopyButton text="nope" />);
+    fireEvent.click(container.querySelector('button')!);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(container.querySelector('[data-testid="copy"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="check"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('stops propagation so wrapping click handlers do not fire', async () => {
+    const onClick = vi.fn();
+    const { container } = render(() => (
+      <div onClick={onClick}>
+        <CopyButton text="stop" />
+      </div>
+    ));
+    fireEvent.click(container.querySelector('button')!);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ui/CopyButton.tsx
+++ b/apps/web/src/components/ui/CopyButton.tsx
@@ -1,0 +1,68 @@
+import { createSignal, Show } from 'solid-js';
+import { Copy, Check } from 'lucide-solid';
+
+export type CopyButtonProps = {
+  text: string;
+  /** Optional override for the visible/hidden label announced to assistive tech. */
+  label?: string;
+  class?: string;
+};
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Clipboard not available (insecure context). Fall back to a visible
+    // textarea selection so the user can copy manually.
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    let ok = false;
+    try {
+      ok = document.execCommand('copy');
+    } catch {
+      ok = false;
+    } finally {
+      document.body.removeChild(ta);
+    }
+    return ok;
+  }
+}
+
+export function CopyButton(props: CopyButtonProps) {
+  const [copied, setCopied] = createSignal(false);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const handleClick = async (e: MouseEvent) => {
+    e.stopPropagation();
+    const ok = await copyToClipboard(props.text);
+    if (!ok) return;
+    setCopied(true);
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => setCopied(false), 2_000);
+  };
+
+  const label = () => props.label ?? (copied() ? 'Copied' : 'Copy');
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={label()}
+      title={label()}
+      class={
+        'inline-flex items-center justify-center rounded p-1 text-text-tertiary hover:text-text-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors ' +
+        (props.class ?? '')
+      }
+    >
+      <Show when={copied()} fallback={<Copy class="w-3.5 h-3.5" />}>
+        <Check class="w-3.5 h-3.5 text-green-600 dark:text-green-400" />
+      </Show>
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #452

Adds two levels of copy affordance to the chat interface:

- **Message-level copy button** in `ChatView` (`apps/web/src/components/ChatView.tsx`), rendered next to the timestamp for every non-empty user/assistant/tool message. Hidden during streaming and on empty content, per the spec.
- **Code-block copy button** rendered by a new `CodeBlock` component (`apps/web/src/components/ui/CodeBlock.tsx`), positioned at the top-right of each fenced code block. A small language label is shown at the top-left when a language is provided.

Both buttons share a new reusable `CopyButton` (`apps/web/src/components/ui/CopyButton.tsx`):

- Uses `lucide-solid` `Copy` / `Check` icons
- Toggles to `Check` for 2 seconds, then reverts
- `navigator.clipboard.writeText` with a `document.execCommand('copy')` fallback for insecure contexts
- `e.stopPropagation()` so wrapping click handlers (e.g. message bubble) don't fire
- Customisable `aria-label`/`title` (defaults: "Copy" / "Copied", or "Copy code" for code blocks)

`MessageContent` (`apps/web/src/components/MessageContent.tsx`) now lexes markdown via `marked.lexer`, splits fenced code tokens out as `CodeBlock` Solid components, and renders the remaining tokens through `marked.parser` as before — so the rest of the markdown (paragraphs, headings, lists, tables, etc.) keeps the same `innerHTML` path with no behaviour change.

### Tests

- New `CopyButton.test.tsx` (6 tests): async clipboard path, fallback path, no-failure path, 2s icon revert, stop-propagation.
- New `CodeBlock.test.tsx` (4 tests): code body, language label shown/hidden, copy button labelled `Copy code`.
- `ChatView.test.tsx`: 3 tests covering the message-level copy button (renders one per non-empty message, omits for empty content, copies the full message body).
- `MessageContent.test.tsx`: 1 integration test confirming fenced code blocks render the `CodeBlock` wrapper.

All 398 web tests pass; `tsc -b` and `eslint src` are clean.