### PR TITLE
fix(web): stop recent-items store from creating a reactive cycle (stack overflow)

### DIFF
--- a/apps/web/src/stores/recent-items.test.ts
+++ b/apps/web/src/stores/recent-items.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRoot, createSignal, createEffect } from 'solid-js';
 import {
   initRecentItems,
   recordRecentSession,
@@ -94,5 +95,50 @@ describe('recent-items store', () => {
     initRecentItems();
     expect(recentSessionsSignal()).toEqual([]);
     expect(recentAgentsSignal()).toEqual([]);
+  });
+
+  // Regression: the command palette records the selected session/agent from a
+  // createEffect. record* reads then writes the recents signal, so if the read
+  // is tracked by the caller the effect re-runs forever (RangeError: Maximum
+  // call stack size exceeded). untrack inside record* must keep it to one run.
+  it('does not create a reactive cycle when called from an effect', async () => {
+    const runs = await new Promise<number>((resolve) => {
+      createRoot((dispose) => {
+        const [id] = createSignal('a1');
+        let count = 0;
+        createEffect(() => {
+          const current = id();
+          count++;
+          recordRecentAgent({ id: current, name: 'Helper' });
+        });
+        // Effects run deferred; flush, then read the run count. Without untrack
+        // this recurses until the stack overflows; with it the effect depends
+        // only on `id` and runs exactly once.
+        setTimeout(() => {
+          dispose();
+          resolve(count);
+        }, 0);
+      });
+    });
+    expect(runs).toBe(1);
+    expect(recentAgentsSignal()).toHaveLength(1);
+  });
+
+  it('recordRecentSession is also safe inside an effect', async () => {
+    const runs = await new Promise<number>((resolve) => {
+      createRoot((dispose) => {
+        const [id] = createSignal('s1');
+        let count = 0;
+        createEffect(() => {
+          recordRecentSession({ id: id(), title: 'Proj' });
+          count++;
+        });
+        setTimeout(() => {
+          dispose();
+          resolve(count);
+        }, 0);
+      });
+    });
+    expect(runs).toBe(1);
   });
 });

--- a/apps/web/src/stores/recent-items.ts
+++ b/apps/web/src/stores/recent-items.ts
@@ -9,7 +9,7 @@
  * decoupled from API caching state.
  */
 
-import { createSignal } from 'solid-js';
+import { createSignal, untrack } from 'solid-js';
 
 export type RecentSession = {
   id: string;
@@ -86,18 +86,30 @@ export function recentAgentsSignal() {
   return recentAgents();
 }
 
-/** Record a session visit and persist. De-duplicates by id. */
+/**
+ * Record a session visit and persist. De-duplicates by id.
+ *
+ * The whole body runs `untrack`ed: these functions read the recents signals and
+ * then write them, so if the read were tracked by a calling `createEffect` (as
+ * the command palette does — recording the selected session on change), the
+ * effect would depend on a signal it mutates and re-run forever (stack
+ * overflow). `untrack` keeps them safe to call from any reactive context.
+ */
 export function recordRecentSession(item: RecentSession): void {
-  const next = pushRecent(recentSessions(), item);
-  setRecentSessionsInternal(next);
-  writeState({ sessions: next, agents: recentAgents() });
+  untrack(() => {
+    const next = pushRecent(recentSessions(), item);
+    setRecentSessionsInternal(next);
+    writeState({ sessions: next, agents: recentAgents() });
+  });
 }
 
-/** Record an agent visit and persist. De-duplicates by id. */
+/** Record an agent visit and persist. De-duplicates by id. See {@link recordRecentSession} re: `untrack`. */
 export function recordRecentAgent(item: RecentAgent): void {
-  const next = pushRecent(recentAgents(), item);
-  setRecentAgentsInternal(next);
-  writeState({ sessions: recentSessions(), agents: next });
+  untrack(() => {
+    const next = pushRecent(recentAgents(), item);
+    setRecentAgentsInternal(next);
+    writeState({ sessions: recentSessions(), agents: next });
+  });
 }
 
 /** Test/utility helper: wipe both lists. */


### PR DESCRIPTION
## Problem

The app throws, surfaced by the global handler as:
```
[Addon System] Unhandled promise rejection: RangeError: Maximum call stack size exceeded
    at handleError (solid-js.js…)
    at runUpdates … at completeUpdates … (repeating)
```
(The `[Addon System]` prefix is misleading — `index.tsx:22` is a *global* `unhandledrejection` handler, not addon-specific.)

## Root cause — a reactive cycle in the command-palette recents store

`recordRecentSession` / `recordRecentAgent` (`apps/web/src/stores/recent-items.ts`) **read** the recents signal and then **write** it:
```js
const next = pushRecent(recentAgents(), item); // read  ← becomes a tracked dep
setRecentAgentsInternal(next);                  // write ← invalidates that dep
```
The command palette (added in #455) records the selected session/agent from a `createEffect` (`rememberSession`/`rememberAgent`). Because the read happens inside the effect's tracking scope and is immediately followed by a write to the same signal, the effect depends on a signal it mutates → **re-runs forever → stack overflow**. It appears as an *unhandled rejection* because the triggering `selectedSessionId` write comes from an async query continuation (auto-select after sessions load).

## Fix

Wrap the body of both `record*` functions in Solid's **`untrack`**, so their signal reads never register as dependencies of a calling reactive scope. This makes them safe to call from *any* effect (the correct design for a read-then-write store mutator), rather than relying on every caller to remember to untrack.

## Tests
- Two regression tests call `record*` inside a `createEffect` and assert it runs **exactly once** (without the fix the effect recurses to a stack overflow).
- Full `recent-items` suite (9) passes; web typecheck + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)