### PR TITLE
feat(backups): backup export &amp; import with selective restore

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/multipart": "^10.1.0",
     "@fastify/sensible": "^6.0.4",
     "@fastify/static": "^8.0.0",
     "@fastify/websocket": "^11.2.0",
@@ -24,6 +25,8 @@
     "@openaidy/runtime": "workspace:*",
     "@openaidy/shared-types": "workspace:*",
     "@whiskeysockets/baileys": "7.0.0-rc10",
+    "adm-zip": "^0.6.0",
+    "archiver": "^8.0.0",
     "croner": "^10.0.1",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.41.0",
@@ -41,6 +44,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
+    "@types/archiver": "^8.0.0",
     "@types/html-to-text": "^9.0.4",
     "@types/qrcode": "^1.5.6",
     "@types/semver": "^7.5.8",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -42,6 +42,8 @@ import { logRoutes } from './routes/logs';
 import { createMcpRoutesPlugin } from './routes/mcp';
 import { addonRoutes } from './routes/addons';
 import { addonProxyRoutes } from './addons/proxy-routes';
+import { backupRoutes } from './backups/routes';
+import { createBackupService } from './backups/service';
 import { AddonStorageEngine, DEFAULT_QUOTAS } from './addons/storage/engine';
 import { ManifestValidator } from './addons/manifest-validator';
 import { createAddonService } from './addons/service';
@@ -538,6 +540,28 @@ export async function buildApp() {
       // Usage tracking endpoints (per-session + aggregated)
       await api.register(usageRoutes, {
         sessionService: services.sessions,
+        authMiddleware,
+      });
+
+      // Backup export/import (admin-only). Sections map to files/dirs under
+      // OPENAIDY_HOME; paths are resolved from env with sensible fallbacks.
+      await api.register(backupRoutes, {
+        backupService: createBackupService(
+          {
+            dbPath:
+              env.SQLITE_PATH ??
+              path.join(env.OPENAIDY_HOME, 'data', 'openaidy.db'),
+            configPath:
+              env.APP_CONFIG_PATH ??
+              path.join(env.OPENAIDY_HOME, 'openaidy.json'),
+            workspacesDir:
+              env.WORKSPACE_BASE_DIR ??
+              path.join(env.OPENAIDY_HOME, 'workspaces'),
+            skillsDir: env.SKILLS_DIR ?? path.join(env.OPENAIDY_HOME, 'skills'),
+            addonsDir: path.join(env.OPENAIDY_HOME, 'addons'),
+          },
+          openAidyVersion,
+        ),
         authMiddleware,
       });
 

--- a/apps/server/src/backups/routes.test.ts
+++ b/apps/server/src/backups/routes.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import AdmZip from 'adm-zip';
+import { backupRoutes } from './routes';
+import { BackupService, type BackupPaths } from './service';
+import { AuthMiddleware } from '../websocket/middleware/auth';
+
+const mockAuthMiddleware = {
+  validateToken: async () => ({
+    sub: 'test',
+    scopes: ['*'],
+    type: 'access' as const,
+    iat: 0,
+    exp: 9999999999,
+  }),
+  extractFromHeader: (_h: string) => 'test-token',
+  hasCapability: () => true,
+} as unknown as AuthMiddleware;
+
+const AUTH = { authorization: 'Bearer test-token' };
+
+/** Build a multipart/form-data body from a file part + string fields. */
+function multipart(
+  file: { field: string; filename: string; content: Buffer } | null,
+  fields: Record<string, string> = {},
+): { body: Buffer; contentType: string } {
+  const boundary = '----oaidytest' + Math.random().toString(36).slice(2);
+  const chunks: Buffer[] = [];
+  const CRLF = '\r\n';
+  for (const [name, value] of Object.entries(fields)) {
+    chunks.push(
+      Buffer.from(
+        `--${boundary}${CRLF}Content-Disposition: form-data; name="${name}"${CRLF}${CRLF}${value}${CRLF}`,
+      ),
+    );
+  }
+  if (file) {
+    chunks.push(
+      Buffer.from(
+        `--${boundary}${CRLF}Content-Disposition: form-data; name="${file.field}"; filename="${file.filename}"${CRLF}Content-Type: application/zip${CRLF}${CRLF}`,
+      ),
+    );
+    chunks.push(file.content);
+    chunks.push(Buffer.from(CRLF));
+  }
+  chunks.push(Buffer.from(`--${boundary}--${CRLF}`));
+  return {
+    body: Buffer.concat(chunks),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
+let home: string;
+let paths: BackupPaths;
+let service: BackupService;
+let app: FastifyInstance;
+
+function write(p: string, content: string) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+async function validBackupBuffer(): Promise<Buffer> {
+  const zipPath = path.join(home, 'valid.zip');
+  await service.buildZip([], fs.createWriteStream(zipPath));
+  return fs.readFileSync(zipPath);
+}
+
+beforeEach(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'oaidy-broutes-'));
+  paths = {
+    dbPath: path.join(home, 'data', 'openaidy.db'),
+    configPath: path.join(home, 'openaidy.json'),
+    workspacesDir: path.join(home, 'workspaces'),
+    skillsDir: path.join(home, 'skills'),
+    addonsDir: path.join(home, 'addons'),
+  };
+  write(paths.dbPath, 'DB');
+  write(paths.configPath, '{"providers":[]}');
+  write(path.join(paths.skillsDir, 's1', 'SKILL.md'), '# s');
+  service = new BackupService(paths, '0.3.8');
+
+  app = Fastify({ logger: false });
+  await app.register(sensible);
+  await app.register(
+    async (api) => {
+      await api.register(backupRoutes, {
+        backupService: service,
+        authMiddleware: mockAuthMiddleware,
+      });
+    },
+    { prefix: '/api' },
+  );
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('GET /api/backups/manifest', () => {
+  it('returns the live manifest', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/backups/manifest',
+      headers: AUTH,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.manifest.kind).toBe('openaidy-backup');
+    expect(body.manifest.sections.config.itemCount).toBe(1);
+  });
+});
+
+describe('POST /api/backups/export', () => {
+  it('returns a zip archive', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/export',
+      headers: AUTH,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/zip');
+    // PK zip magic bytes.
+    expect(res.rawPayload.slice(0, 2).toString('latin1')).toBe('PK');
+  });
+
+  it('honors a section filter', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/export',
+      headers: AUTH,
+      payload: { sections: ['config'] },
+    });
+    expect(res.statusCode).toBe(200);
+    const zip = new AdmZip(res.rawPayload);
+    expect(zip.getEntry('config/openaidy.json')).toBeTruthy();
+    expect(zip.getEntry('skills/s1/SKILL.md')).toBeFalsy();
+  });
+
+  it('rejects an invalid sections value', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/export',
+      headers: AUTH,
+      payload: { sections: ['nope'] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/backups/preview', () => {
+  it('returns the manifest for a valid backup zip', async () => {
+    const buf = await validBackupBuffer();
+    const { body, contentType } = multipart({
+      field: 'file',
+      filename: 'backup.zip',
+      content: buf,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/preview',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.manifest.kind).toBe('openaidy-backup');
+    expect(json.zipSizeBytes).toBe(buf.length);
+  });
+
+  it('rejects a non-zip file with 400', async () => {
+    const { body, contentType } = multipart({
+      field: 'file',
+      filename: 'x.zip',
+      content: Buffer.from('not a zip'),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/preview',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a zip missing manifest.json with 400', async () => {
+    const zip = new AdmZip();
+    zip.addFile('db/openaidy.db', Buffer.from('x'));
+    const { body, contentType } = multipart({
+      field: 'file',
+      filename: 'x.zip',
+      content: zip.toBuffer(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/preview',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/backups/import', () => {
+  it('applies the requested sections and returns per-section results', async () => {
+    const buf = await validBackupBuffer();
+    // Restore into a different home so we can assert files were written.
+    const destHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oaidy-dest-'));
+    const destService = new BackupService(
+      {
+        dbPath: path.join(destHome, 'data', 'openaidy.db'),
+        configPath: path.join(destHome, 'openaidy.json'),
+        workspacesDir: path.join(destHome, 'workspaces'),
+        skillsDir: path.join(destHome, 'skills'),
+        addonsDir: path.join(destHome, 'addons'),
+      },
+      '0.3.8',
+    );
+    const destApp = Fastify({ logger: false });
+    await destApp.register(sensible);
+    await destApp.register(
+      async (api) => {
+        await api.register(backupRoutes, {
+          backupService: destService,
+          authMiddleware: mockAuthMiddleware,
+        });
+      },
+      { prefix: '/api' },
+    );
+    await destApp.ready();
+
+    const { body, contentType } = multipart(
+      { field: 'file', filename: 'backup.zip', content: buf },
+      { sections: JSON.stringify(['config', 'skills']) },
+    );
+    const res = await destApp.inject({
+      method: 'POST',
+      url: '/api/backups/import',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    const results = res.json().results as Array<{
+      section: string;
+      success: boolean;
+    }>;
+    expect(results.map((r) => r.section).sort()).toEqual(['config', 'skills']);
+    expect(results.every((r) => r.success)).toBe(true);
+    expect(fs.existsSync(path.join(destHome, 'openaidy.json'))).toBe(true);
+    expect(fs.existsSync(path.join(destHome, 'skills', 's1', 'SKILL.md'))).toBe(
+      true,
+    );
+
+    await destApp.close();
+    fs.rmSync(destHome, { recursive: true, force: true });
+  });
+
+  it('rejects import with no sections', async () => {
+    const buf = await validBackupBuffer();
+    const { body, contentType } = multipart(
+      { field: 'file', filename: 'backup.zip', content: buf },
+      { sections: '[]' },
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/import',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects an unknown section', async () => {
+    const buf = await validBackupBuffer();
+    const { body, contentType } = multipart(
+      { field: 'file', filename: 'backup.zip', content: buf },
+      { sections: JSON.stringify(['bogus']) },
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/backups/import',
+      headers: { ...AUTH, 'content-type': contentType },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/server/src/backups/routes.ts
+++ b/apps/server/src/backups/routes.ts
@@ -1,0 +1,217 @@
+/**
+ * Backup routes — export/import of OpenAidy data (issue #451).
+ *
+ *   GET  /backups/manifest  — live snapshot of what a full backup would contain
+ *   POST /backups/export    — stream a .zip of the selected sections
+ *   POST /backups/preview   — read an uploaded zip's manifest (no changes)
+ *   POST /backups/import    — apply selected sections from an uploaded zip
+ *
+ * All endpoints are admin-scoped: a backup exposes provider API keys and an
+ * import can replace the whole database.
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import multipart from '@fastify/multipart';
+import AdmZip from 'adm-zip';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import { requireAuth } from '../middleware/require-auth';
+import {
+  BACKUP_SECTIONS,
+  type BackupSection,
+  type BackupManifestResponse,
+  type BackupPreview,
+  type ImportResponse,
+  type ImportedSection,
+} from '@openaidy/shared-types';
+import type { BackupService } from './service';
+
+const ADMIN_SCOPE = '*';
+
+/** Hard ceiling on an uploaded backup (compressed) — guards memory/DoS. */
+const MAX_UPLOAD_BYTES = 512 * 1024 * 1024; // 512 MB
+/** Hard ceiling on total uncompressed size — guards against zip bombs. */
+const MAX_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
+
+export type BackupRoutesOptions = {
+  backupService: BackupService;
+  authMiddleware: AuthMiddleware;
+};
+
+function isBackupSection(v: unknown): v is BackupSection {
+  return (
+    typeof v === 'string' && (BACKUP_SECTIONS as readonly string[]).includes(v)
+  );
+}
+
+/** Parse + validate the `sections` list from a request (array of section names). */
+function parseSections(raw: unknown): BackupSection[] | null {
+  if (raw === undefined || raw === null) return [];
+  let arr: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      arr = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!Array.isArray(arr)) return null;
+  const out: BackupSection[] = [];
+  for (const s of arr) {
+    if (!isBackupSection(s)) return null;
+    out.push(s);
+  }
+  return out;
+}
+
+/** Open a zip buffer and reject obvious zip bombs before we decompress entries. */
+function openZipGuarded(buffer: Buffer): AdmZip {
+  const zip = new AdmZip(buffer);
+  let total = 0;
+  for (const entry of zip.getEntries()) {
+    total += entry.header.size;
+    if (total > MAX_UNCOMPRESSED_BYTES) {
+      throw new Error('Backup exceeds the maximum uncompressed size');
+    }
+  }
+  return zip;
+}
+
+export const backupRoutes: FastifyPluginAsync<BackupRoutesOptions> = async (
+  app,
+  options,
+) => {
+  const { backupService, authMiddleware } = options;
+
+  // Scoped to this plugin: only backup upload endpoints parse multipart.
+  await app.register(multipart, {
+    limits: { fileSize: MAX_UPLOAD_BYTES, files: 1 },
+  });
+
+  app.addHook(
+    'preHandler',
+    requireAuth({ authMiddleware, requiredScope: ADMIN_SCOPE }),
+  );
+
+  // GET /backups/manifest — live snapshot for the Export tab.
+  app.get('/backups/manifest', async () => {
+    const manifest = backupService.buildManifest();
+    return { manifest } satisfies BackupManifestResponse;
+  });
+
+  // POST /backups/export — stream a zip of the selected sections (all if omitted).
+  app.post<{ Body: { sections?: BackupSection[] } | undefined }>(
+    '/backups/export',
+    async (request, reply) => {
+      const sections = parseSections(request.body?.sections);
+      if (sections === null) {
+        return reply
+          .code(400)
+          .send({
+            error: 'Invalid sections; expected an array of section names',
+          });
+      }
+
+      const date = new Date().toISOString().slice(0, 10);
+      const filename = `openaidy-backup-${date}.zip`;
+
+      reply.raw.setHeader('Content-Type', 'application/zip');
+      reply.raw.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${filename}"`,
+      );
+      // We write directly to the raw stream; take over the response lifecycle.
+      reply.hijack();
+      try {
+        await backupService.buildZip(sections, reply.raw);
+      } catch (err) {
+        request.log.error({ err }, 'Backup export failed');
+        // Headers are already sent; just tear the connection down.
+        reply.raw.destroy();
+      }
+    },
+  );
+
+  // POST /backups/preview — read an uploaded zip's manifest without applying it.
+  app.post('/backups/preview', async (request, reply) => {
+    if (!request.isMultipart()) {
+      return reply
+        .code(400)
+        .send({ error: 'Expected multipart/form-data with a file field' });
+    }
+    const filePart = await request.file();
+    if (!filePart) {
+      return reply.code(400).send({ error: 'No file uploaded' });
+    }
+    const buffer = await filePart.toBuffer();
+    try {
+      openZipGuarded(buffer);
+      const manifest = backupService.readManifest(buffer);
+      return {
+        manifest,
+        zipSizeBytes: buffer.length,
+      } satisfies BackupPreview;
+    } catch (err) {
+      return reply.code(400).send({
+        error: err instanceof Error ? err.message : 'Invalid backup file',
+      });
+    }
+  });
+
+  // POST /backups/import — apply selected sections from an uploaded zip.
+  app.post('/backups/import', async (request, reply) => {
+    if (!request.isMultipart()) {
+      return reply
+        .code(400)
+        .send({ error: 'Expected multipart/form-data with file + sections' });
+    }
+
+    let buffer: Buffer | undefined;
+    let sectionsRaw: string | undefined;
+    // Iterate parts to capture both the file and the `sections` field.
+    for await (const part of request.parts()) {
+      if (part.type === 'file') {
+        buffer = await part.toBuffer();
+      } else if (part.fieldname === 'sections') {
+        sectionsRaw = String(part.value);
+      }
+    }
+
+    if (!buffer) {
+      return reply.code(400).send({ error: 'No file uploaded' });
+    }
+    const sections = parseSections(sectionsRaw);
+    if (sections === null) {
+      return reply.code(400).send({ error: 'Invalid sections field' });
+    }
+    if (sections.length === 0) {
+      return reply.code(400).send({ error: 'No sections selected to import' });
+    }
+
+    let zip: AdmZip;
+    try {
+      zip = openZipGuarded(buffer);
+      // Validate it's a real backup before touching the filesystem.
+      backupService.readManifest(buffer);
+    } catch (err) {
+      return reply.code(400).send({
+        error: err instanceof Error ? err.message : 'Invalid backup file',
+      });
+    }
+
+    const results: ImportedSection[] = [];
+    for (const section of sections) {
+      try {
+        results.push(backupService.applySection(section, zip));
+      } catch (err) {
+        results.push({
+          section,
+          success: false,
+          error: err instanceof Error ? err.message : 'Import failed',
+          itemsImported: 0,
+        });
+      }
+    }
+
+    return { results } satisfies ImportResponse;
+  });
+};

--- a/apps/server/src/backups/service.test.ts
+++ b/apps/server/src/backups/service.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+import { BackupService, type BackupPaths } from './service';
+
+let home: string;
+let paths: BackupPaths;
+let service: BackupService;
+
+function write(p: string, content: string) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+/** Zip the output of buildZip into an AdmZip by streaming to a temp file. */
+async function buildZipToAdm(
+  svc: BackupService,
+  sections: Parameters<BackupService['buildZip']>[0],
+): Promise<AdmZip> {
+  const zipPath = path.join(
+    home,
+    `out-${Math.random().toString(36).slice(2)}.zip`,
+  );
+  const out = fs.createWriteStream(zipPath);
+  await svc.buildZip(sections, out);
+  return new AdmZip(fs.readFileSync(zipPath));
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'oaidy-backup-'));
+  paths = {
+    dbPath: path.join(home, 'data', 'openaidy.db'),
+    configPath: path.join(home, 'openaidy.json'),
+    workspacesDir: path.join(home, 'workspaces'),
+    skillsDir: path.join(home, 'skills'),
+    addonsDir: path.join(home, 'addons'),
+  };
+  // Fixtures
+  write(paths.dbPath, 'SQLITEDATA');
+  write(paths.configPath, '{"providers":[]}');
+  write(path.join(paths.workspacesDir, 'default', 'AGENT.md'), '# agent');
+  write(path.join(paths.workspacesDir, 'default', 'MISSION.md'), '# mission');
+  write(path.join(paths.skillsDir, 'my-skill', 'SKILL.md'), '# skill');
+  write(
+    path.join(paths.addonsDir, 'my-addon', 'addon.json'),
+    '{"id":"my-addon"}',
+  );
+  service = new BackupService(paths, '0.3.8');
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('BackupService.buildManifest', () => {
+  it('returns a valid manifest with per-section counts and sizes', () => {
+    const m = service.buildManifest();
+    expect(m.kind).toBe('openaidy-backup');
+    expect(m.version).toBe(1);
+    expect(m.openaidyVersion).toBe('0.3.8');
+    expect(m.sections.db.itemCount).toBe(1);
+    expect(m.sections.db.sizeBytes).toBeGreaterThan(0);
+    expect(m.sections.config.itemCount).toBe(1);
+    expect(m.sections.workspaces.itemCount).toBe(1); // one top-level workspace
+    expect(m.sections.workspaces.sizeBytes).toBeGreaterThan(0);
+    expect(m.sections.skills.itemCount).toBe(1);
+    expect(m.sections.addons.itemCount).toBe(1);
+  });
+
+  it('reports zero for missing sections', () => {
+    fs.rmSync(paths.skillsDir, { recursive: true, force: true });
+    const m = service.buildManifest();
+    expect(m.sections.skills).toEqual({ itemCount: 0, sizeBytes: 0 });
+  });
+});
+
+describe('BackupService.buildZip', () => {
+  it('produces a zip with manifest.json and all sections when none specified', async () => {
+    const zip = await buildZipToAdm(service, []);
+    expect(zip.getEntry('manifest.json')).toBeTruthy();
+    expect(zip.getEntry('db/openaidy.db')).toBeTruthy();
+    expect(zip.getEntry('config/openaidy.json')).toBeTruthy();
+    expect(zip.getEntry('workspaces/default/AGENT.md')).toBeTruthy();
+    expect(zip.getEntry('skills/my-skill/SKILL.md')).toBeTruthy();
+    expect(zip.getEntry('addons/my-addon/addon.json')).toBeTruthy();
+  });
+
+  it('includes only the selected sections', async () => {
+    const zip = await buildZipToAdm(service, ['db']);
+    expect(zip.getEntry('manifest.json')).toBeTruthy();
+    expect(zip.getEntry('db/openaidy.db')).toBeTruthy();
+    expect(zip.getEntry('config/openaidy.json')).toBeFalsy();
+    expect(zip.getEntry('workspaces/default/AGENT.md')).toBeFalsy();
+  });
+});
+
+describe('BackupService.readManifest', () => {
+  it('reads the manifest from a valid backup zip', async () => {
+    const zip = await buildZipToAdm(service, []);
+    const manifest = service.readManifest(zip.toBuffer());
+    expect(manifest.kind).toBe('openaidy-backup');
+    expect(manifest.sections.config.itemCount).toBe(1);
+  });
+
+  it('throws on a non-zip file', () => {
+    expect(() => service.readManifest(Buffer.from('not a zip'))).toThrow();
+  });
+
+  it('throws on a zip missing manifest.json', () => {
+    const zip = new AdmZip();
+    zip.addFile('db/openaidy.db', Buffer.from('x'));
+    expect(() => service.readManifest(zip.toBuffer())).toThrow(/manifest/i);
+  });
+});
+
+describe('BackupService.applySection', () => {
+  // Apply into a fresh, empty destination home.
+  let dest: BackupService;
+  let destPaths: BackupPaths;
+  let destHome: string;
+  let sourceZip: AdmZip;
+
+  beforeEach(async () => {
+    sourceZip = await buildZipToAdm(service, []);
+    destHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oaidy-restore-'));
+    destPaths = {
+      dbPath: path.join(destHome, 'data', 'openaidy.db'),
+      configPath: path.join(destHome, 'openaidy.json'),
+      workspacesDir: path.join(destHome, 'workspaces'),
+      skillsDir: path.join(destHome, 'skills'),
+      addonsDir: path.join(destHome, 'addons'),
+    };
+    dest = new BackupService(destPaths, '0.3.8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(destHome, { recursive: true, force: true });
+  });
+
+  it('replaces the db file and flags restart required', () => {
+    const r = dest.applySection('db', sourceZip);
+    expect(r).toMatchObject({
+      section: 'db',
+      success: true,
+      restartRequired: true,
+    });
+    expect(fs.readFileSync(destPaths.dbPath, 'utf-8')).toBe('SQLITEDATA');
+  });
+
+  it('overwrites the config file', () => {
+    write(destPaths.configPath, '{"stale":true}');
+    const r = dest.applySection('config', sourceZip);
+    expect(r.success).toBe(true);
+    expect(fs.readFileSync(destPaths.configPath, 'utf-8')).toBe(
+      '{"providers":[]}',
+    );
+  });
+
+  it('merges workspaces: existing overwritten, new added, none deleted', () => {
+    // Pre-existing files: one that will be overwritten, one that must survive.
+    write(path.join(destPaths.workspacesDir, 'default', 'AGENT.md'), 'OLD');
+    write(path.join(destPaths.workspacesDir, 'default', 'KEEP.md'), 'keep me');
+
+    const r = dest.applySection('workspaces', sourceZip);
+    expect(r.success).toBe(true);
+    // Overwritten from backup:
+    expect(
+      fs.readFileSync(
+        path.join(destPaths.workspacesDir, 'default', 'AGENT.md'),
+        'utf-8',
+      ),
+    ).toBe('# agent');
+    // New file added from backup:
+    expect(
+      fs.existsSync(
+        path.join(destPaths.workspacesDir, 'default', 'MISSION.md'),
+      ),
+    ).toBe(true);
+    // Pre-existing file NOT in the backup is preserved (no deletion):
+    expect(
+      fs.readFileSync(
+        path.join(destPaths.workspacesDir, 'default', 'KEEP.md'),
+        'utf-8',
+      ),
+    ).toBe('keep me');
+  });
+
+  it('is idempotent — re-applying yields the same bytes', () => {
+    dest.applySection('skills', sourceZip);
+    const first = fs.readFileSync(
+      path.join(destPaths.skillsDir, 'my-skill', 'SKILL.md'),
+      'utf-8',
+    );
+    dest.applySection('skills', sourceZip);
+    const second = fs.readFileSync(
+      path.join(destPaths.skillsDir, 'my-skill', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(second).toBe(first);
+  });
+
+  it('merges addons files', () => {
+    const r = dest.applySection('addons', sourceZip);
+    expect(r.success).toBe(true);
+    expect(
+      fs.existsSync(path.join(destPaths.addonsDir, 'my-addon', 'addon.json')),
+    ).toBe(true);
+  });
+});

--- a/apps/server/src/backups/service.ts
+++ b/apps/server/src/backups/service.ts
@@ -1,0 +1,366 @@
+/**
+ * Backup service — builds and applies OpenAidy data backups.
+ *
+ * A backup is a `.zip` with a `manifest.json` plus one subdirectory per
+ * section (db, config, workspaces, skills, addons). Paths are injected so the
+ * service is testable against a temp OPENAIDY_HOME. See issue #451.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { ZipArchive } from 'archiver';
+import AdmZip from 'adm-zip';
+import {
+  BACKUP_FORMAT_VERSION,
+  BACKUP_KIND,
+  BACKUP_SECTIONS,
+  isBackupManifest,
+  type BackupSection,
+  type BackupManifest,
+  type BackupSectionSummary,
+  type ImportedSection,
+} from '@openaidy/shared-types';
+
+/** Resolved filesystem locations for each backup section. */
+export type BackupPaths = {
+  /** SQLite DB file (e.g. $OPENAIDY_HOME/data/openaidy.db). */
+  dbPath: string;
+  /** App config file (e.g. $OPENAIDY_HOME/openaidy.json). */
+  configPath: string;
+  /** Workspaces root dir. */
+  workspacesDir: string;
+  /** Skills root dir. */
+  skillsDir: string;
+  /** Addons root dir. */
+  addonsDir: string;
+};
+
+/** A section backed by a single file vs. a recursive directory. */
+type SectionSource =
+  | { kind: 'file'; path: string }
+  | { kind: 'dir'; path: string };
+
+function dirExists(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function fileExists(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Recursive [count-of-files, total-bytes] for a directory (0/0 if missing). */
+function measureDir(dir: string): { files: number; bytes: number } {
+  let files = 0;
+  let bytes = 0;
+  if (!dirExists(dir)) return { files, bytes };
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const sub = measureDir(full);
+      files += sub.files;
+      bytes += sub.bytes;
+    } else if (entry.isFile()) {
+      files += 1;
+      try {
+        bytes += fs.statSync(full).size;
+      } catch {
+        // unreadable — skip
+      }
+    }
+  }
+  return { files, bytes };
+}
+
+/** Number of top-level entries in a dir (workspaces/skills/addons "items"). */
+function countTopLevel(dir: string): number {
+  if (!dirExists(dir)) return 0;
+  return fs.readdirSync(dir, { withFileTypes: true }).length;
+}
+
+export class BackupService {
+  constructor(
+    private readonly paths: BackupPaths,
+    private readonly openaidyVersion: string,
+  ) {}
+
+  private sectionSource(section: BackupSection): SectionSource {
+    switch (section) {
+      case 'db':
+        return { kind: 'file', path: this.paths.dbPath };
+      case 'config':
+        return { kind: 'file', path: this.paths.configPath };
+      case 'workspaces':
+        return { kind: 'dir', path: this.paths.workspacesDir };
+      case 'skills':
+        return { kind: 'dir', path: this.paths.skillsDir };
+      case 'addons':
+        return { kind: 'dir', path: this.paths.addonsDir };
+    }
+  }
+
+  /** The db file plus its WAL/SHM sidecars, when present. */
+  private dbFiles(): string[] {
+    return [
+      this.paths.dbPath,
+      `${this.paths.dbPath}-wal`,
+      `${this.paths.dbPath}-shm`,
+    ].filter(fileExists);
+  }
+
+  private sectionSummary(section: BackupSection): BackupSectionSummary {
+    const src = this.sectionSource(section);
+    if (src.kind === 'file') {
+      if (section === 'db') {
+        const files = this.dbFiles();
+        const bytes = files.reduce((sum, f) => sum + fs.statSync(f).size, 0);
+        return { itemCount: files.length > 0 ? 1 : 0, sizeBytes: bytes };
+      }
+      const present = fileExists(src.path);
+      return {
+        itemCount: present ? 1 : 0,
+        sizeBytes: present ? fs.statSync(src.path).size : 0,
+      };
+    }
+    return {
+      itemCount: countTopLevel(src.path),
+      sizeBytes: measureDir(src.path).bytes,
+    };
+  }
+
+  /** Build a manifest from the live OPENAIDY_HOME. */
+  buildManifest(): BackupManifest {
+    const sections = {} as Record<BackupSection, BackupSectionSummary>;
+    for (const section of BACKUP_SECTIONS) {
+      sections[section] = this.sectionSummary(section);
+    }
+    return {
+      version: BACKUP_FORMAT_VERSION,
+      kind: BACKUP_KIND,
+      createdAt: new Date().toISOString(),
+      openaidyVersion: this.openaidyVersion,
+      sections,
+    };
+  }
+
+  /**
+   * Stream a backup zip of the given sections (default: all) to a writable.
+   * Resolves once the archive is fully flushed. Rejects on archive error.
+   */
+  buildZip(
+    sections: BackupSection[],
+    out: NodeJS.WritableStream,
+  ): Promise<void> {
+    const selected =
+      sections.length > 0
+        ? BACKUP_SECTIONS.filter((s) => sections.includes(s))
+        : [...BACKUP_SECTIONS];
+
+    // Manifest reflects only the sections included in THIS archive.
+    const manifest: BackupManifest = {
+      version: BACKUP_FORMAT_VERSION,
+      kind: BACKUP_KIND,
+      createdAt: new Date().toISOString(),
+      openaidyVersion: this.openaidyVersion,
+      sections: {} as Record<BackupSection, BackupSectionSummary>,
+    };
+    for (const section of BACKUP_SECTIONS) {
+      manifest.sections[section] = selected.includes(section)
+        ? this.sectionSummary(section)
+        : { itemCount: 0, sizeBytes: 0 };
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const archive = new ZipArchive({ zlib: { level: 9 } });
+      archive.on('error', reject);
+      archive.on('warning', (err) => {
+        if (err.code !== 'ENOENT') reject(err);
+      });
+      out.on('close', () => resolve());
+      out.on('error', reject);
+      archive.pipe(out);
+
+      archive.append(JSON.stringify(manifest, null, 2), {
+        name: 'manifest.json',
+      });
+
+      for (const section of selected) {
+        const src = this.sectionSource(section);
+        if (section === 'db') {
+          for (const f of this.dbFiles()) {
+            archive.file(f, { name: `db/${path.basename(f)}` });
+          }
+        } else if (src.kind === 'file') {
+          if (fileExists(src.path)) {
+            archive.file(src.path, {
+              name: `${section}/${path.basename(src.path)}`,
+            });
+          }
+        } else if (dirExists(src.path)) {
+          archive.directory(src.path, section);
+        }
+      }
+
+      void archive.finalize();
+    });
+  }
+
+  /** Parse and validate the manifest from a backup zip buffer. Throws on invalid. */
+  readManifest(zipBuffer: Buffer): BackupManifest {
+    let zip: AdmZip;
+    try {
+      zip = new AdmZip(zipBuffer);
+    } catch {
+      throw new Error('Not a valid zip archive');
+    }
+    const entry = zip.getEntry('manifest.json');
+    if (!entry) {
+      throw new Error('Backup is missing manifest.json');
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(entry.getData().toString('utf-8'));
+    } catch {
+      throw new Error('manifest.json is not valid JSON');
+    }
+    if (!isBackupManifest(parsed)) {
+      throw new Error('manifest.json is not an OpenAidy backup manifest');
+    }
+    return parsed;
+  }
+
+  /**
+   * Apply one section from a backup zip. Non-destructive for dir sections
+   * (files overwritten/added, never deleted); db/config are file replacements.
+   * Returns a per-section result; throws are caught by the caller.
+   */
+  applySection(section: BackupSection, zip: AdmZip): ImportedSection {
+    switch (section) {
+      case 'db':
+        return this.applyFilesReplace(
+          'db',
+          this.paths.dbPath,
+          zip,
+          /* restartRequired */ true,
+        );
+      case 'config':
+        return this.applyFilesReplace(
+          'config',
+          this.paths.configPath,
+          zip,
+          /* restartRequired */ true,
+        );
+      case 'workspaces':
+        return this.applyDirMerge('workspaces', this.paths.workspacesDir, zip);
+      case 'skills':
+        return this.applyDirMerge('skills', this.paths.skillsDir, zip);
+      case 'addons':
+        return this.applyDirMerge('addons', this.paths.addonsDir, zip);
+    }
+  }
+
+  /**
+   * Replace a single-file section (db, config). For db this also restores the
+   * WAL/SHM sidecars and removes stale ones so the imported DB is consistent.
+   */
+  private applyFilesReplace(
+    section: 'db' | 'config',
+    destPath: string,
+    zip: AdmZip,
+    restartRequired: boolean,
+  ): ImportedSection {
+    const prefix = `${section}/`;
+    const entries = zip
+      .getEntries()
+      .filter((e) => !e.isDirectory && e.entryName.startsWith(prefix));
+    if (entries.length === 0) {
+      return {
+        section,
+        success: false,
+        error: `Backup contains no ${section} section`,
+        itemsImported: 0,
+      };
+    }
+
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+    if (section === 'db') {
+      // Clear existing sidecars so we don't mix an old WAL with a new DB.
+      for (const suffix of ['-wal', '-shm']) {
+        try {
+          fs.rmSync(`${destPath}${suffix}`, { force: true });
+        } catch {
+          // ignore
+        }
+      }
+      for (const entry of entries) {
+        const base = path.basename(entry.entryName);
+        // Map the archived basename back onto the live db path family.
+        const target =
+          base === path.basename(destPath)
+            ? destPath
+            : path.join(path.dirname(destPath), base);
+        fs.writeFileSync(target, entry.getData());
+      }
+      return { section, success: true, itemsImported: 1, restartRequired };
+    }
+
+    // config: single file overwrite in place.
+    fs.writeFileSync(destPath, entries[0]!.getData());
+    return { section, success: true, itemsImported: 1, restartRequired };
+  }
+
+  /**
+   * Merge a directory section: write every archived file under the section
+   * prefix into destDir (creating dirs, overwriting existing files, never
+   * deleting). Idempotent — re-applying the same backup yields the same bytes.
+   * itemsImported counts the top-level entries touched.
+   */
+  private applyDirMerge(
+    section: BackupSection,
+    destDir: string,
+    zip: AdmZip,
+  ): ImportedSection {
+    const prefix = `${section}/`;
+    const entries = zip
+      .getEntries()
+      .filter((e) => !e.isDirectory && e.entryName.startsWith(prefix));
+
+    fs.mkdirSync(destDir, { recursive: true });
+    const topLevel = new Set<string>();
+
+    for (const entry of entries) {
+      const rel = entry.entryName.slice(prefix.length);
+      if (!rel) continue;
+      // Guard against zip-slip: reject paths that escape destDir.
+      const target = path.join(destDir, rel);
+      const normalized = path.normalize(target);
+      if (
+        normalized !== destDir &&
+        !normalized.startsWith(destDir + path.sep)
+      ) {
+        continue;
+      }
+      fs.mkdirSync(path.dirname(normalized), { recursive: true });
+      fs.writeFileSync(normalized, entry.getData());
+      const first = rel.split('/')[0];
+      if (first) topLevel.add(first);
+    }
+
+    return { section, success: true, itemsImported: topLevel.size };
+  }
+}
+
+export function createBackupService(
+  paths: BackupPaths,
+  openaidyVersion: string,
+): BackupService {
+  return new BackupService(paths, openaidyVersion);
+}

--- a/apps/web/src/components/pages/BackupManifestTable.tsx
+++ b/apps/web/src/components/pages/BackupManifestTable.tsx
@@ -1,0 +1,70 @@
+import { For } from 'solid-js';
+import type { BackupManifest, BackupSection } from '@openaidy/shared-types';
+import { BACKUP_SECTIONS } from '@openaidy/shared-types';
+import { formatBytes } from '../../lib/api-backups';
+
+const SECTION_LABELS: Record<BackupSection, string> = {
+  db: 'Database',
+  config: 'Configuration',
+  workspaces: 'Workspaces',
+  skills: 'Skills',
+  addons: 'Addons',
+};
+
+export type BackupManifestTableProps = {
+  manifest: BackupManifest;
+  /** Currently-selected sections. */
+  selected: BackupSection[];
+  onToggle: (section: BackupSection, checked: boolean) => void;
+};
+
+/** A checklist table of backup sections with item count + size. */
+export function BackupManifestTable(props: BackupManifestTableProps) {
+  const isSelected = (s: BackupSection) => props.selected.includes(s);
+
+  return (
+    <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table class="min-w-full text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-800/60 text-text-tertiary">
+          <tr>
+            <th class="px-4 py-2 text-left font-medium w-10" />
+            <th class="px-4 py-2 text-left font-medium">Section</th>
+            <th class="px-4 py-2 text-right font-medium">Items</th>
+            <th class="px-4 py-2 text-right font-medium">Size</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+          <For each={BACKUP_SECTIONS}>
+            {(section) => {
+              const summary = () => props.manifest.sections[section];
+              return (
+                <tr>
+                  <td class="px-4 py-2.5">
+                    <input
+                      type="checkbox"
+                      class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      checked={isSelected(section)}
+                      aria-label={SECTION_LABELS[section]}
+                      onChange={(e) =>
+                        props.onToggle(section, e.currentTarget.checked)
+                      }
+                    />
+                  </td>
+                  <td class="px-4 py-2.5 text-text-primary">
+                    {SECTION_LABELS[section]}
+                  </td>
+                  <td class="px-4 py-2.5 text-right tabular-nums text-text-secondary">
+                    {summary().itemCount}
+                  </td>
+                  <td class="px-4 py-2.5 text-right tabular-nums text-text-secondary">
+                    {formatBytes(summary().sizeBytes)}
+                  </td>
+                </tr>
+              );
+            }}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/BackupResultsTable.tsx
+++ b/apps/web/src/components/pages/BackupResultsTable.tsx
@@ -1,0 +1,67 @@
+import { For, Show } from 'solid-js';
+import { CheckCircle, XCircle } from 'lucide-solid';
+import type { BackupSection, ImportedSection } from '@openaidy/shared-types';
+
+const SECTION_LABELS: Record<BackupSection, string> = {
+  db: 'Database',
+  config: 'Configuration',
+  workspaces: 'Workspaces',
+  skills: 'Skills',
+  addons: 'Addons',
+};
+
+export type BackupResultsTableProps = {
+  results: ImportedSection[];
+};
+
+/** Per-section outcome table shown after an import. */
+export function BackupResultsTable(props: BackupResultsTableProps) {
+  return (
+    <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table class="min-w-full text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-800/60 text-text-tertiary">
+          <tr>
+            <th class="px-4 py-2 text-left font-medium">Section</th>
+            <th class="px-4 py-2 text-left font-medium">Result</th>
+            <th class="px-4 py-2 text-right font-medium">Items</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+          <For each={props.results}>
+            {(r) => (
+              <tr>
+                <td class="px-4 py-2.5 text-text-primary">
+                  {SECTION_LABELS[r.section]}
+                </td>
+                <td class="px-4 py-2.5">
+                  <Show
+                    when={r.success}
+                    fallback={
+                      <span class="inline-flex items-center gap-1.5 text-red-600 dark:text-red-400">
+                        <XCircle class="w-4 h-4" />
+                        {r.error ?? 'Failed'}
+                      </span>
+                    }
+                  >
+                    <span class="inline-flex items-center gap-1.5 text-green-600 dark:text-green-400">
+                      <CheckCircle class="w-4 h-4" />
+                      Restored
+                      <Show when={r.restartRequired}>
+                        <span class="text-amber-600 dark:text-amber-400">
+                          (restart required)
+                        </span>
+                      </Show>
+                    </span>
+                  </Show>
+                </td>
+                <td class="px-4 py-2.5 text-right tabular-nums text-text-secondary">
+                  {r.itemsImported}
+                </td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/BackupsPage.test.tsx
+++ b/apps/web/src/components/pages/BackupsPage.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
+import type { BackupManifest } from '@openaidy/shared-types';
+
+vi.mock('../../lib/api-backups', () => ({
+  getBackupManifest: vi.fn(),
+  downloadBackup: vi.fn(),
+  previewBackup: vi.fn(),
+  importBackup: vi.fn(),
+  formatBytes: (n: number) => `${n} B`,
+}));
+
+import {
+  getBackupManifest,
+  downloadBackup,
+  previewBackup,
+  importBackup,
+} from '../../lib/api-backups';
+import { BackupsPage } from './BackupsPage';
+
+function manifest(): BackupManifest {
+  return {
+    version: 1,
+    kind: 'openaidy-backup',
+    createdAt: '2026-07-21T00:00:00.000Z',
+    openaidyVersion: '0.3.8',
+    sections: {
+      db: { itemCount: 1, sizeBytes: 100 },
+      config: { itemCount: 1, sizeBytes: 200 },
+      workspaces: { itemCount: 3, sizeBytes: 300 },
+      skills: { itemCount: 2, sizeBytes: 400 },
+      addons: { itemCount: 1, sizeBytes: 500 },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getBackupManifest).mockResolvedValue(manifest());
+});
+
+describe('BackupsPage — export', () => {
+  it('renders a checkbox for all 5 sections once the manifest loads', async () => {
+    render(() => <BackupsPage />);
+    for (const label of [
+      'Database',
+      'Configuration',
+      'Workspaces',
+      'Skills',
+      'Addons',
+    ]) {
+      expect(await screen.findByLabelText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('downloads the selected sections', async () => {
+    render(() => <BackupsPage />);
+    await screen.findByLabelText('Database');
+    // Deselect config, then download.
+    fireEvent.click(screen.getByLabelText('Configuration'));
+    fireEvent.click(screen.getByRole('button', { name: /download backup/i }));
+    await waitFor(() => expect(downloadBackup).toHaveBeenCalledTimes(1));
+    const sections = vi.mocked(downloadBackup).mock.calls[0]![0];
+    expect(sections).not.toContain('config');
+    expect(sections).toContain('db');
+  });
+
+  it('shows an error and does not download when no sections are selected', async () => {
+    render(() => <BackupsPage />);
+    await screen.findByLabelText('Database');
+    for (const label of [
+      'Database',
+      'Configuration',
+      'Workspaces',
+      'Skills',
+      'Addons',
+    ]) {
+      fireEvent.click(screen.getByLabelText(label));
+    }
+    fireEvent.click(screen.getByRole('button', { name: /download backup/i }));
+    await screen.findByText(/select at least one section/i);
+    expect(downloadBackup).not.toHaveBeenCalled();
+  });
+});
+
+describe('BackupsPage — import', () => {
+  async function goToImport() {
+    render(() => <BackupsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    return screen.findByText(/choose backup file/i);
+  }
+
+  function selectFile() {
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], 'backup.zip', {
+      type: 'application/zip',
+    });
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+    return file;
+  }
+
+  it('previews a chosen file and renders its manifest', async () => {
+    vi.mocked(previewBackup).mockResolvedValue({
+      manifest: manifest(),
+      zipSizeBytes: 1234,
+    });
+    await goToImport();
+    selectFile();
+    await waitFor(() => expect(previewBackup).toHaveBeenCalledTimes(1));
+    // Manifest table rendered → section labels present, Restore button shown.
+    expect(
+      await screen.findByRole('button', { name: /restore/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Skills')).toBeInTheDocument();
+  });
+
+  it('restores the selected sections and shows results', async () => {
+    vi.mocked(previewBackup).mockResolvedValue({
+      manifest: manifest(),
+      zipSizeBytes: 1234,
+    });
+    vi.mocked(importBackup).mockResolvedValue({
+      results: [
+        { section: 'config', success: true, itemsImported: 1 },
+        { section: 'skills', success: true, itemsImported: 2 },
+      ],
+    });
+    await goToImport();
+    selectFile();
+    const restore = await screen.findByRole('button', { name: /restore/i });
+    fireEvent.click(restore);
+    await waitFor(() => expect(importBackup).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/import results/i)).toBeInTheDocument();
+  });
+
+  it('shows an error when the file is not a valid backup', async () => {
+    vi.mocked(previewBackup).mockRejectedValue(
+      new Error('Not a valid zip archive'),
+    );
+    await goToImport();
+    selectFile();
+    expect(
+      await screen.findByText(/not a valid zip archive/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /restore/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/pages/BackupsPage.tsx
+++ b/apps/web/src/components/pages/BackupsPage.tsx
@@ -1,11 +1,261 @@
+import { createSignal, createResource, Show } from 'solid-js';
+import { Download, Upload, Loader, AlertCircle } from 'lucide-solid';
 import { Layout } from './Layout';
+import { Tabs } from '../ui/Tabs';
+import { BackupManifestTable } from './BackupManifestTable';
+import { BackupResultsTable } from './BackupResultsTable';
+import {
+  getBackupManifest,
+  downloadBackup,
+  previewBackup,
+  importBackup,
+} from '../../lib/api-backups';
+import { BACKUP_SECTIONS } from '@openaidy/shared-types';
+import type {
+  BackupSection,
+  BackupPreview,
+  ImportedSection,
+} from '@openaidy/shared-types';
+
+type BackupTab = 'export' | 'import';
 
 export function BackupsPage() {
+  const [tab, setTab] = createSignal<BackupTab>('export');
+
   return (
-    <Layout title="Backups" description="Data export and import">
-      <div class="flex items-center justify-center h-64">
-        <p class="text-text-tertiary">Backup management coming soon</p>
+    <Layout title="Backups" description="Export and restore your OpenAidy data">
+      <Tabs<BackupTab>
+        tabs={[
+          { id: 'export', label: 'Export' },
+          { id: 'import', label: 'Import' },
+        ]}
+        activeTab={tab}
+        onTabChange={setTab}
+      />
+      <div class="bg-white dark:bg-gray-800 shadow rounded-b-lg p-4 sm:p-6">
+        <Show when={tab() === 'export'}>
+          <ExportTab />
+        </Show>
+        <Show when={tab() === 'import'}>
+          <ImportTab />
+        </Show>
       </div>
     </Layout>
+  );
+}
+
+function ExportTab() {
+  const [manifest, { refetch }] = createResource(getBackupManifest);
+  // Start with everything selected.
+  const [selected, setSelected] = createSignal<BackupSection[]>([
+    ...BACKUP_SECTIONS,
+  ]);
+  const [busy, setBusy] = createSignal(false);
+  const [error, setError] = createSignal<string | undefined>();
+
+  const toggle = (section: BackupSection, checked: boolean) => {
+    setSelected((prev) =>
+      checked
+        ? [...new Set([...prev, section])]
+        : prev.filter((s) => s !== section),
+    );
+  };
+
+  const onDownload = async () => {
+    setError(undefined);
+    if (selected().length === 0) {
+      setError('Select at least one section to export');
+      return;
+    }
+    setBusy(true);
+    try {
+      await downloadBackup(selected());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Export failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <p class="text-sm text-text-secondary">
+        Choose which sections to include. The backup is a <code>.zip</code> you
+        can restore on another machine or keep as a safety copy. Provider API
+        keys travel with the configuration section.
+      </p>
+
+      <Show
+        when={manifest()}
+        fallback={
+          <Show
+            when={!manifest.error}
+            fallback={
+              <p class="text-sm text-red-600 dark:text-red-400">
+                Failed to load backup info.{' '}
+                <button class="underline" onClick={() => void refetch()}>
+                  Retry
+                </button>
+              </p>
+            }
+          >
+            <div class="flex items-center gap-2 text-sm text-text-tertiary py-6">
+              <Loader class="w-4 h-4 animate-spin" /> Loading…
+            </div>
+          </Show>
+        }
+      >
+        {(m) => (
+          <BackupManifestTable
+            manifest={m()}
+            selected={selected()}
+            onToggle={toggle}
+          />
+        )}
+      </Show>
+
+      <Show when={error()}>
+        <p class="flex items-center gap-1.5 text-sm text-red-600 dark:text-red-400">
+          <AlertCircle class="w-4 h-4" />
+          {error()}
+        </p>
+      </Show>
+
+      <button
+        type="button"
+        onClick={() => void onDownload()}
+        disabled={busy() || !manifest()}
+        class="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium px-4 py-2 transition-colors"
+      >
+        <Show when={busy()} fallback={<Download class="w-4 h-4" />}>
+          <Loader class="w-4 h-4 animate-spin" />
+        </Show>
+        {busy() ? 'Preparing…' : 'Download Backup'}
+      </button>
+    </div>
+  );
+}
+
+function ImportTab() {
+  const [file, setFile] = createSignal<File | undefined>();
+  const [preview, setPreview] = createSignal<BackupPreview | undefined>();
+  const [selected, setSelected] = createSignal<BackupSection[]>([]);
+  const [results, setResults] = createSignal<ImportedSection[] | undefined>();
+  const [busy, setBusy] = createSignal(false);
+  const [error, setError] = createSignal<string | undefined>();
+
+  const toggle = (section: BackupSection, checked: boolean) => {
+    setSelected((prev) =>
+      checked
+        ? [...new Set([...prev, section])]
+        : prev.filter((s) => s !== section),
+    );
+  };
+
+  const onFile = async (e: Event) => {
+    const input = e.currentTarget as HTMLInputElement;
+    const chosen = input.files?.[0];
+    setError(undefined);
+    setResults(undefined);
+    setPreview(undefined);
+    if (!chosen) return;
+    setFile(chosen);
+    setBusy(true);
+    try {
+      const p = await previewBackup(chosen);
+      setPreview(p);
+      // Pre-check every section present in the backup.
+      setSelected(
+        BACKUP_SECTIONS.filter((s) => p.manifest.sections[s].itemCount > 0),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid backup file');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRestore = async () => {
+    const f = file();
+    if (!f) return;
+    setError(undefined);
+    if (selected().length === 0) {
+      setError('Select at least one section to restore');
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await importBackup(f, selected());
+      setResults(res.results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <p class="text-sm text-text-secondary">
+        Restore is non-destructive: existing records are kept and matching files
+        are overwritten. The database and configuration take effect after a
+        server restart.
+      </p>
+
+      <div>
+        <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium px-4 py-2 cursor-pointer transition-colors">
+          <Upload class="w-4 h-4" />
+          Choose Backup File
+          <input
+            type="file"
+            accept=".zip,application/zip"
+            class="hidden"
+            onChange={(e) => void onFile(e)}
+          />
+        </label>
+        <Show when={file()}>
+          <span class="ml-2 text-sm text-text-tertiary">{file()!.name}</span>
+        </Show>
+      </div>
+
+      <Show when={error()}>
+        <p class="flex items-center gap-1.5 text-sm text-red-600 dark:text-red-400">
+          <AlertCircle class="w-4 h-4" />
+          {error()}
+        </p>
+      </Show>
+
+      <Show when={preview() && !results()}>
+        <div class="space-y-4">
+          <BackupManifestTable
+            manifest={preview()!.manifest}
+            selected={selected()}
+            onToggle={toggle}
+          />
+          <button
+            type="button"
+            onClick={() => void onRestore()}
+            disabled={busy()}
+            class="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium px-4 py-2 transition-colors"
+          >
+            <Show when={busy()} fallback={<Download class="w-4 h-4" />}>
+              <Loader class="w-4 h-4 animate-spin" />
+            </Show>
+            {busy() ? 'Restoring…' : 'Restore'}
+          </button>
+        </div>
+      </Show>
+
+      <Show when={results()}>
+        {(r) => (
+          <div class="space-y-2">
+            <h3 class="text-sm font-medium text-text-primary">
+              Import results
+            </h3>
+            <BackupResultsTable results={r()} />
+          </div>
+        )}
+      </Show>
+    </div>
   );
 }

--- a/apps/web/src/lib/api-backups.ts
+++ b/apps/web/src/lib/api-backups.ts
@@ -1,0 +1,116 @@
+/**
+ * Backup API client — manifest, export (download), preview, import.
+ */
+
+import { getStoredToken } from './auth-token';
+import { API_BASE } from './api';
+import type {
+  BackupManifest,
+  BackupPreview,
+  BackupSection,
+  ImportResponse,
+} from '@openaidy/shared-types';
+
+function authHeader(): Record<string, string> {
+  const token = getStoredToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Human-readable byte size, e.g. 5242880 → "5.0 MB". */
+export function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+  );
+  const value = bytes / Math.pow(1024, i);
+  return `${i === 0 ? value : value.toFixed(1)} ${units[i]}`;
+}
+
+async function errorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: string };
+    return body.error ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Live snapshot of what a full backup would contain. */
+export async function getBackupManifest(): Promise<BackupManifest> {
+  const response = await fetch(`${API_BASE}/api/backups/manifest`, {
+    headers: authHeader(),
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, 'Failed to load backup info'));
+  }
+  const body = (await response.json()) as { manifest: BackupManifest };
+  return body.manifest;
+}
+
+/**
+ * Request a backup zip of the given sections and trigger a browser download.
+ * Passing an empty array exports all sections.
+ */
+export async function downloadBackup(sections: BackupSection[]): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/backups/export`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify({ sections }),
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, 'Backup export failed'));
+  }
+  const blob = await response.blob();
+  const disposition = response.headers.get('Content-Disposition') ?? '';
+  const match = disposition.match(/filename="([^"]+)"/);
+  const date = new Date().toISOString().slice(0, 10);
+  const filename = match?.[1] ?? `openaidy-backup-${date}.zip`;
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Upload a backup zip and read its manifest without applying anything. */
+export async function previewBackup(file: File): Promise<BackupPreview> {
+  const form = new FormData();
+  form.append('file', file);
+  const response = await fetch(`${API_BASE}/api/backups/preview`, {
+    method: 'POST',
+    headers: authHeader(),
+    body: form,
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, 'Invalid backup file'));
+  }
+  return (await response.json()) as BackupPreview;
+}
+
+/** Upload a backup zip and apply the selected sections. */
+export async function importBackup(
+  file: File,
+  sections: BackupSection[],
+): Promise<ImportResponse> {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('sections', JSON.stringify(sections));
+  const response = await fetch(`${API_BASE}/api/backups/import`, {
+    method: 'POST',
+    headers: authHeader(),
+    body: form,
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, 'Import failed'));
+  }
+  return (await response.json()) as ImportResponse;
+}

--- a/packages/shared-types/src/backups.ts
+++ b/packages/shared-types/src/backups.ts
@@ -1,0 +1,94 @@
+/**
+ * Backup export/import types.
+ *
+ * A backup is a `.zip` archive with a versioned `manifest.json` plus one
+ * subdirectory per data section. Import is selective: the user chooses which
+ * sections to restore, and restores are non-destructive (add/overwrite, never
+ * delete — except `db`, which is a full file replacement).
+ */
+
+/** Backup archive manifest format version. */
+export const BACKUP_FORMAT_VERSION = 1;
+export const BACKUP_KIND = 'openaidy-backup';
+
+/** Sections available in a backup. */
+export type BackupSection =
+  | 'db'
+  | 'config'
+  | 'workspaces'
+  | 'skills'
+  | 'addons';
+
+/** All sections, in a stable display order. */
+export const BACKUP_SECTIONS: readonly BackupSection[] = [
+  'db',
+  'config',
+  'workspaces',
+  'skills',
+  'addons',
+];
+
+/** Per-section item count and size info for display. */
+export type BackupSectionSummary = {
+  itemCount: number;
+  sizeBytes: number;
+};
+
+/** The manifest written into every backup zip. */
+export type BackupManifest = {
+  version: typeof BACKUP_FORMAT_VERSION;
+  kind: typeof BACKUP_KIND;
+  /** ISO 8601 */
+  createdAt: string;
+  openaidyVersion: string;
+  sections: Record<BackupSection, BackupSectionSummary>;
+};
+
+/** Response body of `GET /api/backups/manifest` (live snapshot of OPENAIDY_HOME). */
+export type BackupManifestResponse = {
+  manifest: BackupManifest;
+};
+
+/** Response body of `POST /api/backups/preview`. */
+export type BackupPreview = {
+  manifest: BackupManifest;
+  zipSizeBytes: number;
+};
+
+/** Request body of `POST /api/backups/export` (omit `sections` for all). */
+export type ExportRequest = {
+  sections?: BackupSection[];
+};
+
+/** Request body of `POST /api/backups/import`. */
+export type ImportRequest = {
+  sections: BackupSection[];
+};
+
+/** Result of importing one section. */
+export type ImportedSection = {
+  section: BackupSection;
+  success: boolean;
+  error?: string;
+  itemsImported: number;
+  /** True when the imported section only takes effect after a server restart. */
+  restartRequired?: boolean;
+};
+
+/** Response body of `POST /api/backups/import`. */
+export type ImportResponse = {
+  results: ImportedSection[];
+};
+
+/** Type guard for a parsed manifest. */
+export function isBackupManifest(value: unknown): value is BackupManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return (
+    m.kind === BACKUP_KIND &&
+    m.version === BACKUP_FORMAT_VERSION &&
+    typeof m.createdAt === 'string' &&
+    typeof m.sections === 'object' &&
+    m.sections !== null
+  );
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -19,3 +19,4 @@ export * from './tasks.js';
 export * from './task-schedules.js';
 export * from './bootstrap-admin.js';
 export * from './model-pricing.js';
+export * from './backups.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/multipart':
+        specifier: ^10.1.0
+        version: 10.1.0
       '@fastify/sensible':
         specifier: ^6.0.4
         version: 6.0.4
@@ -95,6 +98,12 @@ importers:
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc10
         version: 7.0.0-rc10(sharp@0.34.5)
+      adm-zip:
+        specifier: ^0.6.0
+        version: 0.6.0
+      archiver:
+        specifier: ^8.0.0
+        version: 8.0.0
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -141,6 +150,12 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.8
+        version: 0.5.8
+      '@types/archiver':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
@@ -1437,8 +1452,14 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -1451,6 +1472,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.1.0':
+    resolution: {integrity: sha512-b2r6CovmLQvLFJ5HJDtxVigZjcO9TwkRGslhiNQxsGJwilm5B3eqvXPOVLudC44zXMXJITpQ/iEATIE7zoXqcQ==}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
@@ -2205,6 +2229,12 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
+
+  '@types/archiver@8.0.0':
+    resolution: {integrity: sha512-YpXPbEuv9+eUIPPQWUPahj3cvs9isWRuF+J4z+KbdYVDO3rWorWQFxUVHnwPu2AgKwvgpki5F2VMX0Xx+mX45A==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2282,6 +2312,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -2573,6 +2606,10 @@ packages:
       link-preview-js:
         optional: true
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -2589,6 +2626,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2643,6 +2684,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  archiver@8.0.0:
+    resolution: {integrity: sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==}
+    engines: {node: '>=18'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -2659,6 +2704,9 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -2672,6 +2720,14 @@ packages:
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-plugin-jsx-dom-expressions@0.40.5:
     resolution: {integrity: sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg==}
@@ -2693,6 +2749,43 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.6:
+    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2748,11 +2841,18 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bun-plugin-dts@0.4.0:
     resolution: {integrity: sha512-g/pHy9SuhnUw+E+bHnJvADOnnZlEIci3nvZY8EuQEMwkpC4V4Kmoa2nG9nfda4jmjj+0POlCRCjdqXrL9gjYtA==}
@@ -2858,6 +2958,10 @@ packages:
   common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
 
+  compress-commons@7.0.1:
+    resolution: {integrity: sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==}
+    engines: {node: '>=18'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2892,9 +2996,21 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@7.0.1:
+    resolution: {integrity: sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==}
+    engines: {node: '>=18'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3311,8 +3427,19 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -3346,6 +3473,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -3376,6 +3506,9 @@ packages:
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
   fastify@5.8.2:
     resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
@@ -3694,6 +3827,10 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
@@ -3701,6 +3838,9 @@ packages:
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3772,6 +3912,10 @@ packages:
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
 
   leac@0.7.0:
     resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
@@ -4390,11 +4534,18 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -4485,9 +4636,20 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@3.0.0:
+    resolution: {integrity: sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==}
+    engines: {node: '>=18'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -4569,6 +4731,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -4744,6 +4909,9 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -4759,6 +4927,9 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4830,6 +5001,15 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -5376,6 +5556,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@7.0.5:
+    resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -6258,10 +6442,14 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/busboy@3.2.0': {}
+
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
+
+  '@fastify/deepmerge@3.2.1': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -6274,6 +6462,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@10.1.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 6.0.0
+      secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
     dependencies:
@@ -6903,6 +7099,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/adm-zip@0.5.8':
+    dependencies:
+      '@types/node': 24.13.1
+
+  '@types/archiver@8.0.0':
+    dependencies:
+      '@types/node': 24.13.1
+      '@types/readdir-glob': 1.1.5
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -6994,6 +7199,10 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 24.13.1
 
   '@types/semver@7.7.1': {}
 
@@ -7360,6 +7569,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   abstract-logging@2.0.1: {}
 
   accepts@2.0.0:
@@ -7372,6 +7585,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 
@@ -7433,6 +7648,22 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  archiver@8.0.0:
+    dependencies:
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      is-stream: 4.0.1
+      lazystream: 1.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 3.0.0
+      tar-stream: 3.2.0
+      zip-stream: 7.0.5
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -7446,6 +7677,8 @@ snapshots:
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
+
+  async@3.2.6: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -7462,6 +7695,8 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
+
+  b4a@1.8.1: {}
 
   babel-plugin-jsx-dom-expressions@0.40.5(@babel/core@7.29.0):
     dependencies:
@@ -7483,8 +7718,36 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.6
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.6:
+    dependencies:
+      bare-path: 3.1.1
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.8: {}
 
@@ -7553,6 +7816,8 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-crc32@1.0.0: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -7560,6 +7825,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
     optional: true
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bun-plugin-dts@0.4.0:
     dependencies:
@@ -7670,6 +7940,14 @@ snapshots:
 
   common-path-prefix@3.0.0: {}
 
+  compress-commons@7.0.1:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 7.0.1
+      is-stream: 4.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
@@ -7692,10 +7970,19 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@7.0.1:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   crelt@1.0.6: {}
 
@@ -8144,7 +8431,17 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.4: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -8199,6 +8496,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8237,6 +8536,8 @@ snapshots:
       fast-string-width: 3.0.2
 
   fastify-plugin@5.1.0: {}
+
+  fastify-plugin@6.0.0: {}
 
   fastify@5.8.2:
     dependencies:
@@ -8576,9 +8877,13 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-stream@4.0.1: {}
+
   is-what@4.1.16: {}
 
   is-what@5.5.0: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -8652,6 +8957,10 @@ snapshots:
   keyv@5.6.0:
     dependencies:
       '@keyv/serialize': 1.1.1
+
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
 
   leac@0.7.0: {}
 
@@ -9213,9 +9522,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  process@0.11.10: {}
 
   property-information@7.2.0: {}
 
@@ -9318,11 +9631,33 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@3.0.0:
+    dependencies:
+      minimatch: 10.2.4
 
   readdirp@3.6.0:
     dependencies:
@@ -9458,6 +9793,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -9672,6 +10009,15 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -9690,6 +10036,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -9795,6 +10145,30 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.4
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thenify-all@1.6.0:
     dependencies:
@@ -10374,6 +10748,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@7.0.5:
+    dependencies:
+      compress-commons: 7.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Closes #451.

Implements the full backup **export** and **import** system, replacing the "coming soon" placeholder. Backups are `.zip` archives with a versioned `manifest.json` + one subdirectory per section; import is selective and non-destructive.

## Backend

- **`shared-types/backups.ts`** — `BackupManifest`, `BackupSection`, preview/import request+response types, `BACKUP_FORMAT_VERSION`, `BACKUP_SECTIONS`, and an `isBackupManifest` guard.
- **`BackupService`** (`apps/server/src/backups/service.ts`) — paths injected for testability:
  - `buildManifest()` — live per-section item counts + sizes.
  - `buildZip()` — **streams** a `manifest.json` + selected sections via `archiver` (db incl. WAL/SHM sidecars; config file; workspaces/skills/addons directories).
  - `readManifest()` — validates an uploaded zip (non-zip / missing-manifest → throws).
  - `applySection()` — `db`/`config` = file replacement (restart-required); `workspaces`/`skills`/`addons` = **non-destructive file merge** (overwrite existing, add new, never delete) with a **zip-slip guard**.
- **`backupRoutes`** — admin-scoped (`*`): `GET /backups/manifest`, streaming `POST /backups/export`, and `POST /backups/preview` + `POST /backups/import` via `@fastify/multipart` (registered **scoped** to this plugin), with upload-size and uncompressed-size (**zip-bomb**) guards.
- Wired into `app.ts` with paths from env (`SQLITE_PATH`, `APP_CONFIG_PATH`, `WORKSPACE_BASE_DIR`, `SKILLS_DIR`, `OPENAIDY_HOME/addons`).
- Deps: `archiver`, `adm-zip`, `@fastify/multipart` (+ types). Note `archiver@8` is class-based ESM (`new ZipArchive(...)`) — fine since the server is `type: module`.

## Frontend

- **`BackupsPage`** — Export tab (section checklist with counts/sizes → download zip) and Import tab (choose `.zip` → preview manifest → select sections → restore → per-section results, with restart-required note).
- `api-backups.ts` (manifest/download/preview/import + `formatBytes`) and reusable `BackupManifestTable` / `BackupResultsTable`.

## Tests

- Server: `service.test.ts` (12) + `routes.test.ts` (10) — manifest, section-filtered export, preview validation, import merge/idempotency, no-sections/unknown-section rejection.
- Web: `BackupsPage.test.tsx` (6) — section rendering, download payload, empty-selection guard, preview, restore + results, invalid-file error.
- All green; server + web + shared-types typecheck and ESLint clean.

## Notes / deviations from the spec
- Addons are restored as a **file merge**; DB-level addon registration comes with the `db` section or a restart (the running instance isn't hot-reloaded — same restart caveat the spec states for `db`/`config`). Live re-registration could be a follow-up.
- Live `exec_output` history isn't part of backups (not a data section).
- Built in an isolated git worktree so it's independent of other in-progress work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)