### PR TITLE
fix(server): quiet noisy test output from MCP auto-connect + startup logs

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -983,7 +983,16 @@ export async function buildApp() {
     // startup with FST_ERR_HOOK_TIMEOUT. Connect in the background and
     // log the outcome; a slow or unavailable MCP server must not take
     // down the HTTP API (routes already tolerate unconnected servers).
-    const mcpServers = configService.getMcpServers();
+    //
+    // Skip entirely under test: every route test spins up buildApp(), and
+    // auto-connecting the bundled template servers (github, playwright,
+    // sequential-thinking, …) floods the test output with "failed to
+    // connect"/"awaiting configuration" logs and wastes seconds on npx/HTTP
+    // timeouts. Read process.env directly (not env.NODE_ENV) because tests
+    // mock ../lib/env without a NODE_ENV field. Tests that exercise MCP
+    // connect do so against the client/service directly, not this hook.
+    const mcpServers =
+      process.env.NODE_ENV === 'test' ? [] : configService.getMcpServers();
     for (const serverConfig of mcpServers) {
       // A server whose ${VAR} secrets aren't set yet (e.g. a preinstalled
       // GitHub server before the user pastes a token) isn't broken — it's

--- a/apps/server/src/bootstrap-admin.ts
+++ b/apps/server/src/bootstrap-admin.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rename, writeFile, chmod } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import type { FastifyBaseLogger } from 'fastify';
 import { AuthMiddleware, CAPABILITIES } from './websocket/middleware/auth';
 import type { BootstrapAdminRecord } from '@openaidy/shared-types';
@@ -141,7 +142,12 @@ export class BootstrapAdminManager {
   private async persistRecord(record: BootstrapAdminRecord): Promise<void> {
     await mkdir(dirname(this.options.tokenPath), { recursive: true });
 
-    const tempPath = `${this.options.tokenPath}.tmp`;
+    // Unique temp name per write. A fixed `${tokenPath}.tmp` is a race: two
+    // managers pointed at the same token path (e.g. concurrent buildApp()s in
+    // tests) would each write the same temp file, and one's rename() pulls it
+    // out from under the other's chmod(), throwing ENOENT. A per-write suffix
+    // keeps the write atomic and isolated.
+    const tempPath = `${this.options.tokenPath}.${randomUUID()}.tmp`;
     const contents = `${JSON.stringify(record, null, 2)}\n`;
 
     await writeFile(tempPath, contents, { encoding: 'utf-8', mode: 0o600 });

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -17,5 +17,11 @@ export default defineConfig({
     },
     // Increase default timeout for all tests
     testTimeout: 15000,
+    // Suppress console output from passing tests so the run stays readable.
+    // Logs are still captured and printed for any test that FAILS, so
+    // debugging isn't hurt. This hides the app's routine startup logs
+    // (WorkspaceService init, bootstrap token, web-bundle notice, request
+    // lines) that otherwise bury the actual results.
+    silent: 'passed-only',
   },
 });


### PR DESCRIPTION
## Problem

Server tests printed the same MCP connection errors over and over, burying the
actual results in stack traces and making the run hard to read (and slower).

Every server route test boots `buildApp()`, whose `onReady` hook auto-connected
**every bundled-template MCP server** (`github`, `playwright`,
`sequential-thinking`, `time`, `context7`, `brave-search`, `tavily`). In the
test/CI environment none of these are reachable, so each suite emitted:

- `[WARN] Failed to connect MCP server on startup` with full `McpError: Request timed out` stack traces
- `[INFO] Connecting to MCP server via stdio/HTTP`
- `[INFO] MCP server awaiting configuration — not auto-connecting`

…and wasted real time on `npx`/HTTP connection attempts (60s timeouts) firing in
the background of otherwise-instant tests.

The existing per-file `LOG_LEVEL: 'silent'` mocks were a no-op: the logger reads
`process.env.LOG_LEVEL` at module load (not the mocked `env` module), and
`'silent'` isn't even a valid level in the shared `LogLevel` type.

## Changes

- **`app.ts`** — skip the MCP auto-connect loop when `NODE_ENV === 'test'`. Read
  `process.env` directly because route tests mock `../lib/env` without a
  `NODE_ENV` field. MCP connect logic is still covered by the client/service
  unit tests (`mcp/client.test.ts`), not this bootstrap hook. This removes the
  noise **and** the wasted connection timeouts.
- **`vitest.config.ts`** — `silent: 'passed-only'` (Vitest 3.2). Hides routine
  startup logs (WorkspaceService init, bootstrap token, web-bundle notice,
  request lines) for **passing** tests, while still printing them for **failing**
  tests — so debugging isn't hurt.
- **`bootstrap-admin.ts`** — fix a latent temp-file race the quieter timing
  exposed. `persistRecord` used a fixed `${tokenPath}.tmp`; suites that share a
  token path (`auth`, `providers`, `sessions` all use `test-bootstrap-admin.json`)
  could have one manager's `rename()` pull the temp file out from under another's
  `chmod()` → `ENOENT`. Now uses a unique per-write temp name (`randomUUID`),
  which is also just the correct atomic-write pattern.

## Verification

- Full server suite: **159 files, 3242 tests passing, 0 failures** (~117s).
- The problematic suites rerun 3× with no flakiness; `tsc --noEmit` clean.
- MCP connection noise and the `ENOENT` chmod error are both gone from output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)