### PR TITLE
feat(update): in-app self-update mechanism for self-hosted installs (#456)

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -44,6 +44,8 @@ import { addonRoutes } from './routes/addons';
 import { addonProxyRoutes } from './addons/proxy-routes';
 import { backupRoutes } from './backups/routes';
 import { createBackupService } from './backups/service';
+import { updateRoutes } from './routes/update';
+import { createUpdateService } from './update/service';
 import { AddonStorageEngine, DEFAULT_QUOTAS } from './addons/storage/engine';
 import { ManifestValidator } from './addons/manifest-validator';
 import { createAddonService } from './addons/service';
@@ -562,6 +564,16 @@ export async function buildApp() {
           },
           openAidyVersion,
         ),
+        authMiddleware,
+      });
+
+      // In-app self-update (admin-only). Checks the npm registry and, for a
+      // packaged global install, runs `npm install -g @openaidy/app@latest`
+      // then restarts via the CLI. `canSelfUpdate` auto-detects packaged mode.
+      await api.register(updateRoutes, {
+        updateService: createUpdateService({
+          currentVersion: openAidyVersion,
+        }),
         authMiddleware,
       });
 

--- a/apps/server/src/routes/update.test.ts
+++ b/apps/server/src/routes/update.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+
+vi.mock('../lib/env', () => ({
+  env: (() => {
+    const appConfigPath = fileURLToPath(
+      new URL('../../../.openaidy/test-update-config.json', import.meta.url),
+    );
+    const appConfigTemplatePath = fileURLToPath(
+      new URL('../../../../config/openaidy.template.json', import.meta.url),
+    );
+    const bootstrapAdminTokenPath = fileURLToPath(
+      new URL(
+        '../../../.openaidy/test-update-bootstrap-admin.json',
+        import.meta.url,
+      ),
+    );
+    return {
+      HOST: '0.0.0.0',
+      PORT: 3001,
+      CORS_ORIGIN: 'http://localhost:3000',
+      DB_KIND: 'sqlite',
+      DATABASE_URL: undefined,
+      SQLITE_PATH: fileURLToPath(
+        new URL('../../../.openaidy/test-update.db', import.meta.url),
+      ),
+      OPENAIDY_HOME: fileURLToPath(
+        new URL('../../../.openaidy', import.meta.url),
+      ),
+      APP_CONFIG_PATH: appConfigPath,
+      APP_CONFIG_TEMPLATE_PATH: appConfigTemplatePath,
+      LOG_LEVEL: 'silent',
+      WORKSPACE_BASE_DIR: fileURLToPath(
+        new URL('../../../.openaidy/workspaces', import.meta.url),
+      ),
+      BOOTSTRAP_ADMIN_ENABLED: true,
+      BOOTSTRAP_ADMIN_TOKEN_PATH: bootstrapAdminTokenPath,
+      BOOTSTRAP_ADMIN_CLIENT_ID: 'test-bootstrap-admin',
+      BOOTSTRAP_ADMIN_TOKEN_EXPIRY_MS: 31536000000,
+      WS_ENABLED: false,
+      WS_PORT: 3001,
+      WS_PATH: '/ws',
+      WS_MAX_CONNECTIONS: 1000,
+      WS_HEARTBEAT_INTERVAL: 30000,
+      WS_AUTH_REQUIRED: false,
+      WS_TOKEN_EXPIRY: 86400000,
+      WS_TOKEN_SECRET: 'test-secret',
+      WS_RATE_LIMIT_MAX: 100,
+      WS_RATE_LIMIT_WINDOW: 60000,
+      WS_PAIRING_CODE_LENGTH: 6,
+      WS_PAIRING_CODE_EXPIRY_MS: 300000,
+      WS_PAIRING_MAX_PENDING: 100,
+      WS_PAIRING_TOKEN_EXPIRY_MS: 2592000000,
+      WS_PAIRING_REQUIRE_ADMIN: true,
+    };
+  })(),
+}));
+
+import { buildApp } from '../app';
+import type { FastifyInstance } from 'fastify';
+import { rm } from 'node:fs/promises';
+import { AuthMiddleware } from '../websocket/middleware/auth';
+
+async function generateAdminToken(): Promise<string> {
+  const auth = new AuthMiddleware({
+    enabled: false,
+    port: 3001,
+    path: '/ws',
+    maxConnections: 1000,
+    heartbeatInterval: 30000,
+    auth: { required: true, secret: 'test-secret', tokenExpiry: 86400000 },
+    rateLimit: { max: 100, window: 60000 },
+  });
+  return auth.generateToken({
+    clientId: 'test-admin',
+    type: 'access',
+    scopes: ['*'],
+    expiresIn: 86400000,
+  });
+}
+
+const DB_PATH = fileURLToPath(
+  new URL('../../../.openaidy/test-update.db', import.meta.url),
+);
+
+/** Stub global fetch: npm registry `/latest` → `latest`, GitHub release → 404. */
+function stubFetch(latest = '9.9.9', registryOk = true) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('registry.npmjs.org')) {
+        return {
+          ok: registryOk,
+          status: registryOk ? 200 : 503,
+          statusText: registryOk ? 'OK' : 'Service Unavailable',
+          json: async () => ({ version: latest }),
+        } as Response;
+      }
+      // GitHub release notes: pretend there are none.
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({}),
+      } as Response;
+    });
+}
+
+let app: FastifyInstance;
+
+describe('Update Routes', () => {
+  let adminToken: string;
+
+  beforeEach(async () => {
+    adminToken = await generateAdminToken();
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.restoreAllMocks();
+    await rm(DB_PATH, { force: true });
+  });
+
+  const auth = () => ({ authorization: `Bearer ${adminToken}` });
+
+  describe('Auth guard', () => {
+    it('returns 401 on GET /api/update/check without a token', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/update/check' });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 401 on POST /api/update without a token', async () => {
+      const res = await app.inject({ method: 'POST', url: '/api/update' });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 401 on GET /api/update/status without a token', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/update/status',
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/update/check', () => {
+    it('reports an available update and canSelfUpdate=false in dev/test', async () => {
+      const fetchSpy = stubFetch('9.9.9');
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/update/check',
+        headers: auth(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.latestVersion).toBe('9.9.9');
+      expect(body.updateAvailable).toBe(true);
+      // The test harness resolves to the monorepo, which cannot self-update.
+      expect(body.canSelfUpdate).toBe(false);
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    it('returns 502 when the registry is unreachable', async () => {
+      stubFetch('9.9.9', false);
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/update/check',
+        headers: auth(),
+      });
+      expect(res.statusCode).toBe(502);
+      expect(res.json().error).toBe('UPDATE_CHECK_FAILED');
+    });
+  });
+
+  describe('GET /api/update/status', () => {
+    it('returns idle on a fresh server', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/update/status',
+        headers: auth(),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().status).toBe('idle');
+    });
+  });
+
+  describe('POST /api/update', () => {
+    it('returns 409 UPDATE_NOT_SUPPORTED in dev/test (cannot self-update)', async () => {
+      stubFetch('9.9.9');
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/update',
+        headers: auth(),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(409);
+      expect(res.json().error).toBe('UPDATE_NOT_SUPPORTED');
+    });
+
+    it('rejects a non-string version with 400', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/update',
+        headers: auth(),
+        payload: { version: 123 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('INVALID_BODY');
+    });
+  });
+});

--- a/apps/server/src/routes/update.test.ts
+++ b/apps/server/src/routes/update.test.ts
@@ -144,6 +144,30 @@ describe('Update Routes', () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    it('returns 403 when the token lacks admin scope', async () => {
+      const auth = new AuthMiddleware({
+        enabled: false,
+        port: 3001,
+        path: '/ws',
+        maxConnections: 1000,
+        heartbeatInterval: 30000,
+        auth: { required: true, secret: 'test-secret', tokenExpiry: 86400000 },
+        rateLimit: { max: 100, window: 60000 },
+      });
+      const limitedToken = await auth.generateToken({
+        clientId: 'limited-user',
+        type: 'access',
+        scopes: ['sessions.read'],
+        expiresIn: 86400000,
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/update/check',
+        headers: { authorization: `Bearer ${limitedToken}` },
+      });
+      expect(res.statusCode).toBe(403);
+    });
   });
 
   describe('GET /api/update/check', () => {
@@ -206,6 +230,17 @@ describe('Update Routes', () => {
         url: '/api/update',
         headers: auth(),
         payload: { version: 123 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('INVALID_BODY');
+    });
+
+    it('rejects a non-semver version string with 400', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/update',
+        headers: auth(),
+        payload: { version: '9.9.9 && rm -rf /' },
       });
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toBe('INVALID_BODY');

--- a/apps/server/src/routes/update.ts
+++ b/apps/server/src/routes/update.ts
@@ -9,6 +9,7 @@
 
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
+import semver from 'semver';
 import type { UpdateCheckResult, UpdateState } from '@openaidy/shared-types';
 import type { AuthMiddleware } from '../websocket/middleware/auth';
 import { requireAuth } from '../middleware/require-auth';
@@ -17,8 +18,17 @@ import type { UpdateService } from '../update/service';
 const ADMIN_SCOPE = '*';
 
 const triggerSchema = z.object({
-  /** Optional explicit target; defaults to the latest published version. */
-  version: z.string().min(1).optional(),
+  // Optional explicit target; defaults to the latest published version. Must
+  // be a valid semver string — this value is passed straight to `npm install
+  // -g <pkg>@<version>`, so anything else is rejected before it gets near
+  // spawn().
+  version: z
+    .string()
+    .min(1)
+    .refine((v) => semver.valid(v) != null, {
+      message: 'version must be a valid semver string',
+    })
+    .optional(),
 });
 
 export type UpdateRoutesOptions = {
@@ -66,7 +76,7 @@ export const updateRoutes: FastifyPluginAsync<UpdateRoutesOptions> = async (
     if (!parsed.success) {
       return reply.code(400).send({
         error: 'INVALID_BODY',
-        message: 'version, if provided, must be a non-empty string',
+        message: 'version, if provided, must be a valid semver string',
       });
     }
 

--- a/apps/server/src/routes/update.ts
+++ b/apps/server/src/routes/update.ts
@@ -1,0 +1,114 @@
+/**
+ * Self-update routes (issue #456). Admin-scoped — updating replaces the running
+ * binary and restarts the server.
+ *
+ *   GET  /update/check   — current vs. latest npm version + whether self-update is possible
+ *   GET  /update/status  — in-memory state of any in-flight update
+ *   POST /update         — trigger `npm install -g @openaidy/app@latest` + restart
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import type { UpdateCheckResult, UpdateState } from '@openaidy/shared-types';
+import type { AuthMiddleware } from '../websocket/middleware/auth';
+import { requireAuth } from '../middleware/require-auth';
+import type { UpdateService } from '../update/service';
+
+const ADMIN_SCOPE = '*';
+
+const triggerSchema = z.object({
+  /** Optional explicit target; defaults to the latest published version. */
+  version: z.string().min(1).optional(),
+});
+
+export type UpdateRoutesOptions = {
+  updateService: UpdateService;
+  authMiddleware: AuthMiddleware;
+};
+
+export const updateRoutes: FastifyPluginAsync<UpdateRoutesOptions> = async (
+  app,
+  opts,
+) => {
+  const { updateService } = opts;
+  const adminAuth = requireAuth({
+    authMiddleware: opts.authMiddleware,
+    requiredScope: ADMIN_SCOPE,
+  });
+
+  app.get<{ Reply: UpdateCheckResult | { error: string; message: string } }>(
+    '/update/check',
+    { preHandler: adminAuth },
+    async (_request, reply) => {
+      try {
+        return await updateService.check();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return reply.code(502).send({
+          error: 'UPDATE_CHECK_FAILED',
+          message: `Unable to check for updates: ${message}`,
+        });
+      }
+    },
+  );
+
+  app.get<{ Reply: UpdateState }>(
+    '/update/status',
+    { preHandler: adminAuth },
+    async () => updateService.getState(),
+  );
+
+  app.post<{
+    Body: unknown;
+    Reply: UpdateState | { error: string; message: string };
+  }>('/update', { preHandler: adminAuth }, async (request, reply) => {
+    const parsed = triggerSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.code(400).send({
+        error: 'INVALID_BODY',
+        message: 'version, if provided, must be a non-empty string',
+      });
+    }
+
+    // Resolve the target version. When the caller doesn't pin one, ask the
+    // registry for the latest and refuse if there's nothing newer to install.
+    let targetVersion = parsed.data.version;
+    if (!targetVersion) {
+      let check: UpdateCheckResult;
+      try {
+        check = await updateService.check();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return reply.code(502).send({
+          error: 'UPDATE_CHECK_FAILED',
+          message: `Unable to check for updates: ${message}`,
+        });
+      }
+      if (!check.updateAvailable) {
+        return reply.code(409).send({
+          error: 'ALREADY_LATEST',
+          message: `Already on the latest version (${check.currentVersion}).`,
+        });
+      }
+      targetVersion = check.latestVersion;
+    }
+
+    const result = updateService.startUpdate(targetVersion);
+    if (!result.ok) {
+      if (result.reason === 'not-supported') {
+        return reply.code(409).send({
+          error: 'UPDATE_NOT_SUPPORTED',
+          message:
+            'This deployment cannot update itself. Update manually with: ' +
+            'npm install -g @openaidy/app@latest && openaidy restart',
+        });
+      }
+      return reply.code(409).send({
+        error: 'UPDATE_IN_PROGRESS',
+        message: 'An update is already in progress.',
+      });
+    }
+
+    return reply.code(202).send(result.state);
+  });
+};

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -20,3 +20,25 @@ try {
   logger.error('Server failed to start', error);
   process.exit(1);
 }
+
+// Graceful shutdown. The CLI (`openaidy stop` / `openaidy restart`) sends
+// SIGTERM to this process; the self-update flow hands off to a detached
+// `openaidy restart` which does the same. Close Fastify (runs onClose hooks:
+// scheduler stop, DB close, WAL checkpoint) so we don't drop in-flight work or
+// leave a half-flushed database behind. Escalation to SIGKILL after 10s is
+// handled by the CLI stop path, so a hung close can't wedge a restart.
+let shuttingDown = false;
+const shutdown = (signal: NodeJS.Signals) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info(`Received ${signal}, shutting down gracefully`);
+  app
+    .close()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('Error during graceful shutdown', error);
+      process.exit(1);
+    });
+};
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/server/src/update/service.test.ts
+++ b/apps/server/src/update/service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createUpdateService, detectSelfUpdatable } from './service';
+
+/**
+ * Build a fake `fetch` that answers the npm registry `/latest` endpoint with
+ * `latest`, and (optionally) the GitHub release endpoint with `notes`.
+ */
+function fakeFetch(opts: {
+  latest?: string;
+  registryOk?: boolean;
+  notes?: string | null;
+}) {
+  const { latest = '0.4.0', registryOk = true, notes = null } = opts;
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('registry.npmjs.org')) {
+      return {
+        ok: registryOk,
+        status: registryOk ? 200 : 503,
+        statusText: registryOk ? 'OK' : 'Service Unavailable',
+        json: async () => ({ version: latest }),
+      } as Response;
+    }
+    if (url.includes('api.github.com')) {
+      return {
+        ok: notes != null,
+        status: notes != null ? 200 : 404,
+        statusText: notes != null ? 'OK' : 'Not Found',
+        json: async () => ({ body: notes }),
+      } as Response;
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+/** A promise whose resolve/reject can be triggered from the test. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe('UpdateService.check', () => {
+  it('reports an update when the registry has a newer version', async () => {
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: true,
+      fetchFn: fakeFetch({ latest: '0.4.0' }),
+    });
+    const result = await svc.check();
+    expect(result.currentVersion).toBe('0.3.8');
+    expect(result.latestVersion).toBe('0.4.0');
+    expect(result.updateAvailable).toBe(true);
+    expect(result.canSelfUpdate).toBe(true);
+  });
+
+  it('reports no update when already on the latest version', async () => {
+    const svc = createUpdateService({
+      currentVersion: '0.4.0',
+      fetchFn: fakeFetch({ latest: '0.4.0' }),
+    });
+    const result = await svc.check();
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  it('includes best-effort release notes when GitHub has them', async () => {
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      fetchFn: fakeFetch({
+        latest: '0.4.0',
+        notes: 'Bug fixes and improvements',
+      }),
+    });
+    const result = await svc.check();
+    expect(result.releaseNotes).toBe('Bug fixes and improvements');
+  });
+
+  it('omits release notes when GitHub has none (does not throw)', async () => {
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      fetchFn: fakeFetch({ latest: '0.4.0', notes: null }),
+    });
+    const result = await svc.check();
+    expect(result.releaseNotes).toBeUndefined();
+  });
+
+  it('throws when the registry request fails', async () => {
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      fetchFn: fakeFetch({ registryOk: false }),
+    });
+    await expect(svc.check()).rejects.toThrow(/registry responded 503/);
+  });
+});
+
+describe('UpdateService.startUpdate', () => {
+  it('refuses when the deployment cannot self-update', () => {
+    const install = vi.fn();
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: false,
+      installFn: install,
+      restartFn: vi.fn(),
+    });
+    const result = svc.startUpdate('0.4.0');
+    expect(result).toEqual({ ok: false, reason: 'not-supported' });
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('installs then restarts on success', async () => {
+    const install = vi.fn().mockResolvedValue(undefined);
+    const restart = vi.fn();
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: true,
+      installFn: install,
+      restartFn: restart,
+    });
+
+    const result = svc.startUpdate('0.4.0');
+    expect(result.ok).toBe(true);
+    // Immediately after triggering, state is 'installing'.
+    expect(svc.getState().status).toBe('installing');
+
+    await flush();
+
+    expect(install).toHaveBeenCalledWith('@openaidy/app', '0.4.0');
+    expect(restart).toHaveBeenCalledOnce();
+    expect(svc.getState().status).toBe('restarting');
+    expect(svc.getState().newVersion).toBe('0.4.0');
+  });
+
+  it('reports an error and does not restart when install fails', async () => {
+    const install = vi.fn().mockRejectedValue(new Error('EACCES'));
+    const restart = vi.fn();
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: true,
+      installFn: install,
+      restartFn: restart,
+    });
+
+    svc.startUpdate('0.4.0');
+    await flush();
+
+    expect(restart).not.toHaveBeenCalled();
+    const state = svc.getState();
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('EACCES');
+  });
+
+  it('rejects a second update while one is in progress', async () => {
+    const gate = deferred<void>();
+    const install = vi.fn().mockReturnValue(gate.promise);
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: true,
+      installFn: install,
+      restartFn: vi.fn(),
+    });
+
+    const first = svc.startUpdate('0.4.0');
+    expect(first.ok).toBe(true);
+    const second = svc.startUpdate('0.4.0');
+    expect(second).toEqual({ ok: false, reason: 'in-progress' });
+
+    gate.resolve();
+    await flush();
+    expect(install).toHaveBeenCalledOnce();
+  });
+});
+
+describe('detectSelfUpdatable', () => {
+  it('is false for the monorepo (dev) — name is not @openaidy/app', () => {
+    // Walking up from this test file lands on the repo-root package.json,
+    // whose name is "openaidy", not the published "@openaidy/app".
+    expect(detectSelfUpdatable('@openaidy/app')).toBe(false);
+  });
+});

--- a/apps/server/src/update/service.test.ts
+++ b/apps/server/src/update/service.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
-import { createUpdateService, detectSelfUpdatable } from './service';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+const spawnMock = vi.fn();
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
+const {
+  createUpdateService,
+  detectSelfUpdatable,
+  defaultInstall,
+  defaultRestart,
+} = await import('./service');
+
+/** A fake ChildProcess: an EventEmitter with the bits defaultInstall/defaultRestart touch. */
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & { unref: () => void };
+  child.unref = vi.fn();
+  return child;
+}
 
 /**
  * Build a fake `fetch` that answers the npm registry `/latest` endpoint with
@@ -155,6 +172,27 @@ describe('UpdateService.startUpdate', () => {
     expect(state.error).toContain('EACCES');
   });
 
+  it('reports an error when the restart hand-off throws', async () => {
+    const install = vi.fn().mockResolvedValue(undefined);
+    const restart = vi.fn().mockImplementation(() => {
+      throw new Error('spawn openaidy ENOENT');
+    });
+    const svc = createUpdateService({
+      currentVersion: '0.3.8',
+      canSelfUpdate: true,
+      installFn: install,
+      restartFn: restart,
+    });
+
+    svc.startUpdate('0.4.0');
+    await flush();
+
+    expect(restart).toHaveBeenCalledOnce();
+    const state = svc.getState();
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('ENOENT');
+  });
+
   it('rejects a second update while one is in progress', async () => {
     const gate = deferred<void>();
     const install = vi.fn().mockReturnValue(gate.promise);
@@ -181,5 +219,47 @@ describe('detectSelfUpdatable', () => {
     // Walking up from this test file lands on the repo-root package.json,
     // whose name is "openaidy", not the published "@openaidy/app".
     expect(detectSelfUpdatable('@openaidy/app')).toBe(false);
+  });
+});
+
+describe('defaultInstall / defaultRestart (real spawn wiring)', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('passes the version as a single argv element, never shell-concatenated', async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const install = defaultInstall('@openaidy/app', '1.2.3');
+    const [cmd, args, opts] = spawnMock.mock.calls[0]!;
+    expect(cmd).toBe('npm');
+    // The version reaches spawn as one argv element — no shell string is built
+    // out of it, so it can't be split into extra shell tokens even if malformed.
+    expect(args).toEqual(['install', '-g', '@openaidy/app@1.2.3']);
+    expect((opts as { shell?: boolean }).shell).toBe(false);
+
+    child.emit('exit', 0);
+    await expect(install).resolves.toBeUndefined();
+  });
+
+  it('defaultInstall rejects (not throws) on a spawn error event', async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const install = defaultInstall('@openaidy/app', '1.2.3');
+    child.emit('error', new Error('ENOENT'));
+    await expect(install).rejects.toThrow('ENOENT');
+  });
+
+  it('defaultRestart does not throw when the spawned process errors', () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    // Before the fix, an unhandled 'error' event on a fire-and-forget spawn
+    // crashes the process with an uncaught exception — assert it no longer does.
+    expect(() => defaultRestart()).not.toThrow();
+    expect(() => child.emit('error', new Error('ENOENT'))).not.toThrow();
+    expect(child.unref).toHaveBeenCalled();
   });
 });

--- a/apps/server/src/update/service.ts
+++ b/apps/server/src/update/service.ts
@@ -1,0 +1,284 @@
+/**
+ * Self-update service (issue #456).
+ *
+ * Responsibilities:
+ *  - `check()`   — ask the npm registry for the latest published version and
+ *                  compare it with the running version.
+ *  - `startUpdate()` — for a packaged global install only: run
+ *                  `npm install -g @openaidy/app@latest`, then hand off to a
+ *                  detached `openaidy restart` so the new bytes are loaded by a
+ *                  fresh process. Progress is tracked in-memory and surfaced
+ *                  via `getState()`.
+ *
+ * The dangerous side effects (spawning npm, spawning the CLI) are injected as
+ * `installFn` / `restartFn` so tests exercise the state machine without ever
+ * touching the real system. `fetchFn` is likewise injectable for the registry.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import semver from 'semver';
+import type { UpdateCheckResult, UpdateState } from '@openaidy/shared-types';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('update');
+
+/** Published package name (see scripts/build-npm-package.mjs). */
+export const DEFAULT_PACKAGE_NAME = '@openaidy/app';
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+const DEFAULT_GITHUB_REPO = 'imzodev/openaidy';
+/** Cap release notes so a huge changelog can't bloat the check response. */
+const RELEASE_NOTES_MAX = 1000;
+
+type FetchFn = typeof fetch;
+/** Runs the install; must reject if the install fails. */
+export type InstallFn = (packageName: string, version: string) => Promise<void>;
+/** Hands off to a fresh process; the current process is expected to go down. */
+export type RestartFn = () => void;
+
+export interface UpdateServiceOptions {
+  /** Currently-running version (semver, no `v` prefix). */
+  currentVersion: string;
+  packageName?: string;
+  registryUrl?: string;
+  /** `owner/repo` used for best-effort release-notes lookup. */
+  githubRepo?: string;
+  /**
+   * Whether this deployment can self-update. Defaults to auto-detection
+   * (true only for a packaged `@openaidy/app` global install).
+   */
+  canSelfUpdate?: boolean;
+  fetchFn?: FetchFn;
+  installFn?: InstallFn;
+  restartFn?: RestartFn;
+}
+
+/**
+ * Walk up from a starting directory to the nearest package.json and report
+ * whether it is the published `@openaidy/app` package. A from-source / dev run
+ * resolves to the monorepo root (name `openaidy`), which cannot self-update.
+ */
+export function detectSelfUpdatable(
+  packageName: string,
+  startDir?: string,
+): boolean {
+  const here = startDir ?? dirname(fileURLToPath(import.meta.url));
+  for (let dir = here; dirname(dir) !== dir; dir = dirname(dir)) {
+    const candidate = resolve(dir, 'package.json');
+    if (!existsSync(candidate)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as {
+        name?: unknown;
+      };
+      if (typeof pkg.name === 'string' && pkg.name) {
+        return pkg.name === packageName;
+      }
+    } catch {
+      // malformed package.json — keep walking
+    }
+  }
+  return false;
+}
+
+/** Default install: `npm install -g <pkg>@<version>`, rejecting on non-zero exit. */
+const defaultInstall: InstallFn = (packageName, version) =>
+  new Promise<void>((resolvePromise, reject) => {
+    const child = spawn('npm', ['install', '-g', `${packageName}@${version}`], {
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`npm install exited with code ${code ?? 'null'}`));
+    });
+  });
+
+/** Default restart: detached `openaidy restart` that outlives this process. */
+const defaultRestart: RestartFn = () => {
+  const child = spawn('openaidy', ['restart'], {
+    detached: true,
+    stdio: 'ignore',
+    shell: process.platform === 'win32',
+  });
+  child.unref();
+};
+
+export class UpdateService {
+  private readonly currentVersion: string;
+  private readonly packageName: string;
+  private readonly registryUrl: string;
+  private readonly githubRepo: string;
+  private readonly canSelfUpdate: boolean;
+  private readonly fetchFn: FetchFn;
+  private readonly installFn: InstallFn;
+  private readonly restartFn: RestartFn;
+
+  private state: UpdateState = { status: 'idle' };
+
+  constructor(opts: UpdateServiceOptions) {
+    this.currentVersion = opts.currentVersion;
+    this.packageName = opts.packageName ?? DEFAULT_PACKAGE_NAME;
+    this.registryUrl = opts.registryUrl ?? DEFAULT_REGISTRY;
+    this.githubRepo = opts.githubRepo ?? DEFAULT_GITHUB_REPO;
+    this.canSelfUpdate =
+      opts.canSelfUpdate ?? detectSelfUpdatable(this.packageName);
+    // Defer to the global `fetch` at call time (not construction time) so a
+    // test that spies on `globalThis.fetch` after the service is built is still
+    // honoured.
+    this.fetchFn =
+      opts.fetchFn ?? ((input, init) => fetch(input, init as RequestInit));
+    this.installFn = opts.installFn ?? defaultInstall;
+    this.restartFn = opts.restartFn ?? defaultRestart;
+  }
+
+  getState(): UpdateState {
+    return { ...this.state };
+  }
+
+  /**
+   * Query the npm registry for the latest version and compare it with the
+   * running one. Throws on a network/registry failure so the route can map it
+   * to a 502 ("Unable to check for updates").
+   */
+  async check(): Promise<UpdateCheckResult> {
+    const url = `${this.registryUrl}/${encodeURIComponent(this.packageName)}/latest`;
+    const response = await this.fetchFn(url);
+    if (!response.ok) {
+      throw new Error(
+        `npm registry responded ${response.status} ${response.statusText}`,
+      );
+    }
+    const body = (await response.json()) as { version?: unknown };
+    const latestVersion =
+      typeof body.version === 'string' ? body.version : undefined;
+    if (!latestVersion || !semver.valid(latestVersion)) {
+      throw new Error('npm registry returned no valid version');
+    }
+
+    const updateAvailable =
+      semver.valid(this.currentVersion) != null &&
+      semver.gt(latestVersion, this.currentVersion);
+
+    const result: UpdateCheckResult = {
+      currentVersion: this.currentVersion,
+      latestVersion,
+      updateAvailable,
+      canSelfUpdate: this.canSelfUpdate,
+    };
+
+    if (updateAvailable) {
+      const releaseNotes = await this.fetchReleaseNotes(latestVersion);
+      if (releaseNotes) result.releaseNotes = releaseNotes;
+    }
+
+    return result;
+  }
+
+  /** Best-effort release-notes body from the GitHub release for `v<version>`. */
+  private async fetchReleaseNotes(
+    version: string,
+  ): Promise<string | undefined> {
+    try {
+      const url = `https://api.github.com/repos/${this.githubRepo}/releases/tags/v${version}`;
+      const response = await this.fetchFn(url, {
+        headers: { Accept: 'application/vnd.github+json' },
+      });
+      if (!response.ok) return undefined;
+      const body = (await response.json()) as { body?: unknown };
+      if (typeof body.body !== 'string' || !body.body.trim()) return undefined;
+      const notes = body.body.trim();
+      return notes.length > RELEASE_NOTES_MAX
+        ? `${notes.slice(0, RELEASE_NOTES_MAX)}…`
+        : notes;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Trigger a self-update. Returns a discriminated result the route maps to an
+   * HTTP status:
+   *  - `not-supported` → 409 (dev / from-source install can't self-update)
+   *  - `in-progress`   → 409 (an update is already running)
+   *  - `ok`            → 202 (install kicked off; server will restart)
+   *
+   * The install + restart run in the background so the request returns before
+   * the process goes down.
+   */
+  startUpdate(
+    targetVersion: string,
+  ):
+    | { ok: true; state: UpdateState }
+    | { ok: false; reason: 'not-supported' | 'in-progress' } {
+    if (!this.canSelfUpdate) {
+      return { ok: false, reason: 'not-supported' };
+    }
+    if (
+      this.state.status === 'installing' ||
+      this.state.status === 'restarting'
+    ) {
+      return { ok: false, reason: 'in-progress' };
+    }
+
+    this.state = {
+      status: 'installing',
+      newVersion: targetVersion,
+      message: `Installing ${this.packageName}@${targetVersion}…`,
+    };
+
+    // Fire-and-forget: the endpoint responds immediately; the client observes
+    // completion by the server restarting on the new version.
+    void this.runUpdate(targetVersion);
+
+    return { ok: true, state: this.getState() };
+  }
+
+  private async runUpdate(targetVersion: string): Promise<void> {
+    logger.info('Starting self-update', {
+      from: this.currentVersion,
+      to: targetVersion,
+    });
+    try {
+      await this.installFn(this.packageName, targetVersion);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Self-update install failed', { error: message });
+      this.state = {
+        status: 'error',
+        newVersion: targetVersion,
+        error: message,
+        message: 'Update failed; the server is still running the old version.',
+      };
+      return;
+    }
+
+    logger.info('Install complete; handing off to restart', {
+      version: targetVersion,
+    });
+    this.state = {
+      status: 'restarting',
+      newVersion: targetVersion,
+      message: 'Update installed; restarting the server…',
+    };
+    try {
+      this.restartFn();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Self-update restart hand-off failed', { error: message });
+      this.state = {
+        status: 'error',
+        newVersion: targetVersion,
+        error: message,
+        message:
+          'Update installed but the restart failed. Restart the server manually.',
+      };
+    }
+  }
+}
+
+export function createUpdateService(opts: UpdateServiceOptions): UpdateService {
+  return new UpdateService(opts);
+}

--- a/apps/server/src/update/service.ts
+++ b/apps/server/src/update/service.ts
@@ -83,7 +83,7 @@ export function detectSelfUpdatable(
 }
 
 /** Default install: `npm install -g <pkg>@<version>`, rejecting on non-zero exit. */
-const defaultInstall: InstallFn = (packageName, version) =>
+export const defaultInstall: InstallFn = (packageName, version) =>
   new Promise<void>((resolvePromise, reject) => {
     const child = spawn('npm', ['install', '-g', `${packageName}@${version}`], {
       stdio: 'ignore',
@@ -97,11 +97,17 @@ const defaultInstall: InstallFn = (packageName, version) =>
   });
 
 /** Default restart: detached `openaidy restart` that outlives this process. */
-const defaultRestart: RestartFn = () => {
+export const defaultRestart: RestartFn = () => {
   const child = spawn('openaidy', ['restart'], {
     detached: true,
     stdio: 'ignore',
     shell: process.platform === 'win32',
+  });
+  // spawn() errors (e.g. ENOENT if `openaidy` isn't on PATH) arrive as an async
+  // 'error' event; without a listener Node throws an uncaught exception that
+  // would crash this process right after it committed to restarting.
+  child.on('error', (err) => {
+    logger.error('Failed to spawn restart process', { error: err.message });
   });
   child.unref();
 };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -53,6 +53,7 @@ import {
   uploadAttachment,
   getConfig,
   getUsageBySession,
+  checkForUpdates,
   type AddonRecord,
 } from './lib/api';
 import { ProviderOnboarding } from './components/onboarding/ProviderOnboarding';
@@ -70,6 +71,7 @@ import {
   recordRecentSession,
   recordRecentAgent,
 } from './stores/recent-items';
+import { initUpdateNotice, recordUpdateCheck } from './stores/update-notice';
 import './index.css';
 
 // Create a client
@@ -90,6 +92,16 @@ function AppContent(props: AppContentProps) {
   // Load recent-items once on mount so the command palette can render
   // persisted recents before the user types anything.
   initRecentItems();
+
+  // Hydrate the dismissed-update marker, then run a best-effort update check so
+  // the Settings sidebar badge can show without the user opening Settings.
+  // Fails silently offline or for non-admin tokens (the check is admin-scoped).
+  initUpdateNotice();
+  void checkForUpdates()
+    .then(recordUpdateCheck)
+    .catch(() => {
+      /* offline / non-admin — no badge */
+    });
 
   // Use the router hook
   const { currentView, currentAddonId, navigate, navigateToAddon } =

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-solid';
 import { ThemeToggle } from './ThemeToggle';
 import type { Session, AddonRecord } from '../lib/api';
+import { updateBadgeVisible } from '../stores/update-notice';
 
 export type ViewType =
   | 'chat'
@@ -334,9 +335,25 @@ export function Sidebar(props: SidebarProps) {
               }`}
               title="Settings"
             >
-              <Settings class="w-5 h-5 flex-shrink-0" />
+              <span class="relative flex-shrink-0">
+                <Settings class="w-5 h-5" />
+                {/* Update-available indicator (issue #456). Shown in both
+                    collapsed and expanded states so the nudge isn't lost when
+                    the sidebar is narrow. */}
+                <Show when={updateBadgeVisible()}>
+                  <span
+                    class="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-primary ring-2 ring-white dark:ring-gray-800"
+                    aria-label="Update available"
+                  />
+                </Show>
+              </span>
               <Show when={!props.isCollapsed}>
-                <span>Settings</span>
+                <span class="flex-1 text-left">Settings</span>
+              </Show>
+              <Show when={!props.isCollapsed && updateBadgeVisible()}>
+                <span class="text-[10px] font-semibold uppercase tracking-wide text-primary">
+                  Update
+                </span>
               </Show>
             </button>
           </div>

--- a/apps/web/src/components/settings/tabs/AboutTab.test.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.test.tsx
@@ -8,9 +8,22 @@ import {
 } from '@solidjs/testing-library';
 import { AboutTab } from './AboutTab';
 import * as api from '../../../lib/api';
+import { resetUpdateNotice } from '../../../stores/update-notice';
 
 vi.mock('../../../lib/api', () => ({
   fetchAppInfo: vi.fn(),
+  checkForUpdates: vi.fn(),
+  triggerUpdate: vi.fn(),
+  // Minimal stand-in for the real error class so `instanceof` checks work.
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    body: { error: string; message?: string };
+    constructor(status: number, body: { error: string; message?: string }) {
+      super(body.message ?? body.error);
+      this.status = status;
+      this.body = body;
+    }
+  },
 }));
 
 const sampleInfo: api.AppInfo = {
@@ -23,9 +36,19 @@ const sampleInfo: api.AppInfo = {
   uptimeMs: 12_345,
 };
 
+const noUpdate: api.UpdateCheckResult = {
+  currentVersion: '0.3.0',
+  latestVersion: '0.3.0',
+  updateAvailable: false,
+  canSelfUpdate: false,
+};
+
 describe('AboutTab', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    resetUpdateNotice();
+    // Default: no update available. Individual tests override as needed.
+    vi.mocked(api.checkForUpdates).mockResolvedValue(noUpdate);
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
@@ -104,5 +127,59 @@ describe('AboutTab', () => {
     expect(api.fetchAppInfo).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
     await waitFor(() => expect(api.fetchAppInfo).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an "Update to vX" button and triggers the update when confirmed', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    vi.mocked(api.checkForUpdates).mockResolvedValue({
+      currentVersion: '0.3.0',
+      latestVersion: '0.4.0',
+      updateAvailable: true,
+      canSelfUpdate: true,
+      releaseNotes: 'Bug fixes and improvements',
+    });
+    vi.mocked(api.triggerUpdate).mockResolvedValue({
+      status: 'installing',
+      newVersion: '0.4.0',
+    });
+
+    render(() => <AboutTab />);
+    const updateBtn = await screen.findByRole('button', {
+      name: /update to v0\.4\.0/i,
+    });
+    fireEvent.click(updateBtn);
+
+    // Confirm dialog opens with a restart warning; confirm it.
+    const confirmBtn = await screen.findByRole('button', {
+      name: /update & restart/i,
+    });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(api.triggerUpdate).toHaveBeenCalledOnce());
+    expect(
+      await screen.findByText(/the server is installing the new version/i),
+    ).toBeInTheDocument();
+  });
+
+  it('guides a manual update when the install cannot self-update', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    vi.mocked(api.checkForUpdates).mockResolvedValue({
+      currentVersion: '0.3.0',
+      latestVersion: '0.4.0',
+      updateAvailable: true,
+      canSelfUpdate: false,
+    });
+
+    render(() => <AboutTab />);
+    await waitFor(() =>
+      expect(screen.getAllByText('v0.3.0').length).toBeGreaterThan(0),
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /update to v0\.4\.0/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/npm install -g @openaidy\/app@latest/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/tabs/AboutTab.test.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../../lib/api', () => ({
   fetchAppInfo: vi.fn(),
   checkForUpdates: vi.fn(),
   triggerUpdate: vi.fn(),
+  fetchUpdateStatus: vi.fn(),
   // Minimal stand-in for the real error class so `instanceof` checks work.
   ApiRequestError: class ApiRequestError extends Error {
     status: number;
@@ -49,13 +50,20 @@ describe('AboutTab', () => {
     resetUpdateNotice();
     // Default: no update available. Individual tests override as needed.
     vi.mocked(api.checkForUpdates).mockResolvedValue(noUpdate);
+    // Default: a status poll (if any test's timer fires) finds a fresh, idle
+    // process — harmless unless a test overrides it to assert poll behavior.
+    vi.mocked(api.fetchUpdateStatus).mockResolvedValue({ status: 'idle' });
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    // jsdom doesn't implement navigation; stub reload so the polling loop
+    // (real setTimeout-based) never throws if it fires during a test.
+    vi.stubGlobal('location', { ...window.location, reload: vi.fn() });
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
   });
 
   it('renders the version with the "v" prefix once info loads', async () => {
@@ -160,6 +168,79 @@ describe('AboutTab', () => {
       await screen.findByText(/the server is installing the new version/i),
     ).toBeInTheDocument();
   });
+
+  it('reloads once /update/status is answered by a fresh (idle) process', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    vi.mocked(api.checkForUpdates).mockResolvedValue({
+      currentVersion: '0.3.0',
+      latestVersion: '0.4.0',
+      updateAvailable: true,
+      canSelfUpdate: true,
+    });
+    vi.mocked(api.triggerUpdate).mockResolvedValue({
+      status: 'installing',
+      newVersion: '0.4.0',
+    });
+    // First poll still hits the old (installing) process; second poll finds
+    // a fresh one with no memory of the update — that's the "done" signal.
+    vi.mocked(api.fetchUpdateStatus)
+      .mockResolvedValueOnce({ status: 'installing', newVersion: '0.4.0' })
+      .mockResolvedValueOnce({ status: 'idle' });
+    const reloadSpy = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload: reloadSpy });
+
+    render(() => <AboutTab />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /update to v0\.4\.0/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: /update & restart/i }),
+    );
+    await waitFor(() => expect(api.triggerUpdate).toHaveBeenCalledOnce());
+
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled(), {
+      timeout: 6_000,
+    });
+    expect(api.fetchUpdateStatus).toHaveBeenCalledTimes(2);
+  }, 8_000);
+
+  it('surfaces a server-reported error instead of reloading onto the old version', async () => {
+    vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);
+    vi.mocked(api.checkForUpdates).mockResolvedValue({
+      currentVersion: '0.3.0',
+      latestVersion: '0.4.0',
+      updateAvailable: true,
+      canSelfUpdate: true,
+    });
+    vi.mocked(api.triggerUpdate).mockResolvedValue({
+      status: 'installing',
+      newVersion: '0.4.0',
+    });
+    vi.mocked(api.fetchUpdateStatus).mockResolvedValue({
+      status: 'error',
+      newVersion: '0.4.0',
+      error: 'EACCES',
+      message: 'Update failed; the server is still running the old version.',
+    });
+    const reloadSpy = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload: reloadSpy });
+
+    render(() => <AboutTab />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /update to v0\.4\.0/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: /update & restart/i }),
+    );
+    await waitFor(() => expect(api.triggerUpdate).toHaveBeenCalledOnce());
+
+    expect(
+      await screen.findByText(/still running the old version/i, undefined, {
+        timeout: 4_000,
+      }),
+    ).toBeInTheDocument();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  }, 6_000);
 
   it('guides a manual update when the install cannot self-update', async () => {
     vi.mocked(api.fetchAppInfo).mockResolvedValue(sampleInfo);

--- a/apps/web/src/components/settings/tabs/AboutTab.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.tsx
@@ -4,6 +4,7 @@ import {
   fetchAppInfo,
   checkForUpdates,
   triggerUpdate,
+  fetchUpdateStatus,
   ApiRequestError,
   type AppInfo,
 } from '../../../lib/api';
@@ -17,8 +18,10 @@ import {
 
 const RELEASES_URL = 'https://github.com/imzodev/openaidy/releases';
 
-/** Seconds to wait for the server to come back after a self-update, then reload. */
-const RELOAD_AFTER_UPDATE_MS = 15_000;
+/** How often to poll /update/status while waiting for the server to restart. */
+const POLL_INTERVAL_MS = 2_000;
+/** Give up and ask the user to refresh manually after this many failed polls (~2 min). */
+const MAX_POLL_ATTEMPTS = 60;
 
 /**
  * Format an uptime duration (ms) as a compact human string.
@@ -102,9 +105,7 @@ export function AboutTab() {
         type: 'success',
         text: 'Updating… the server is installing the new version and will restart. This page will reload automatically.',
       });
-      // Give the server time to install + restart, then reload to pick up the
-      // new bundle. If it isn't back yet the reload simply retries the load.
-      setTimeout(() => window.location.reload(), RELOAD_AFTER_UPDATE_MS);
+      void pollForRestart();
     } catch (err) {
       setUpdateInProgress(false);
       setConfirmOpen(false);
@@ -113,6 +114,46 @@ export function AboutTab() {
           ? (err.body?.message ?? err.body?.error ?? 'Update failed.')
           : 'Update failed. The server may be unreachable.';
       setMessage({ type: 'error', text });
+    }
+  };
+
+  /**
+   * Poll /update/status until the server comes back on the new version. A
+   * network failure means the old process is mid-restart (expected — keep
+   * waiting). A reachable 'installing'/'restarting' state means the old
+   * process is still up (keep waiting). A reachable 'error' means the install
+   * or restart failed before the process went down — surface it rather than
+   * reloading onto the still-running old version. Anything else reachable
+   * (i.e. 'idle') means a fresh process answered, since its in-memory state
+   * resets on boot — safe to reload.
+   */
+  const pollForRestart = async (attempt = 0): Promise<void> => {
+    if (attempt >= MAX_POLL_ATTEMPTS) {
+      setUpdateInProgress(false);
+      setMessage({
+        type: 'error',
+        text: 'The server did not come back after the update. Refresh the page manually, or check the server logs.',
+      });
+      return;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    try {
+      const status = await fetchUpdateStatus();
+      if (status.status === 'error') {
+        setUpdateInProgress(false);
+        setMessage({
+          type: 'error',
+          text: status.message ?? status.error ?? 'Update failed.',
+        });
+        return;
+      }
+      if (status.status === 'installing' || status.status === 'restarting') {
+        void pollForRestart(attempt + 1);
+        return;
+      }
+      window.location.reload();
+    } catch {
+      void pollForRestart(attempt + 1);
     }
   };
 

--- a/apps/web/src/components/settings/tabs/AboutTab.tsx
+++ b/apps/web/src/components/settings/tabs/AboutTab.tsx
@@ -1,8 +1,24 @@
-import { createResource, createSignal, Show } from 'solid-js';
-import { Copy, RefreshCw } from 'lucide-solid';
-import { fetchAppInfo, type AppInfo } from '../../../lib/api';
+import { createResource, createSignal, createEffect, Show } from 'solid-js';
+import { Copy, RefreshCw, ArrowUpCircle } from 'lucide-solid';
+import {
+  fetchAppInfo,
+  checkForUpdates,
+  triggerUpdate,
+  ApiRequestError,
+  type AppInfo,
+} from '../../../lib/api';
+import { ConfirmDialog, SaveMessage, type SaveMessageType } from '../../ui';
+import {
+  recordUpdateCheck,
+  dismissUpdate,
+  setUpdateInProgress,
+  updateInProgress,
+} from '../../../stores/update-notice';
 
 const RELEASES_URL = 'https://github.com/imzodev/openaidy/releases';
+
+/** Seconds to wait for the server to come back after a self-update, then reload. */
+const RELOAD_AFTER_UPDATE_MS = 15_000;
 
 /**
  * Format an uptime duration (ms) as a compact human string.
@@ -33,7 +49,18 @@ function buildDebugBlock(info: AppInfo): string {
 
 export function AboutTab() {
   const [info, { refetch }] = createResource(fetchAppInfo);
+  // Update check is admin-scoped and may fail (offline, non-admin). Keep it
+  // separate from `info` so a check failure never hides the version panel.
+  const [update, { refetch: refetchUpdate }] = createResource(checkForUpdates);
   const [copied, setCopied] = createSignal(false);
+  const [confirmOpen, setConfirmOpen] = createSignal(false);
+  const [message, setMessage] = createSignal<SaveMessageType>(null);
+
+  // Feed the sidebar badge whenever a fresh check resolves.
+  createEffect(() => {
+    const result = update();
+    if (result) recordUpdateCheck(result);
+  });
 
   const handleCopy = async () => {
     const value = info();
@@ -62,6 +89,33 @@ export function AboutTab() {
     }
   };
 
+  const handleConfirmUpdate = async () => {
+    setMessage(null);
+    setUpdateInProgress(true);
+    try {
+      await triggerUpdate();
+      // The server is now installing + restarting. Dismiss the badge (the
+      // user acted on it) and tell them the page will reconnect on its own.
+      dismissUpdate();
+      setConfirmOpen(false);
+      setMessage({
+        type: 'success',
+        text: 'Updating… the server is installing the new version and will restart. This page will reload automatically.',
+      });
+      // Give the server time to install + restart, then reload to pick up the
+      // new bundle. If it isn't back yet the reload simply retries the load.
+      setTimeout(() => window.location.reload(), RELOAD_AFTER_UPDATE_MS);
+    } catch (err) {
+      setUpdateInProgress(false);
+      setConfirmOpen(false);
+      const text =
+        err instanceof ApiRequestError
+          ? (err.body?.message ?? err.body?.error ?? 'Update failed.')
+          : 'Update failed. The server may be unreachable.';
+      setMessage({ type: 'error', text });
+    }
+  };
+
   return (
     <div class="p-6 max-w-2xl">
       <h2 class="text-lg font-semibold text-text-primary mb-1">
@@ -70,6 +124,8 @@ export function AboutTab() {
       <p class="text-sm text-text-tertiary mb-6">
         Build and runtime information for this OpenAidy instance.
       </p>
+
+      <SaveMessage message={message} />
 
       <Show when={info.loading}>
         <div class="text-text-tertiary">Loading version info…</div>
@@ -101,8 +157,27 @@ export function AboutTab() {
               <div class="text-xs uppercase tracking-wide text-text-tertiary mb-1">
                 Version
               </div>
-              <div class="font-mono text-3xl font-semibold text-text-primary">
-                v{data().version}
+              <div class="flex items-center gap-3 flex-wrap">
+                <div class="font-mono text-3xl font-semibold text-text-primary">
+                  v{data().version}
+                </div>
+                {/* Update-to button — only when a newer version exists AND this
+                    deployment can update itself (packaged global install). */}
+                <Show
+                  when={update()?.updateAvailable && update()?.canSelfUpdate}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setConfirmOpen(true)}
+                    disabled={updateInProgress()}
+                    class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary hover:bg-primary-hover text-white text-sm disabled:opacity-50"
+                  >
+                    <ArrowUpCircle class="w-4 h-4" />
+                    {updateInProgress()
+                      ? 'Updating…'
+                      : `Update to v${update()!.latestVersion}`}
+                  </button>
+                </Show>
               </div>
               <a
                 href={`${RELEASES_URL}/tag/v${data().version}`}
@@ -112,6 +187,36 @@ export function AboutTab() {
               >
                 View release on GitHub →
               </a>
+
+              {/* Let the user dismiss the sidebar update badge without updating
+                  (issue #456: badge persists "until dismissed or updated"). */}
+              <Show when={update()?.updateAvailable}>
+                <button
+                  type="button"
+                  onClick={() => dismissUpdate()}
+                  class="inline-block mt-2 ml-4 text-xs text-text-tertiary hover:text-text-secondary hover:underline"
+                >
+                  Dismiss update notice
+                </button>
+              </Show>
+
+              {/* Update available but this install can't self-update (dev /
+                  from-source) — guide the user to update manually. */}
+              <Show
+                when={update()?.updateAvailable && !update()?.canSelfUpdate}
+              >
+                <div class="mt-3 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3 text-sm text-text-secondary">
+                  <div class="mb-1">
+                    <span class="font-medium text-text-primary">
+                      v{update()!.latestVersion}
+                    </span>{' '}
+                    is available. This install can't update itself — run:
+                  </div>
+                  <code class="block font-mono text-xs bg-gray-100 dark:bg-gray-900 rounded px-2 py-1 overflow-x-auto">
+                    npm install -g @openaidy/app@latest && openaidy restart
+                  </code>
+                </div>
+              </Show>
             </div>
 
             <dl class="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 text-sm mb-6">
@@ -148,7 +253,10 @@ export function AboutTab() {
               </button>
               <button
                 type="button"
-                onClick={() => refetch()}
+                onClick={() => {
+                  refetch();
+                  refetchUpdate();
+                }}
                 class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 text-text-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-sm"
               >
                 <RefreshCw class="w-3.5 h-3.5" />
@@ -163,6 +271,36 @@ export function AboutTab() {
               release tag (e.g. <span class="font-mono">v{data().version}</span>
               ).
             </p>
+
+            <ConfirmDialog
+              isOpen={confirmOpen()}
+              title="Update OpenAidy?"
+              confirmLabel="Update & restart"
+              cancelLabel="Cancel"
+              isPending={updateInProgress()}
+              onConfirm={handleConfirmUpdate}
+              onCancel={() => setConfirmOpen(false)}
+              body={
+                <div class="space-y-3">
+                  <p class="text-text-secondary">
+                    Update from <span class="font-mono">v{data().version}</span>{' '}
+                    to <span class="font-mono">v{update()?.latestVersion}</span>
+                    ? The server will restart and this page will reconnect
+                    automatically. Any in-progress runs will be interrupted.
+                  </p>
+                  <Show when={update()?.releaseNotes}>
+                    <div>
+                      <div class="text-xs uppercase tracking-wide text-text-tertiary mb-1">
+                        Release notes
+                      </div>
+                      <pre class="max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-gray-100 dark:bg-gray-900 p-2 text-xs text-text-secondary">
+                        {update()!.releaseNotes}
+                      </pre>
+                    </div>
+                  </Show>
+                </div>
+              }
+            />
           </>
         )}
       </Show>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1551,3 +1551,19 @@ export async function triggerUpdate(): Promise<UpdateState> {
   }
   return response.json();
 }
+
+/**
+ * Poll the in-memory state of any in-flight update. Callers should expect
+ * this to reject with a network error while the server is mid-restart —
+ * that's the expected signal to keep polling, not a real failure.
+ */
+export async function fetchUpdateStatus(): Promise<UpdateState> {
+  const response = await apiFetch(`${API_BASE}/api/update/status`);
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({
+      error: 'request.failed',
+    }))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,6 +4,7 @@
  */
 
 import { ApiRequestError } from '@openaidy/shared-types';
+import type { UpdateCheckResult, UpdateState } from '@openaidy/shared-types';
 import { getStoredToken } from './auth-token';
 
 export type {
@@ -79,6 +80,7 @@ export type {
 } from './types';
 
 export { ApiRequestError } from '@openaidy/shared-types';
+export type { UpdateCheckResult, UpdateState } from '@openaidy/shared-types';
 
 import type {
   Session,
@@ -1505,6 +1507,47 @@ export async function fetchAppInfo(): Promise<AppInfo> {
   const response = await apiFetch(`${API_BASE}/api/info`);
   if (!response.ok) {
     throw new Error(`Failed to fetch app info: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+// ============================================================================
+// Self-update API Functions (issue #456)
+// ============================================================================
+
+/**
+ * Check the npm registry for a newer version. Throws on network/registry
+ * failure (the server returns 502) so callers can show "Unable to check".
+ * Requires admin scope; a non-admin token yields a 401/403 (also a throw).
+ */
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
+  const response = await apiFetch(`${API_BASE}/api/update/check`);
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({
+      error: 'request.failed',
+    }))) as ApiError;
+    throw new ApiRequestError(response.status, body);
+  }
+  return response.json();
+}
+
+/**
+ * Trigger a self-update (admin-only). The server installs the latest version
+ * and restarts; this resolves with the initial `installing` state (HTTP 202).
+ * Throws `ApiRequestError` on 400/409/502 (e.g. dev install can't self-update,
+ * already up to date, or an update is already running).
+ */
+export async function triggerUpdate(): Promise<UpdateState> {
+  const response = await apiFetch(`${API_BASE}/api/update`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({
+      error: 'request.failed',
+    }))) as ApiError;
+    throw new ApiRequestError(response.status, body);
   }
   return response.json();
 }

--- a/apps/web/src/stores/update-notice.test.ts
+++ b/apps/web/src/stores/update-notice.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { UpdateCheckResult } from '@openaidy/shared-types';
+import {
+  initUpdateNotice,
+  recordUpdateCheck,
+  availableUpdateVersion,
+  updateBadgeVisible,
+  dismissUpdate,
+  updateInProgress,
+  setUpdateInProgress,
+  resetUpdateNotice,
+} from './update-notice';
+
+const STORAGE_KEY = 'openaidy_update_dismissed';
+
+const store = new Map<string, string>();
+const localStorageMock = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+  key: (i: number) => Array.from(store.keys())[i] ?? null,
+  get length() {
+    return store.size;
+  },
+};
+
+function check(
+  updateAvailable: boolean,
+  latestVersion = '0.4.0',
+): UpdateCheckResult {
+  return {
+    currentVersion: '0.3.8',
+    latestVersion,
+    updateAvailable,
+    canSelfUpdate: true,
+  };
+}
+
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal('localStorage', localStorageMock);
+  resetUpdateNotice();
+});
+
+describe('update-notice store', () => {
+  it('starts with no badge and no available version', () => {
+    initUpdateNotice();
+    expect(availableUpdateVersion()).toBeNull();
+    expect(updateBadgeVisible()).toBe(false);
+  });
+
+  it('shows the badge when an update is available', () => {
+    recordUpdateCheck(check(true, '0.4.0'));
+    expect(availableUpdateVersion()).toBe('0.4.0');
+    expect(updateBadgeVisible()).toBe(true);
+  });
+
+  it('hides the badge when already up to date', () => {
+    recordUpdateCheck(check(false));
+    expect(availableUpdateVersion()).toBeNull();
+    expect(updateBadgeVisible()).toBe(false);
+  });
+
+  it('hides the badge for a dismissed version and persists the dismissal', () => {
+    recordUpdateCheck(check(true, '0.4.0'));
+    dismissUpdate();
+    expect(updateBadgeVisible()).toBe(false);
+    expect(store.get(STORAGE_KEY)).toBe('0.4.0');
+  });
+
+  it('re-shows the badge when a newer version than the dismissed one appears', () => {
+    recordUpdateCheck(check(true, '0.4.0'));
+    dismissUpdate();
+    expect(updateBadgeVisible()).toBe(false);
+
+    // A newer release lands — the old dismissal must not suppress it.
+    recordUpdateCheck(check(true, '0.5.0'));
+    expect(updateBadgeVisible()).toBe(true);
+  });
+
+  it('hydrates a persisted dismissal on init', () => {
+    store.set(STORAGE_KEY, '0.4.0');
+    initUpdateNotice();
+    recordUpdateCheck(check(true, '0.4.0'));
+    expect(updateBadgeVisible()).toBe(false);
+  });
+
+  it('tracks in-progress state (in-memory only)', () => {
+    expect(updateInProgress()).toBe(false);
+    setUpdateInProgress(true);
+    expect(updateInProgress()).toBe(true);
+    // Not persisted — nothing written to localStorage.
+    expect(store.has(STORAGE_KEY)).toBe(false);
+  });
+});

--- a/apps/web/src/stores/update-notice.ts
+++ b/apps/web/src/stores/update-notice.ts
@@ -1,0 +1,100 @@
+/**
+ * Update-notice store (issue #456)
+ *
+ * Tracks whether a newer OpenAidy version is available so the Settings sidebar
+ * item can show a badge, and remembers which version the user has dismissed so
+ * the badge doesn't nag after they've acknowledged it.
+ *
+ * Two kinds of state:
+ *  - `dismissedVersion` is persisted to localStorage — a dismissal must survive
+ *    reloads, otherwise the badge reappears on every page load.
+ *  - `availableVersion` and `updateInProgress` are in-memory only. The latest
+ *    version is re-derived from a fresh `/api/update/check` on each boot, and an
+ *    in-progress flag must NOT survive a restart (the server going down IS the
+ *    successful end of an update — a stale `true` would wedge the UI).
+ */
+
+import { createSignal, untrack } from 'solid-js';
+import type { UpdateCheckResult } from '@openaidy/shared-types';
+
+const STORAGE_KEY = 'openaidy_update_dismissed';
+
+function readDismissed(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw && typeof raw === 'string' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeDismissed(version: string | null): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (version) localStorage.setItem(STORAGE_KEY, version);
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage may be full or disabled (private mode); silently ignore.
+  }
+}
+
+const [availableVersion, setAvailableVersion] = createSignal<string | null>(
+  null,
+);
+const [dismissedVersion, setDismissedVersion] = createSignal<string | null>(
+  null,
+);
+const [updateInProgress, setUpdateInProgressInternal] = createSignal(false);
+
+/** Hydrate the dismissed version from localStorage. Call once on app mount. */
+export function initUpdateNotice(): void {
+  setDismissedVersion(readDismissed());
+}
+
+/**
+ * Record the result of an update check. When an update is available the newest
+ * version is remembered (drives the badge); otherwise the badge state clears.
+ */
+export function recordUpdateCheck(result: UpdateCheckResult): void {
+  setAvailableVersion(result.updateAvailable ? result.latestVersion : null);
+}
+
+/** The newest available version, or null when up to date / not yet checked. */
+export function availableUpdateVersion(): string | null {
+  return availableVersion();
+}
+
+/**
+ * Whether the Settings sidebar badge should show: an update is available and
+ * it isn't the version the user already dismissed.
+ */
+export function updateBadgeVisible(): boolean {
+  const available = availableVersion();
+  return available != null && available !== dismissedVersion();
+}
+
+/** Dismiss the badge for the currently-available version (persisted). */
+export function dismissUpdate(): void {
+  untrack(() => {
+    const available = availableVersion();
+    if (!available) return;
+    setDismissedVersion(available);
+    writeDismissed(available);
+  });
+}
+
+/** Whether an update is currently being installed (in-memory only). */
+export { updateInProgress };
+
+export function setUpdateInProgress(value: boolean): void {
+  setUpdateInProgressInternal(value);
+}
+
+/** Test/utility helper: reset all state and clear persistence. */
+export function resetUpdateNotice(): void {
+  setAvailableVersion(null);
+  setDismissedVersion(null);
+  setUpdateInProgressInternal(false);
+  writeDismissed(null);
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -20,3 +20,4 @@ export * from './task-schedules.js';
 export * from './bootstrap-admin.js';
 export * from './model-pricing.js';
 export * from './backups.js';
+export * from './update.js';

--- a/packages/shared-types/src/update.ts
+++ b/packages/shared-types/src/update.ts
@@ -1,0 +1,54 @@
+/**
+ * In-app self-update contract (issue #456).
+ *
+ * The server can update a self-hosted, globally-installed OpenAidy
+ * (`npm i -g @openaidy/app`) from the UI: it queries the npm registry for the
+ * latest version, runs `npm install -g @openaidy/app@latest`, then restarts
+ * itself via the `openaidy` CLI. Types here are the shared server/web contract.
+ */
+
+/**
+ * Lifecycle of an update run, tracked in-memory on the server.
+ *
+ *  - `idle`       — no update in progress (fresh boot / after a completed one).
+ *  - `installing` — `npm install -g @openaidy/app@latest` is running.
+ *  - `restarting` — install succeeded; the server is handing off to a detached
+ *                   `openaidy restart` and is about to go down.
+ *  - `error`      — the install (or restart hand-off) failed; the server stays
+ *                   up on the current version and `error` explains why.
+ *
+ * There is no `complete` state exposed by a live server: a successful update
+ * ends with the process restarting, so the client observes success by the
+ * server coming back on the new version (or the connection dropping then
+ * reconnecting), not by polling for `complete`.
+ */
+export type UpdateStatus = 'idle' | 'installing' | 'restarting' | 'error';
+
+/** Result of `GET /api/update/check`. */
+export interface UpdateCheckResult {
+  /** Currently-running version (semver, no `v` prefix). */
+  currentVersion: string;
+  /** Latest published version from the npm registry (semver, no `v` prefix). */
+  latestVersion: string;
+  /** True when `latestVersion` is strictly newer than `currentVersion`. */
+  updateAvailable: boolean;
+  /**
+   * Whether this deployment can update itself in-place. Only a packaged global
+   * install (`@openaidy/app`) can; a from-source / dev run cannot, and the UI
+   * should guide the user to update manually instead of offering the button.
+   */
+  canSelfUpdate: boolean;
+  /** Best-effort release-notes summary for `latestVersion`; omitted if unavailable. */
+  releaseNotes?: string;
+}
+
+/** In-memory update state, returned by `GET /api/update/status` and `POST /api/update`. */
+export interface UpdateState {
+  status: UpdateStatus;
+  /** Human-readable description of the current step. */
+  message?: string;
+  /** The version being installed (present once an update has been triggered). */
+  newVersion?: string;
+  /** Failure reason; present only when `status === 'error'`. */
+  error?: string;
+}


### PR DESCRIPTION
Closes #456.

Adds an admin-only in-app self-update flow so self-hosted users can update from the UI instead of SSHing in to run `curl … install.sh | bash`.

## Backend

- **`apps/server/src/update/service.ts`** — `UpdateService`: queries the npm registry for the latest `@openaidy/app` version (semver compare), fetches best-effort GitHub release notes, and drives a small in-memory update state machine. The dangerous side effects — `npm install` and the restart — are **injected** (`installFn` / `restartFn` / `fetchFn`) so the whole flow is unit-testable without ever touching the system.
- **`apps/server/src/routes/update.ts`** (admin scope `*`):
  - `GET /api/update/check` → `{ currentVersion, latestVersion, updateAvailable, canSelfUpdate, releaseNotes? }`
  - `GET /api/update/status` → in-memory `{ status, message?, newVersion?, error? }`
  - `POST /api/update` → for a packaged global install, runs `npm install -g @openaidy/app@latest` then hands off to a detached `openaidy restart` (returns `202 installing`). A dev / from-source install returns `409 UPDATE_NOT_SUPPORTED` with the manual command; registry failures return `502`.
- **`apps/server/src/server.ts`** — added `SIGTERM`/`SIGINT` → `app.close()` graceful shutdown (previously absent). This lets a restart drain in-flight work and checkpoint SQLite cleanly instead of being hard-killed.
- **`packages/shared-types/src/update.ts`** — shared `UpdateStatus` / `UpdateCheckResult` / `UpdateState` contract.

### How restart works (no process manager)
There's no systemd/pm2/docker — the CLI runs the server as a detached process tracked by a PID file, and `openaidy restart` already does stop+start with port preservation. The update installs the new global package, then spawns a detached `openaidy restart`; the graceful `SIGTERM` handler lets the old process exit cleanly while the fresh one boots on the new bytes. Packaged mode is auto-detected (the install's `package.json` name is `@openaidy/app`), so `canSelfUpdate` is `false` in dev.

## Frontend (SolidJS)

- **`stores/update-notice.ts`** — sidebar-badge state. Dismissed version is persisted to `localStorage`; the in-progress flag is in-memory only (a restart is the successful end of an update, so a stale `true` must not survive it).
- **`AboutTab`** — "Update to vX.Y.Z" button → confirm dialog (release notes + restart/interruption warning) → triggers the update and shows an "Updating…" message, then auto-reloads to reconnect. When the install can't self-update it shows the manual command instead. Includes a "Dismiss update notice" control.
- **`Sidebar`** — update-available badge (dot + "Update" pill) on the Settings item, shown collapsed and expanded. A best-effort check runs on app boot so the badge lights up without opening Settings (fails silently offline / for non-admin tokens).

## Tests & checks

- New: `update/service.test.ts` (10), `routes/update.test.ts` (8), `stores/update-notice.test.ts` (7), plus 2 new `AboutTab` cases.
- Full suites green: **server 3260 passing / 0 fail**, **web 455 passing / 0 fail**. `tsc` (server + web) and `pnpm lint` clean.

## Notes / follow-ups
- The end-to-end `npm install -g` + restart can only be exercised on a real packaged global install; it's covered here via injected `installFn`/`restartFn` and manual reasoning. Worth a manual smoke test on a real install before release.
- Release-notes lookup hits the GitHub releases API best-effort (no token); it degrades gracefully to no notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)