### PR TITLE
chore(release): bump version to 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Cut the v0.3.9 release. Bumps the root `package.json` version from
`0.3.8` to `0.3.9` — single source of truth per `RELEASING.md`.

The tag `v0.3.9` has already been created and pushed, so this PR is
just the metadata change. Once merged, `.github/workflows/release.yml`
picks up the tag and publishes the GitHub Release with auto-generated
notes (idempotent — safe to re-run if it fails).