### PR TITLE
feat(usage): redesign usage chart bars, tie model colors to legend and table

### DIFF
--- a/apps/web/src/components/pages/UsagePage.test.tsx
+++ b/apps/web/src/components/pages/UsagePage.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
+import type { UsageReport, UsageTotals } from '../../lib/types';
+
+vi.mock('../../lib/api', () => ({
+  getUsage: vi.fn(),
+}));
+
+import { getUsage } from '../../lib/api';
+import { UsagePage } from './UsagePage';
+
+function totals(over: Partial<UsageTotals>): UsageTotals {
+  return {
+    runCount: 1,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    cost: 0,
+    hasCost: false,
+    ...over,
+  };
+}
+
+/**
+ * Two days, two models. Day 1 has exactly double the tokens of day 2 so
+ * the test can assert bar heights scale with the day's total. Model rank
+ * order is anthropic/claude (900) > openai/gpt (600), so claude gets
+ * palette[0] (blue) and gpt gets palette[1] (emerald).
+ */
+function report(): UsageReport {
+  return {
+    totals: totals({ runCount: 4, totalTokens: 1500 }),
+    byDay: [
+      { ...totals({ totalTokens: 1000 }), day: '2026-07-20' },
+      { ...totals({ totalTokens: 500 }), day: '2026-07-21' },
+    ],
+    byProvider: [],
+    byModel: [
+      {
+        ...totals({ runCount: 3, totalTokens: 900 }),
+        providerId: 'anthropic',
+        modelId: 'claude',
+      },
+      {
+        ...totals({ runCount: 1, totalTokens: 600 }),
+        providerId: 'openai',
+        modelId: 'gpt',
+      },
+    ],
+    byDayByModel: [
+      {
+        ...totals({ totalTokens: 800 }),
+        day: '2026-07-20',
+        providerId: 'anthropic',
+        modelId: 'claude',
+      },
+      {
+        ...totals({ totalTokens: 200 }),
+        day: '2026-07-20',
+        providerId: 'openai',
+        modelId: 'gpt',
+      },
+      {
+        ...totals({ totalTokens: 400 }),
+        day: '2026-07-21',
+        providerId: 'openai',
+        modelId: 'gpt',
+      },
+      {
+        ...totals({ totalTokens: 100 }),
+        day: '2026-07-21',
+        providerId: 'anthropic',
+        modelId: 'claude',
+      },
+    ],
+  };
+}
+
+/** Stacked-bar segments = svg rects whose class carries a model hue. */
+function segmentRects(container: HTMLElement): SVGRectElement[] {
+  return [...container.querySelectorAll('svg rect')].filter((r) => {
+    const cls = r.getAttribute('class') ?? '';
+    return cls.includes('fill-') && !cls.includes('fill-gray');
+  }) as SVGRectElement[];
+}
+
+/** Hue shared by a fill/bg class pair, e.g. "fill-blue-500" → "blue-500". */
+function hueOf(cls: string, prefix: 'fill' | 'bg'): string | null {
+  const m = cls.match(new RegExp(`${prefix}-([a-z]+-\\d+)`));
+  return m?.[1] ?? null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getUsage).mockResolvedValue(report());
+});
+
+describe('UsagePage — stacked daily chart', () => {
+  it('renders one colored segment per model per day', async () => {
+    const { container } = render(() => <UsagePage />);
+    await screen.findByText('Tokens per day, by model');
+
+    const segments = segmentRects(container);
+    expect(segments).toHaveLength(4);
+    const hues = segments.map((r) => hueOf(r.getAttribute('class')!, 'fill'));
+    // Rank order: claude = blue (palette[0]), gpt = emerald (palette[1]).
+    expect(hues.filter((h) => h === 'blue-500')).toHaveLength(2);
+    expect(hues.filter((h) => h === 'emerald-500')).toHaveLength(2);
+  });
+
+  it('scales bar heights by the day total (double the tokens = double the height)', async () => {
+    const { container } = render(() => <UsagePage />);
+    await screen.findByText('Tokens per day, by model');
+
+    // Group segments by x (one x per day) and sum their heights.
+    const byX = new Map<string, number>();
+    for (const r of segmentRects(container)) {
+      const x = r.getAttribute('x')!;
+      byX.set(x, (byX.get(x) ?? 0) + Number(r.getAttribute('height')));
+    }
+    const heights = [...byX.values()].sort((a, b) => b - a);
+    expect(heights).toHaveLength(2);
+    expect(heights[1]! / heights[0]!).toBeCloseTo(0.5, 5);
+  });
+
+  it('shows a cursor-following tooltip when hovering a segment', async () => {
+    const { container } = render(() => <UsagePage />);
+    await screen.findByText('Tokens per day, by model');
+
+    const segment = segmentRects(container).find((r) =>
+      (r.getAttribute('class') ?? '').includes('fill-blue-500'),
+    )!;
+    fireEvent.mouseMove(segment, { clientX: 100, clientY: 50 });
+
+    // The legend always shows the model key; a second copy means the
+    // tooltip appeared. The percentage line is unique to the tooltip.
+    const matches = await screen.findAllByText('anthropic/claude');
+    expect(matches).toHaveLength(2);
+    expect(screen.getByText(/80\.0% of day/)).toBeInTheDocument();
+  });
+});
+
+describe('UsagePage — model colors match across chart, legend and table', () => {
+  it('gives every legend item a painted swatch using the model hue', async () => {
+    render(() => <UsagePage />);
+    await screen.findByText('Tokens per day, by model');
+
+    const legend = await screen.findByRole('button', {
+      name: /anthropic\/claude/,
+    });
+    const dot = legend.querySelector('span[aria-hidden="true"]')!;
+    expect(hueOf(dot.getAttribute('class')!, 'bg')).toBe('blue-500');
+
+    const legend2 = screen.getByRole('button', { name: /openai\/gpt/ });
+    const dot2 = legend2.querySelector('span[aria-hidden="true"]')!;
+    expect(hueOf(dot2.getAttribute('class')!, 'bg')).toBe('emerald-500');
+  });
+
+  it('marks each By-model table row with a dot in the same hue as its bar segments', async () => {
+    const { container } = render(() => <UsagePage />);
+    await screen.findByText('By model');
+
+    const rows = [...container.querySelectorAll('tbody tr')];
+    const claudeRow = rows.find((r) => r.textContent?.includes('claude'))!;
+    const gptRow = rows.find((r) => r.textContent?.includes('gpt'))!;
+
+    const claudeDot = claudeRow.querySelector('span[aria-hidden="true"]')!;
+    expect(hueOf(claudeDot.getAttribute('class')!, 'bg')).toBe('blue-500');
+
+    const gptDot = gptRow.querySelector('span[aria-hidden="true"]')!;
+    expect(hueOf(gptDot.getAttribute('class')!, 'bg')).toBe('emerald-500');
+  });
+
+  it('dims other models’ segments when a legend item is hovered', async () => {
+    const { container } = render(() => <UsagePage />);
+    await screen.findByText('Tokens per day, by model');
+
+    const legend = await screen.findByRole('button', {
+      name: /anthropic\/claude/,
+    });
+    fireEvent.mouseEnter(legend);
+
+    for (const r of segmentRects(container)) {
+      const cls = r.getAttribute('class') ?? '';
+      const expected = cls.includes('fill-blue-500') ? '1' : '0.2';
+      expect(r.style.opacity).toBe(expected);
+    }
+  });
+});

--- a/apps/web/src/components/pages/UsagePage.tsx
+++ b/apps/web/src/components/pages/UsagePage.tsx
@@ -7,7 +7,11 @@ import type {
   UsageByModel,
   UsageReport,
 } from '../../lib/types';
-import { formatNumber, formatCost } from '../../lib/usage-format';
+import {
+  formatNumber,
+  formatCost,
+  formatTokensCompact,
+} from '../../lib/usage-format';
 
 type RangePreset = '7d' | '30d' | '90d' | 'all';
 
@@ -34,31 +38,37 @@ function fromForPreset(preset: RangePreset): string | undefined {
  * more than 10 models the chart becomes hard to read but stays honest —
  * every model still gets a visible segment and a legend entry.
  *
- * Why Tailwind classes and not raw hex: the rest of this file already
- * uses Tailwind classes for SVG fill (`fill-primary`), and the same
- * classes work for the legend swatches below.
+ * Each entry carries both halves of the color: `fill` for SVG bar
+ * segments and `bg` for HTML swatches (legend dots, table dots) — a
+ * `fill-*` class paints nothing on a non-SVG element, so the two
+ * contexts need separate classes built from the same hue.
  */
-const CHART_PALETTE = [
-  'fill-blue-500',
-  'fill-emerald-500',
-  'fill-amber-500',
-  'fill-violet-500',
-  'fill-rose-500',
-  'fill-cyan-500',
-  'fill-orange-500',
-  'fill-lime-500',
-  'fill-pink-500',
-  'fill-indigo-500',
-] as const;
+type ModelColor = { fill: string; bg: string };
 
-const FILL_OVERFLOW = 'fill-gray-300 dark:fill-gray-600';
+const CHART_PALETTE: readonly ModelColor[] = [
+  { fill: 'fill-blue-500', bg: 'bg-blue-500' },
+  { fill: 'fill-emerald-500', bg: 'bg-emerald-500' },
+  { fill: 'fill-amber-500', bg: 'bg-amber-500' },
+  { fill: 'fill-violet-500', bg: 'bg-violet-500' },
+  { fill: 'fill-rose-500', bg: 'bg-rose-500' },
+  { fill: 'fill-cyan-500', bg: 'bg-cyan-500' },
+  { fill: 'fill-orange-500', bg: 'bg-orange-500' },
+  { fill: 'fill-lime-500', bg: 'bg-lime-500' },
+  { fill: 'fill-pink-500', bg: 'bg-pink-500' },
+  { fill: 'fill-indigo-500', bg: 'bg-indigo-500' },
+];
 
-/** Stable model-key → CSS-class assignment, sorted by totalTokens desc. */
-function buildModelColorMap(byModel: UsageByModel[]): Map<string, string> {
-  const map = new Map<string, string>();
+const COLOR_OVERFLOW: ModelColor = {
+  fill: 'fill-gray-300 dark:fill-gray-600',
+  bg: 'bg-gray-300 dark:bg-gray-600',
+};
+
+/** Stable model-key → color assignment, sorted by totalTokens desc. */
+function buildModelColorMap(byModel: UsageByModel[]): Map<string, ModelColor> {
+  const map = new Map<string, ModelColor>();
   byModel.forEach((row, i) => {
     const key = `${row.providerId}/${row.modelId}`;
-    map.set(key, CHART_PALETTE[i % CHART_PALETTE.length] ?? FILL_OVERFLOW);
+    map.set(key, CHART_PALETTE[i % CHART_PALETTE.length] ?? COLOR_OVERFLOW);
   });
   return map;
 }
@@ -84,12 +94,55 @@ function indexSegmentsByDay(
   return out;
 }
 
+/** Tooltip payload for the chart's floating (non-native) tooltip. */
+type ChartTooltip =
+  | {
+      kind: 'segment';
+      left: number;
+      top: number;
+      day: string;
+      modelKey: string;
+      tokens: number;
+      pct: string;
+      bg: string;
+    }
+  | { kind: 'day'; left: number; top: number; day: string; tokens: number };
+
+/**
+ * Path for a bar silhouette with only the top corners rounded. Used as a
+ * clip path so the stacked segments stay crisp rectangles while the bar
+ * as a whole reads as one rounded column.
+ */
+function roundedTopPath(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): string {
+  const rr = Math.max(0, Math.min(r, w / 2, h));
+  return [
+    `M ${x} ${y + h}`,
+    `L ${x} ${y + rr}`,
+    `Q ${x} ${y} ${x + rr} ${y}`,
+    `L ${x + w - rr} ${y}`,
+    `Q ${x + w} ${y} ${x + w} ${y + rr}`,
+    `L ${x + w} ${y + h}`,
+    'Z',
+  ].join(' ');
+}
+
 /**
  * Stacked daily token-usage chart. Each bar = one day; bar height = that
- * day's total tokens; bar segments = per-model contributions, colored
- * stably by rank (top model = palette[0]). Replaces the previous
- * single-color chart so the dashboard shows *which* models drove usage,
- * not just the magnitude.
+ * day's total tokens, scaled to the largest day in the range so magnitude
+ * is visible at a glance; bar segments = per-model contributions, colored
+ * stably by rank (top model = palette[0]).
+ *
+ * Interactions: hovering a column highlights it and dims the rest;
+ * hovering a legend item highlights that model's segments across every
+ * bar — the fast way to learn which color is which model. Values surface
+ * in a cursor-following tooltip (native <title> is too slow for a dense
+ * chart).
  *
  * Pure inline SVG — no chart dependency, matches the rest of the page.
  */
@@ -101,22 +154,55 @@ function StackedDailyChart(props: {
   const segmentsByDay = () => indexSegmentsByDay(props.byDayByModel);
   const colorByModel = () => buildModelColorMap(props.byModel);
 
+  const [tooltip, setTooltip] = createSignal<ChartTooltip | null>(null);
+  const [hoverDay, setHoverDay] = createSignal<string | null>(null);
+  const [hoverModel, setHoverModel] = createSignal<string | null>(null);
+  let containerRef: HTMLDivElement | undefined;
+
   const width = 720;
-  const height = 180;
+  const height = 200;
   const padBottom = 22;
-  const padTop = 8;
-  const gap = 3;
-  // Minimum visible segment height (px). Keeps tiny contributions
-  // hoverable; the tooltip shows the real (unfloored) value.
-  const minSegH = 0.5;
+  const padTop = 10;
+  // Room on the left for the compact gridline labels.
+  const padLeft = 34;
+  const gap = 4;
+  const barRadius = 3;
+  // Bars for days with any usage never drop below this height, so a small
+  // day still reads as present rather than rounding away to nothing.
+  const minBarH = 2;
+
+  const usableH = height - padBottom - padTop;
+  const chartW = width - padLeft;
+
+  const maxDayTotal = () =>
+    Math.max(1, ...props.byDay.map((d) => d.totalTokens));
 
   const barWidth = () => {
     const n = props.byDay.length || 1;
-    return Math.max(2, (width - gap * (n - 1)) / n);
+    return Math.max(2, (chartW - gap * (n - 1)) / n);
   };
 
   // Show at most ~8 date labels to avoid collisions.
   const labelEvery = () => Math.max(1, Math.ceil(props.byDay.length / 8));
+
+  /** Cursor position relative to the chart container, clamped so the
+   *  tooltip never overflows the card edges. */
+  const pointFromEvent = (e: MouseEvent): { left: number; top: number } => {
+    const rect = containerRef?.getBoundingClientRect();
+    if (!rect) return { left: 0, top: 0 };
+    return {
+      left: Math.min(Math.max(e.clientX - rect.left, 72), rect.width - 72),
+      top: e.clientY - rect.top,
+    };
+  };
+
+  /** Opacity of one segment given the current hover state: the hovered
+   *  day and hovered model stay solid, everything else fades back. */
+  const segmentOpacity = (day: string, modelKey: string): number => {
+    if (hoverModel() !== null) return hoverModel() === modelKey ? 1 : 0.2;
+    if (hoverDay() !== null) return hoverDay() === day ? 1 : 0.35;
+    return 1;
+  };
 
   return (
     <Show
@@ -127,99 +213,262 @@ function StackedDailyChart(props: {
         </div>
       }
     >
-      <div class="overflow-x-auto">
-        <svg
-          viewBox={`0 0 ${width} ${height}`}
-          class="w-full min-w-[480px]"
-          role="img"
-          aria-label="Daily token usage by model"
-        >
-          <For each={props.byDay}>
-            {(day, i) => {
-              const bw = barWidth();
-              const x = i() * (bw + gap);
-              const usableH = height - padBottom - padTop;
-              const dayTotal = Math.max(1, day.totalTokens);
-              const dayMap = segmentsByDay().get(day.day);
-              // Within-day ordering: largest segment at the bottom of the
-              // bar so the total stays anchored and small contributions
-              // sit on top. Tie-break by model key for stable renders.
-              const segments = dayMap
-                ? [...dayMap.values()].sort((a, b) => {
-                    if (b.totalTokens !== a.totalTokens) {
-                      return b.totalTokens - a.totalTokens;
-                    }
-                    return `${a.providerId}/${a.modelId}`.localeCompare(
-                      `${b.providerId}/${b.modelId}`,
-                    );
-                  })
-                : [];
+      <div class="relative" ref={containerRef}>
+        <div class="overflow-x-auto">
+          <svg
+            viewBox={`0 0 ${width} ${height}`}
+            class="w-full min-w-[480px] select-none"
+            role="img"
+            aria-label="Daily token usage by model"
+          >
+            {/* Horizontal gridlines at 50% / 100% of the largest day +
+                the baseline the bars sit on. */}
+            <For each={[0.5, 1]}>
+              {(f) => {
+                const y = padTop + usableH * (1 - f);
+                return (
+                  <>
+                    <line
+                      x1={padLeft}
+                      y1={y}
+                      x2={width}
+                      y2={y}
+                      class="stroke-gray-200 dark:stroke-gray-700"
+                      stroke-width="1"
+                      stroke-dasharray={f === 1 ? undefined : '3 3'}
+                    />
+                    <text
+                      x={padLeft - 5}
+                      y={y + 3}
+                      text-anchor="end"
+                      class="fill-text-tertiary pointer-events-none"
+                      style={{ 'font-size': '8px' }}
+                    >
+                      {formatTokensCompact(Math.round(maxDayTotal() * f))}
+                    </text>
+                  </>
+                );
+              }}
+            </For>
+            <line
+              x1={padLeft}
+              y1={height - padBottom}
+              x2={width}
+              y2={height - padBottom}
+              class="stroke-gray-300 dark:stroke-gray-600"
+              stroke-width="1"
+            />
 
-              // `cursorY` tracks the top edge of the next segment to draw
-              // — we paint from the baseline upward.
-              let cursorY = height - padBottom;
-              const showLabel = i() % labelEvery() === 0;
+            <For each={props.byDay}>
+              {(day, i) => {
+                const bw = barWidth();
+                const x = padLeft + i() * (bw + gap);
+                const dayTotal = Math.max(1, day.totalTokens);
+                const barH =
+                  day.totalTokens > 0
+                    ? Math.max(
+                        minBarH,
+                        (day.totalTokens / maxDayTotal()) * usableH,
+                      )
+                    : 0;
+                const barTop = height - padBottom - barH;
+                const dayMap = segmentsByDay().get(day.day);
+                // Within-day ordering: largest segment at the bottom of the
+                // bar so the total stays anchored and small contributions
+                // sit on top. Tie-break by model key for stable renders.
+                const segments = dayMap
+                  ? [...dayMap.values()].sort((a, b) => {
+                      if (b.totalTokens !== a.totalTokens) {
+                        return b.totalTokens - a.totalTokens;
+                      }
+                      return `${a.providerId}/${a.modelId}`.localeCompare(
+                        `${b.providerId}/${b.modelId}`,
+                      );
+                    })
+                  : [];
+
+                // `cursorY` tracks the top edge of the next segment to draw
+                // — we paint from the baseline upward.
+                let cursorY = height - padBottom;
+                const showLabel = i() % labelEvery() === 0;
+                return (
+                  <g
+                    onMouseOver={() => setHoverDay(day.day)}
+                    onMouseLeave={() => {
+                      setHoverDay(null);
+                      setTooltip(null);
+                    }}
+                  >
+                    {/* Column highlight, shown while the day is hovered.
+                        Painted first so it sits behind the bar. */}
+                    <rect
+                      x={x - gap / 2}
+                      y={padTop}
+                      width={bw + gap}
+                      height={usableH}
+                      rx={4}
+                      class="fill-gray-300 dark:fill-gray-600"
+                      style={{
+                        opacity: hoverDay() === day.day ? 0.18 : 0,
+                        transition: 'opacity 120ms',
+                      }}
+                      onMouseMove={(e) =>
+                        setTooltip({
+                          kind: 'day',
+                          ...pointFromEvent(e),
+                          day: day.day,
+                          tokens: day.totalTokens,
+                        })
+                      }
+                    />
+                    {/* Segments, clipped to the rounded-top silhouette. */}
+                    <clipPath id={`usage-bar-clip-${i()}`}>
+                      <path
+                        d={roundedTopPath(x, barTop, bw, barH, barRadius)}
+                      />
+                    </clipPath>
+                    <g clip-path={`url(#usage-bar-clip-${i()})`}>
+                      <For each={segments}>
+                        {(seg) => {
+                          const modelKey = `${seg.providerId}/${seg.modelId}`;
+                          // Segments split the bar proportionally; the
+                          // bar itself carries the absolute scale, so the
+                          // stack always fills the rounded silhouette.
+                          const h = (seg.totalTokens / dayTotal) * barH;
+                          const y = cursorY - h;
+                          cursorY = y;
+                          const color =
+                            colorByModel().get(modelKey) ?? COLOR_OVERFLOW;
+                          const pct = (
+                            (seg.totalTokens / dayTotal) *
+                            100
+                          ).toFixed(1);
+                          return (
+                            <rect
+                              x={x}
+                              y={y}
+                              width={bw}
+                              height={h}
+                              class={color.fill}
+                              style={{
+                                opacity: segmentOpacity(day.day, modelKey),
+                                transition: 'opacity 120ms',
+                              }}
+                              onMouseMove={(e) =>
+                                setTooltip({
+                                  kind: 'segment',
+                                  ...pointFromEvent(e),
+                                  day: day.day,
+                                  modelKey,
+                                  tokens: seg.totalTokens,
+                                  pct,
+                                  bg: color.bg,
+                                })
+                              }
+                            />
+                          );
+                        }}
+                      </For>
+                    </g>
+                    <Show when={showLabel}>
+                      <text
+                        x={x + bw / 2}
+                        y={height - 6}
+                        text-anchor="middle"
+                        class="fill-text-tertiary pointer-events-none"
+                        style={{ 'font-size': '9px' }}
+                      >
+                        {day.day.slice(5)}
+                      </text>
+                    </Show>
+                  </g>
+                );
+              }}
+            </For>
+          </svg>
+        </div>
+
+        {/* Floating tooltip — follows the cursor, never captures it. */}
+        <Show when={tooltip()}>
+          {(tip) => {
+            // Narrowed once locally so both variants stay type-safe.
+            const body = () => {
+              const t = tip();
+              if (t.kind === 'day') {
+                return (
+                  <>
+                    <div class="font-medium text-text-primary">{t.day}</div>
+                    <div class="mt-0.5 text-text-secondary tabular-nums">
+                      {formatNumber(t.tokens)} tokens
+                    </div>
+                  </>
+                );
+              }
               return (
                 <>
-                  <For each={segments}>
-                    {(seg) => {
-                      const modelKey = `${seg.providerId}/${seg.modelId}`;
-                      const rawH = (seg.totalTokens / dayTotal) * usableH;
-                      const h = Math.max(minSegH, rawH);
-                      const y = cursorY - h;
-                      cursorY = y;
-                      const color =
-                        colorByModel().get(modelKey) ?? FILL_OVERFLOW;
-                      const pct = (
-                        (seg.totalTokens / dayTotal) *
-                        100
-                      ).toFixed(1);
-                      return (
-                        <rect x={x} y={y} width={bw} height={h} class={color}>
-                          <title>
-                            {day.day} · {modelKey}:{' '}
-                            {formatNumber(seg.totalTokens)} tokens ({pct}% of
-                            day)
-                          </title>
-                        </rect>
-                      );
-                    }}
-                  </For>
-                  <Show when={showLabel}>
-                    <text
-                      x={x + bw / 2}
-                      y={height - 6}
-                      text-anchor="middle"
-                      class="fill-text-tertiary"
-                      style={{ 'font-size': '9px' }}
-                    >
-                      {day.day.slice(5)}
-                    </text>
-                  </Show>
+                  <div class="flex items-center gap-1.5 text-text-secondary">
+                    <span class={`inline-block w-2 h-2 rounded-full ${t.bg}`} />
+                    {t.modelKey}
+                  </div>
+                  <div class="mt-0.5 font-medium text-text-primary tabular-nums">
+                    {formatNumber(t.tokens)} tokens{' '}
+                    <span class="font-normal text-text-tertiary">
+                      ({t.pct}% of day)
+                    </span>
+                  </div>
+                  <div class="text-text-tertiary">{t.day}</div>
                 </>
               );
-            }}
-          </For>
-        </svg>
+            };
+            return (
+              <div
+                aria-hidden="true"
+                class="absolute z-10 pointer-events-none rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-2.5 py-1.5 text-xs shadow-lg whitespace-nowrap"
+                style={{
+                  left: `${tip().left}px`,
+                  top: `${tip().top}px`,
+                  transform: 'translate(-50%, calc(-100% - 10px))',
+                }}
+              >
+                {body()}
+              </div>
+            );
+          }}
+        </Show>
       </div>
-      {/* Legend — one row per model in rank order, color swatch + key +
-          total tokens across the range. Wraps on narrow viewports. */}
+
+      {/* Legend — one item per model in rank order: color dot + key +
+          total tokens across the range. Hovering an item highlights that
+          model's segments in every bar above. Wraps on narrow viewports. */}
       <Show when={props.byModel.length > 0}>
-        <ul class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-text-secondary">
+        <ul class="mt-3 flex flex-wrap gap-x-1.5 gap-y-1 text-xs">
           <For each={props.byModel}>
             {(row) => {
               const key = `${row.providerId}/${row.modelId}`;
-              const color = colorByModel().get(key) ?? FILL_OVERFLOW;
+              const color = colorByModel().get(key) ?? COLOR_OVERFLOW;
               return (
-                <li class="flex items-center gap-1.5">
-                  <span
-                    class={`inline-block w-3 h-3 rounded-sm ${color}`}
-                    aria-hidden="true"
-                  />
-                  <span class="tabular-nums">{key}</span>
-                  <span class="text-text-tertiary tabular-nums">
-                    {formatNumber(row.totalTokens)}
-                  </span>
+                <li>
+                  <button
+                    type="button"
+                    class={`flex items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors ${
+                      hoverModel() === key
+                        ? 'bg-gray-100 dark:bg-gray-700/60 text-text-primary'
+                        : 'text-text-secondary hover:bg-gray-100 dark:hover:bg-gray-700/60'
+                    }`}
+                    onMouseEnter={() => setHoverModel(key)}
+                    onMouseLeave={() => setHoverModel(null)}
+                    onFocus={() => setHoverModel(key)}
+                    onBlur={() => setHoverModel(null)}
+                  >
+                    <span
+                      class={`inline-block w-2.5 h-2.5 rounded-full ${color.bg}`}
+                      aria-hidden="true"
+                    />
+                    <span class="tabular-nums">{key}</span>
+                    <span class="text-text-tertiary tabular-nums">
+                      {formatNumber(row.totalTokens)}
+                    </span>
+                  </button>
                 </li>
               );
             }}
@@ -258,6 +507,10 @@ export function UsagePage() {
   );
 
   const totals = () => report()?.totals;
+
+  // Same model→color assignment the chart uses, so the dots in the table
+  // below match the bar segments and legend swatches exactly.
+  const colorByModel = () => buildModelColorMap(report()?.byModel ?? []);
 
   return (
     <Layout
@@ -378,31 +631,43 @@ export function UsagePage() {
                     }
                   >
                     <For each={report()?.byModel ?? []}>
-                      {(row) => (
-                        <tr class="border-b border-gray-100 dark:border-gray-700/50 last:border-0">
-                          <td class="px-4 py-2 text-text-secondary">
-                            {row.providerId}
-                          </td>
-                          <td class="px-4 py-2 text-text-primary">
-                            {row.modelId}
-                          </td>
-                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
-                            {formatNumber(row.runCount)}
-                          </td>
-                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
-                            {formatNumber(row.promptTokens)}
-                          </td>
-                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
-                            {formatNumber(row.completionTokens)}
-                          </td>
-                          <td class="px-4 py-2 text-right tabular-nums text-text-primary">
-                            {formatNumber(row.totalTokens)}
-                          </td>
-                          <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
-                            {formatCost(row.cost, row.hasCost)}
-                          </td>
-                        </tr>
-                      )}
+                      {(row) => {
+                        const color =
+                          colorByModel().get(
+                            `${row.providerId}/${row.modelId}`,
+                          ) ?? COLOR_OVERFLOW;
+                        return (
+                          <tr class="border-b border-gray-100 dark:border-gray-700/50 last:border-0">
+                            <td class="px-4 py-2 text-text-secondary">
+                              {row.providerId}
+                            </td>
+                            <td class="px-4 py-2 text-text-primary">
+                              <span class="inline-flex items-center gap-2">
+                                <span
+                                  class={`inline-block w-2.5 h-2.5 rounded-full ${color.bg}`}
+                                  aria-hidden="true"
+                                />
+                                {row.modelId}
+                              </span>
+                            </td>
+                            <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                              {formatNumber(row.runCount)}
+                            </td>
+                            <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                              {formatNumber(row.promptTokens)}
+                            </td>
+                            <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                              {formatNumber(row.completionTokens)}
+                            </td>
+                            <td class="px-4 py-2 text-right tabular-nums text-text-primary">
+                              {formatNumber(row.totalTokens)}
+                            </td>
+                            <td class="px-4 py-2 text-right tabular-nums text-text-secondary">
+                              {formatCost(row.cost, row.hasCost)}
+                            </td>
+                          </tr>
+                        );
+                      }}
                     </For>
                   </Show>
                 </tbody>


### PR DESCRIPTION
## Summary

Redesigns the Usage page's stacked daily chart and fixes the model↔color identification problem: bars had colors but nothing else on the page did, so there was no way to tell which segment belonged to which model (the legend swatches were actually broken — they used SVG `fill-*` classes on HTML `<span>`s, which paint nothing).

## Bars

- **Bar height now encodes magnitude**: heights scale to the largest day in the range (previously every bar was full height — segment heights were computed against the day total, so a 100-token day and a 1M-token day looked identical). Small days get a 2px minimum so they still read as present.
- **Rounded bar tops** via a per-bar clip path — segments stay crisp rectangles while the column silhouette is rounded.
- **Gridlines** at 50% / 100% of the max day with compact labels (`1.2M`), plus a baseline axis.
- **Cursor-following tooltip** replaces the slow native `<title>`: shows day, model, tokens, and % of day for segments; day + total tokens when hovering the column.
- **Hover interactions**: hovering a column highlights it and dims the other bars; hovering (or focusing) a legend item highlights that model's segments across *every* bar — the fast way to learn which color is which model.

## Model colors

- Palette entries are now `{ fill, bg }` class pairs built from the same hue: `fill-*` for SVG segments, `bg-*` for HTML swatches.
- Legend swatches actually paint now (they were invisible), and legend items are interactive buttons.
- Each row in the **By model** table gets a color dot matching its bar segments and legend swatch.

## Tests

New `UsagePage.test.tsx` (6 tests) covering: segment count/colors per model per day, bar heights scaling with day totals, the hover tooltip, legend swatches painting with the right hue, table dots matching bar hues, and legend-hover dimming.

## Verification

- `tsc -b` clean, `eslint` clean, `prettier` clean
- Full web suite: 56 files, 502 tests passed
- `pnpm build` succeeds

Visual check left for reviewer (screenshots welcome on the PR).