### PR TITLE
feat(channels): add Discord channel

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "adm-zip": "^0.6.0",
     "archiver": "^8.0.0",
     "croner": "^10.0.1",
+    "discord.js": "^14.16.3",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.41.0",
     "eventemitter3": "^5.0.4",

--- a/apps/server/src/channels/discord/secret.ts
+++ b/apps/server/src/channels/discord/secret.ts
@@ -1,0 +1,28 @@
+import type { McpSecretValue } from '@openaidy/config';
+import { decryptSecret, isEncryptedSecret } from '../../mcp/secret-crypto.js';
+
+/**
+ * Resolve a channel bot token to its plaintext value.
+ *
+ * - `{ kind: 'env', value }` → read `process.env[value]` (throws if unset).
+ * - `{ kind: 'inline', value }` → decrypt if it is `enc:v1:` ciphertext,
+ *   otherwise return the (legacy) plaintext as-is.
+ * - legacy plain string → treated as an inline plaintext token.
+ *
+ * Mirrors the MCP secret resolution in `mcp/placeholder-resolver.ts`.
+ */
+export function resolveBotToken(token: McpSecretValue): string {
+  if (typeof token === 'string') {
+    return token;
+  }
+  if (token.kind === 'env') {
+    const value = process.env[token.value];
+    if (!value) {
+      throw new Error(`Discord bot token env var "${token.value}" is not set`);
+    }
+    return value;
+  }
+  return isEncryptedSecret(token.value)
+    ? decryptSecret(token.value)
+    : token.value;
+}

--- a/apps/server/src/channels/discord/service.test.ts
+++ b/apps/server/src/channels/discord/service.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Discord Channel Tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
+import type { DiscordChannelConfig } from '@openaidy/config';
+import type { DiscordChannelDeps } from './types.js';
+import { clearSessionMapForTesting } from '../message-handler.js';
+
+// --- Mock discord.js -------------------------------------------------------
+class MockClient {
+  static lastInstance: MockClient | null = null;
+  static lastToken: string | null = null;
+
+  options: unknown;
+  user = { id: 'bot-123' };
+  private onceHandlers = new Map<string, (...a: unknown[]) => unknown>();
+  private onHandlers = new Map<string, (...a: unknown[]) => unknown>();
+
+  login = vi.fn(async (token: string) => {
+    MockClient.lastToken = token;
+  });
+  destroy = vi.fn(async () => {});
+
+  constructor(options: unknown) {
+    this.options = options;
+    MockClient.lastInstance = this;
+  }
+
+  once(event: string, cb: (...a: unknown[]) => unknown): this {
+    this.onceHandlers.set(event, cb);
+    return this;
+  }
+  on(event: string, cb: (...a: unknown[]) => unknown): this {
+    this.onHandlers.set(event, cb);
+    return this;
+  }
+
+  emitReady(): void {
+    this.onceHandlers.get('clientReady')?.();
+  }
+  emitMessage(msg: unknown): void {
+    this.onHandlers.get('messageCreate')?.(msg);
+  }
+}
+
+vi.mock('discord.js', () => ({
+  Client: MockClient,
+  Events: {
+    ClientReady: 'clientReady',
+    MessageCreate: 'messageCreate',
+    Error: 'error',
+  },
+  GatewayIntentBits: {
+    Guilds: 1,
+    GuildMessages: 2,
+    MessageContent: 4,
+    DirectMessages: 8,
+  },
+  Partials: { Channel: 'Channel' },
+}));
+
+// Wait a macrotask so the fire-and-forget async message handler settles.
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe('DiscordChannel', () => {
+  let deps: DiscordChannelDeps;
+  let submit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearSessionMapForTesting();
+    MockClient.lastInstance = null;
+    MockClient.lastToken = null;
+    submit = vi.fn(async () => ({
+      ok: true as const,
+      assistantMessage: { content: 'reply!' },
+    }));
+    deps = {
+      authBaseDir: '/tmp/oa-discord-test',
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as unknown as FastifyBaseLogger,
+      sessionService: {
+        listSessions: vi.fn(async () => []),
+        createSession: vi.fn(async () => ({
+          id: 's1',
+          title: 't',
+          createdAt: '',
+        })),
+        submitMessageNonStreaming: submit,
+      } as unknown as DiscordChannelDeps['sessionService'],
+    };
+  });
+
+  function cfg(
+    overrides: Partial<DiscordChannelConfig> = {},
+  ): DiscordChannelConfig {
+    return {
+      type: 'discord',
+      id: 'd1',
+      agentId: 'a1',
+      botToken: { kind: 'inline', value: 'plain-token' },
+      respondToMentions: true,
+      enabled: true,
+      ...overrides,
+    };
+  }
+
+  function message(overrides: Record<string, unknown> = {}) {
+    return {
+      author: { bot: false, id: 'user-1' },
+      guildId: null,
+      channelId: 'chan-1',
+      content: 'hello bot',
+      mentions: { has: vi.fn(() => false) },
+      reply: vi.fn(async () => {}),
+      ...overrides,
+    };
+  }
+
+  async function connected(config: DiscordChannelConfig) {
+    const { DiscordChannel } = await import('./service.js');
+    const channel = new DiscordChannel(config, deps);
+    await channel.connect();
+    const client = MockClient.lastInstance!;
+    client.emitReady();
+    return { channel, client };
+  }
+
+  it('exposes id/type/agentId from config', async () => {
+    const { DiscordChannel } = await import('./service.js');
+    const channel = new DiscordChannel(cfg(), deps);
+    expect(channel.id).toBe('d1');
+    expect(channel.type).toBe('discord');
+    expect(channel.agentId).toBe('a1');
+  });
+
+  it('logs in with the resolved token and connects on ready', async () => {
+    const { channel } = await connected(cfg());
+    expect(MockClient.lastToken).toBe('plain-token');
+    expect(channel.getStatus()).toBe('connected');
+  });
+
+  it('sets error status when the bot token env var is missing', async () => {
+    const { DiscordChannel } = await import('./service.js');
+    const channel = new DiscordChannel(
+      cfg({ botToken: { kind: 'env', value: 'MISSING_DISCORD_TOKEN' } }),
+      deps,
+    );
+    await channel.connect();
+    expect(channel.getStatus()).toBe('error');
+    expect(MockClient.lastInstance).toBeNull();
+  });
+
+  it('replies to a DM from an allowed sender', async () => {
+    const { client } = await connected(cfg());
+    const m = message({ guildId: null });
+    client.emitMessage(m);
+    await tick();
+    expect(submit).toHaveBeenCalled();
+    expect(m.reply).toHaveBeenCalledWith('reply!');
+  });
+
+  it('ignores a DM from a sender not in dmAllowlist', async () => {
+    const { client } = await connected(cfg({ dmAllowlist: ['other-user'] }));
+    const m = message({ guildId: null, author: { bot: false, id: 'user-1' } });
+    client.emitMessage(m);
+    await tick();
+    expect(submit).not.toHaveBeenCalled();
+    expect(m.reply).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages authored by bots', async () => {
+    const { client } = await connected(cfg());
+    const m = message({ author: { bot: true, id: 'bot-999' } });
+    client.emitMessage(m);
+    await tick();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('replies to a server message that @mentions the bot and strips the mention', async () => {
+    const { client } = await connected(cfg());
+    const m = message({
+      guildId: 'g1',
+      channelId: 'c1',
+      content: '<@bot-123> what is up',
+      mentions: { has: vi.fn(() => true) },
+    });
+    client.emitMessage(m);
+    await tick();
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'what is up' }),
+    );
+    expect(m.reply).toHaveBeenCalledWith('reply!');
+  });
+
+  it('ignores a server message with no mention and channel not allowlisted', async () => {
+    const { client } = await connected(cfg({ respondToMentions: true }));
+    const m = message({
+      guildId: 'g1',
+      channelId: 'c1',
+      mentions: { has: vi.fn(() => false) },
+    });
+    client.emitMessage(m);
+    await tick();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('replies to any message in an allowlisted server channel', async () => {
+    const { client } = await connected(
+      cfg({ channelAllowlist: ['c1'], respondToMentions: false }),
+    );
+    const m = message({
+      guildId: 'g1',
+      channelId: 'c1',
+      mentions: { has: vi.fn(() => false) },
+    });
+    client.emitMessage(m);
+    await tick();
+    expect(m.reply).toHaveBeenCalledWith('reply!');
+  });
+
+  it('destroys the client and reports disconnected on disconnect', async () => {
+    const { channel, client } = await connected(cfg());
+    await channel.disconnect();
+    expect(client.destroy).toHaveBeenCalled();
+    expect(channel.getStatus()).toBe('disconnected');
+  });
+});

--- a/apps/server/src/channels/discord/service.ts
+++ b/apps/server/src/channels/discord/service.ts
@@ -1,0 +1,206 @@
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Partials,
+  type Message,
+} from 'discord.js';
+import { EventEmitter } from 'node:events';
+import type { IChannel } from '../interface.js';
+import type { ChannelStatus } from '@openaidy/shared-types';
+import type { DiscordChannelConfig } from '@openaidy/config';
+import type { DiscordChannelDeps } from './types.js';
+import { handleInboundChannelMessage } from '../message-handler.js';
+import { resolveBotToken } from './secret.js';
+
+/** Discord hard limit on a single message's content length. */
+const DISCORD_MAX_MESSAGE_LENGTH = 2000;
+
+/**
+ * Discord channel implementation using discord.js.
+ *
+ * Token-based (no QR), so it implements the base {@link IChannel} — not
+ * IQrChannel. Owns the discord.js gateway client lifecycle; delegates all
+ * message processing and LLM invocation to the shared channel message handler.
+ *
+ * Trigger rules (see {@link DiscordChannelConfig}): replies to DMs (optionally
+ * restricted to `dmAllowlist`), to messages in `channelAllowlist` server
+ * channels, and — when `respondToMentions` — to server messages that @mention
+ * the bot.
+ */
+export class DiscordChannel extends EventEmitter implements IChannel {
+  readonly id: string;
+  readonly type = 'discord' as const;
+  readonly agentId: string;
+
+  private status: ChannelStatus = 'disconnected';
+  private client: Client | null = null;
+
+  constructor(
+    private readonly config: DiscordChannelConfig,
+    private readonly deps: DiscordChannelDeps,
+  ) {
+    super();
+    this.id = config.id;
+    this.agentId = config.agentId;
+  }
+
+  getStatus(): ChannelStatus {
+    return this.status;
+  }
+
+  onStatusChange(cb: (status: ChannelStatus) => void): void {
+    this.on('status', cb);
+  }
+
+  /** Remove a registered status change callback */
+  removeListener(event: 'status', cb: (status: ChannelStatus) => void): this {
+    return super.removeListener(event, cb);
+  }
+
+  async connect(): Promise<void> {
+    if (this.client) {
+      this.deps.logger.warn(
+        { channelId: this.id },
+        'discord: connect() called while already connected',
+      );
+      return;
+    }
+
+    let token: string;
+    try {
+      token = resolveBotToken(this.config.botToken);
+    } catch (err) {
+      this.deps.logger.error(
+        { err, channelId: this.id },
+        'discord: failed to resolve bot token',
+      );
+      this.setStatus('error');
+      return;
+    }
+
+    const client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.DirectMessages,
+      ],
+      // Required to receive DMs (their channel isn't cached up front).
+      partials: [Partials.Channel],
+    });
+    this.client = client;
+
+    client.once(Events.ClientReady, () => {
+      this.setStatus('connected');
+      this.deps.logger.info({ channelId: this.id }, 'discord: connected');
+    });
+
+    client.on(Events.MessageCreate, (message) => {
+      void this.handleMessage(message);
+    });
+
+    client.on(Events.Error, (err) => {
+      this.deps.logger.error(
+        { err, channelId: this.id },
+        'discord: client error',
+      );
+      this.setStatus('error');
+    });
+
+    try {
+      await client.login(token);
+    } catch (err) {
+      this.deps.logger.error(
+        { err, channelId: this.id },
+        'discord: login failed',
+      );
+      this.client = null;
+      this.setStatus('error');
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.client) return;
+    try {
+      await this.client.destroy();
+    } catch {
+      // destroy can throw if the client is already torn down
+    }
+    this.client = null;
+    this.setStatus('disconnected');
+  }
+
+  /**
+   * Decide whether an inbound message should be answered, extract its text,
+   * dispatch to the agent, and reply. Errors are logged, never thrown.
+   */
+  private async handleMessage(message: Message): Promise<void> {
+    try {
+      // Ignore bots (including our own replies) — prevents loops.
+      if (message.author?.bot) return;
+
+      const isDm = message.guildId == null;
+      if (isDm) {
+        const allow = this.config.dmAllowlist;
+        if (allow?.length && !allow.includes(message.author.id)) return;
+      } else {
+        const inAllowedChannel =
+          this.config.channelAllowlist?.includes(message.channelId) ?? false;
+        const mentioned =
+          this.config.respondToMentions !== false &&
+          !!this.client?.user &&
+          message.mentions.has(this.client.user.id);
+        if (!inAllowedChannel && !mentioned) return;
+      }
+
+      // Strip a leading bot @mention (mention-triggered server messages).
+      let text = message.content ?? '';
+      if (this.client?.user) {
+        text = text
+          .replace(new RegExp(`^<@!?${this.client.user.id}>\\s*`), '')
+          .trim();
+      }
+      if (!text) return;
+
+      const reply = await handleInboundChannelMessage({
+        channelType: 'discord',
+        senderId: message.author.id,
+        text,
+        channelId: this.id,
+        agentId: this.config.agentId,
+        // Gating (DM/mention/channel) is applied above; the handler's own
+        // allowlist is unused for Discord.
+        allowlist: undefined,
+        sessionService: this.deps.sessionService,
+        logger: this.deps.logger,
+      });
+
+      if (reply) {
+        for (const part of splitForDiscord(reply)) {
+          await message.reply(part);
+        }
+      }
+    } catch (err) {
+      this.deps.logger.error(
+        { err, channelId: this.id },
+        'discord: unhandled error processing inbound message',
+      );
+    }
+  }
+
+  private setStatus(s: ChannelStatus): void {
+    this.status = s;
+    this.emit('status', s);
+  }
+}
+
+/** Split a reply into Discord-sized (<=2000 char) chunks. */
+function splitForDiscord(text: string): string[] {
+  if (text.length <= DISCORD_MAX_MESSAGE_LENGTH) return [text];
+  const parts: string[] = [];
+  for (let i = 0; i < text.length; i += DISCORD_MAX_MESSAGE_LENGTH) {
+    parts.push(text.slice(i, i + DISCORD_MAX_MESSAGE_LENGTH));
+  }
+  return parts;
+}

--- a/apps/server/src/channels/discord/types.ts
+++ b/apps/server/src/channels/discord/types.ts
@@ -1,0 +1,13 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { SessionMessageService } from '../../sessions/service.js';
+
+/**
+ * Dependencies required by the Discord channel implementation.
+ * Mirrors the registry-level deps; `authBaseDir` is unused by Discord (the bot
+ * token comes from config) but kept for parity with other channels.
+ */
+export type DiscordChannelDeps = {
+  sessionService: SessionMessageService;
+  authBaseDir: string;
+  logger: FastifyBaseLogger;
+};

--- a/apps/server/src/channels/index.ts
+++ b/apps/server/src/channels/index.ts
@@ -4,6 +4,7 @@ import type { SessionMessageService } from '../sessions/service';
 import { ChannelRegistry } from './registry.js';
 import type { IChannel } from './interface.js';
 import { WhatsAppChannel } from './whatsapp/service.js';
+import { DiscordChannel } from './discord/service.js';
 
 export type ChannelRegistryDeps = {
   sessionService: SessionMessageService;
@@ -33,6 +34,9 @@ function createChannelInstance(
 ): IChannel | null {
   if (cfg.type === 'whatsapp') {
     return new WhatsAppChannel(cfg, deps);
+  }
+  if (cfg.type === 'discord') {
+    return new DiscordChannel(cfg, deps);
   }
   // Future channel types go here, e.g.:
   // if (cfg.type === 'telegram') {

--- a/apps/server/src/channels/message-handler.test.ts
+++ b/apps/server/src/channels/message-handler.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  handleInboundChannelMessage,
+  buildChannelSessionKey,
+  clearSessionMapForTesting,
+} from './message-handler.js';
+import type { SessionRecord } from '../types.js';
+
+const mockSessionService = {
+  listSessions: vi.fn<() => Promise<SessionRecord[]>>(),
+  createSession: vi.fn<() => Promise<SessionRecord>>(),
+  submitMessageNonStreaming:
+    vi.fn<
+      () => Promise<
+        | { ok: true; assistantMessage: { content: string } }
+        | { ok: false; error: { code: string; message: string } }
+      >
+    >(),
+};
+
+const mockLogger = {
+  debug: vi.fn<() => void>(),
+  info: vi.fn<() => void>(),
+  warn: vi.fn<() => void>(),
+  error: vi.fn<(err: unknown) => void>(),
+};
+
+const baseParams = {
+  channelType: 'discord',
+  senderId: 'user-1',
+  text: 'Hello agent',
+  channelId: 'server',
+  agentId: 'my-agent',
+  allowlist: undefined as string[] | undefined,
+  sessionService: mockSessionService,
+  logger: mockLogger as unknown as import('fastify').FastifyBaseLogger,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearSessionMapForTesting();
+  mockSessionService.listSessions.mockResolvedValue([]);
+  mockSessionService.createSession.mockResolvedValue({
+    id: 'session-123',
+    title: 'discord:server:user-1',
+    createdAt: new Date().toISOString(),
+  });
+  mockSessionService.submitMessageNonStreaming.mockResolvedValue({
+    ok: true,
+    assistantMessage: { content: 'Hello human!' },
+  });
+});
+
+describe('buildChannelSessionKey', () => {
+  it('namespaces by channel type, channel id, and sender', () => {
+    expect(buildChannelSessionKey('discord', 'server', 'user-1')).toBe(
+      'discord:server:user-1',
+    );
+    expect(buildChannelSessionKey('whatsapp', 'personal', '15551234567')).toBe(
+      'whatsapp:personal:15551234567',
+    );
+  });
+});
+
+describe('handleInboundChannelMessage', () => {
+  it('returns the agent reply and uses a type-prefixed session title', async () => {
+    const reply = await handleInboundChannelMessage(baseParams);
+    expect(reply).toBe('Hello human!');
+    expect(mockSessionService.createSession).toHaveBeenCalledWith(
+      'discord:server:user-1',
+    );
+  });
+
+  it('allows everyone when allowlist is empty/undefined', async () => {
+    expect(
+      await handleInboundChannelMessage({ ...baseParams, allowlist: [] }),
+    ).toBe('Hello human!');
+    expect(
+      await handleInboundChannelMessage({
+        ...baseParams,
+        allowlist: undefined,
+      }),
+    ).toBe('Hello human!');
+  });
+
+  it('rejects when a non-empty allowlist excludes every candidate id', async () => {
+    const reply = await handleInboundChannelMessage({
+      ...baseParams,
+      allowlist: ['someone-else'],
+    });
+    expect(reply).toBeNull();
+    expect(mockSessionService.submitMessageNonStreaming).not.toHaveBeenCalled();
+  });
+
+  it('matches an allowlist against any candidate id', async () => {
+    const reply = await handleInboundChannelMessage({
+      ...baseParams,
+      candidateIds: ['alias', 'user-1'],
+      allowlist: ['user-1'],
+    });
+    expect(reply).toBe('Hello human!');
+  });
+
+  it('returns null and logs when the agent invocation fails', async () => {
+    mockSessionService.submitMessageNonStreaming.mockResolvedValue({
+      ok: false,
+      error: { code: 'provider.error', message: 'timeout' },
+    });
+    const reply = await handleInboundChannelMessage(baseParams);
+    expect(reply).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/channels/message-handler.ts
+++ b/apps/server/src/channels/message-handler.ts
@@ -1,0 +1,166 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { SessionMessageService } from '../sessions/service.js';
+
+/**
+ * Build a session key namespaced by channel type, channel id, and sender.
+ * The type prefix keeps sessions from different channels (e.g. `whatsapp:` vs
+ * `discord:`) from colliding in the shared session map / session titles.
+ */
+export function buildChannelSessionKey(
+  channelType: string,
+  channelId: string,
+  senderId: string,
+): string {
+  return `${channelType}:${channelId}:${senderId}`;
+}
+
+/**
+ * In-memory session key → sessionId map.
+ * Survives across messages within a server process.
+ * On server restart the map is rebuilt from existing sessions via listSessions().
+ */
+class SessionMap {
+  private readonly map = new Map<string, string>();
+
+  get(key: string): string | undefined {
+    return this.map.get(key);
+  }
+
+  set(key: string, sessionId: string): void {
+    this.map.set(key, sessionId);
+  }
+
+  /** Reset all entries — for testing only */
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+// Singleton — shared across all channels' message handling within one process.
+// Keys are namespaced by channel type (see buildChannelSessionKey), so sharing
+// is safe across channels.
+const sessionMap = new SessionMap();
+
+/** Reset the session map — for testing only */
+export function clearSessionMapForTesting(): void {
+  sessionMap.clear();
+}
+
+/**
+ * Find existing session ID by session title, or create a new session.
+ * Results are cached in module-level sessionMap.
+ */
+async function findOrCreateSession(
+  sessionKey: string,
+  sessionService: Pick<SessionMessageService, 'listSessions' | 'createSession'>,
+): Promise<string> {
+  // Check in-memory cache first
+  const cached = sessionMap.get(sessionKey);
+  if (cached) return cached;
+
+  // Try to find existing session by title (listSessions returns sessions with id + title)
+  const sessions = await sessionService.listSessions();
+  const sessionsArr = sessions as Array<{ id: string; title: string }>;
+  const existing = sessionsArr.find((s) => s.title === sessionKey);
+
+  if (existing) {
+    sessionMap.set(sessionKey, existing.id);
+    return existing.id;
+  }
+
+  // Create new session
+  const created = await sessionService.createSession(sessionKey);
+  const id = (created as { id: string }).id;
+  sessionMap.set(sessionKey, id);
+  return id;
+}
+
+/**
+ * Handle an inbound message from any channel.
+ *
+ * Single responsibility: translate an inbound message into a session
+ * interaction and return the text reply (or null if rejected/errored).
+ * Channel-agnostic — no transport (Baileys, discord.js, …) imports — so it is
+ * fully unit-testable in isolation and shared by every channel.
+ */
+export async function handleInboundChannelMessage(params: {
+  /** Channel type, used for the session-key prefix and log context. */
+  channelType: string;
+  /** Stable id of the sender (session key + default allowlist candidate). */
+  senderId: string;
+  /**
+   * Id forms the sender may be matched against in the allowlist. Defaults to
+   * `[senderId]` when omitted (WhatsApp passes phone + LID forms).
+   */
+  candidateIds?: string[];
+  text: string;
+  channelId: string;
+  agentId: string;
+  allowlist: string[] | undefined;
+  sessionService: Pick<
+    SessionMessageService,
+    'listSessions' | 'createSession' | 'submitMessageNonStreaming'
+  >;
+  logger: FastifyBaseLogger;
+}): Promise<string | null> {
+  const {
+    channelType,
+    senderId,
+    text,
+    channelId,
+    agentId,
+    allowlist,
+    sessionService,
+    logger,
+  } = params;
+  const candidateIds = params.candidateIds?.length
+    ? params.candidateIds
+    : [senderId];
+  logger.debug(
+    {
+      channelType,
+      senderId,
+      candidateIds,
+      text,
+      channelId,
+      agentId,
+      allowlist,
+    },
+    `${channelType}: message received`,
+  );
+  // 1. Allowlist gate. An empty/absent allowlist allows everyone — matching
+  //    the channel UI ("leave empty to allow everyone"). A non-empty allowlist
+  //    restricts to the listed ids, matched against any of the sender's id
+  //    forms.
+  if (allowlist?.length && !candidateIds.some((id) => allowlist.includes(id))) {
+    // Logged at info (not debug) so an operator can see exactly which id
+    // arrived and add it to the allowlist if a message is being dropped.
+    logger.info(
+      { channelType, senderId, candidateIds, channelId },
+      `${channelType}: message rejected by allowlist`,
+    );
+    return null;
+  }
+
+  // 2. Build session key and find or create session
+  const sessionKey = buildChannelSessionKey(channelType, channelId, senderId);
+  const sessionId = await findOrCreateSession(sessionKey, sessionService);
+
+  // 3. Submit message (non-streaming — channel needs full reply text)
+  const result = await sessionService.submitMessageNonStreaming({
+    sessionId,
+    role: 'user',
+    content: text,
+    agentId,
+  });
+
+  if (!result.ok) {
+    logger.error(
+      { error: result.error, sessionId, channelId, channelType },
+      `${channelType}: agent invocation failed`,
+    );
+    return null;
+  }
+
+  return result.assistantMessage?.content ?? null;
+}

--- a/apps/server/src/channels/reconcile.test.ts
+++ b/apps/server/src/channels/reconcile.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import type { FastifyBaseLogger } from 'fastify';
-import type { WhatsAppChannelConfig } from '@openaidy/config';
+import type {
+  WhatsAppChannelConfig,
+  DiscordChannelConfig,
+} from '@openaidy/config';
 import {
   createChannelRegistry,
   reconcileChannelRegistry,
@@ -29,6 +32,17 @@ function wa(id: string, agentId = 'default'): WhatsAppChannelConfig {
   return { type: 'whatsapp', id, agentId, enabled: true };
 }
 
+function dc(id: string, agentId = 'default'): DiscordChannelConfig {
+  return {
+    type: 'discord',
+    id,
+    agentId,
+    botToken: { kind: 'inline', value: 'tok' },
+    respondToMentions: true,
+    enabled: true,
+  };
+}
+
 describe('createChannelRegistry', () => {
   it('builds a channel instance per whatsapp config entry', () => {
     const registry = createChannelRegistry([wa('a'), wa('b')], makeDeps());
@@ -44,6 +58,12 @@ describe('createChannelRegistry', () => {
   it('handles undefined config as no channels', () => {
     const registry = createChannelRegistry(undefined, makeDeps());
     expect(registry.getAll()).toHaveLength(0);
+  });
+
+  it('builds a discord channel instance for a discord config entry', () => {
+    const registry = createChannelRegistry([dc('d1'), wa('w1')], makeDeps());
+    expect(registry.get('d1')?.type).toBe('discord');
+    expect(registry.get('w1')?.type).toBe('whatsapp');
   });
 });
 

--- a/apps/server/src/channels/whatsapp/message-handler.ts
+++ b/apps/server/src/channels/whatsapp/message-handler.ts
@@ -1,77 +1,17 @@
 import type { FastifyBaseLogger } from 'fastify';
 import type { SessionMessageService } from '../../sessions/service.js';
+import { handleInboundChannelMessage } from '../message-handler.js';
 
-/**
- * Build a session key for a WhatsApp contact.
- */
-function buildSessionKey(channelId: string, waId: string): string {
-  return `whatsapp:${channelId}:${waId}`;
-}
-
-/**
- * In-memory session key → sessionId map.
- * Survives across messages within a server process.
- * On server restart the map is rebuilt from existing sessions via listSessions().
- */
-class SessionMap {
-  private readonly map = new Map<string, string>();
-
-  get(key: string): string | undefined {
-    return this.map.get(key);
-  }
-
-  set(key: string, sessionId: string): void {
-    this.map.set(key, sessionId);
-  }
-
-  /** Reset all entries — for testing only */
-  clear(): void {
-    this.map.clear();
-  }
-}
-
-// Singleton — shared across all message handling within one process
-const sessionMap = new SessionMap();
-
-/** Reset the session map — for testing only */
-export function clearSessionMapForTesting(): void {
-  sessionMap.clear();
-}
-
-/**
- * Find existing session ID by session title, or create a new session.
- * Results are cached in module-level sessionMap.
- */
-async function findOrCreateSession(
-  sessionKey: string,
-  sessionService: Pick<SessionMessageService, 'listSessions' | 'createSession'>,
-): Promise<string> {
-  // Check in-memory cache first
-  const cached = sessionMap.get(sessionKey);
-  if (cached) return cached;
-
-  // Try to find existing session by title (listSessions returns sessions with id + title)
-  const sessions = await sessionService.listSessions();
-  const sessionsArr = sessions as Array<{ id: string; title: string }>;
-  const existing = sessionsArr.find((s) => s.title === sessionKey);
-
-  if (existing) {
-    sessionMap.set(sessionKey, existing.id);
-    return existing.id;
-  }
-
-  // Create new session
-  const created = await sessionService.createSession(sessionKey);
-  const id = (created as { id: string }).id;
-  sessionMap.set(sessionKey, id);
-  return id;
-}
+// Re-export so existing WhatsApp callers/tests keep importing from here.
+export { clearSessionMapForTesting } from '../message-handler.js';
 
 /**
  * Handle an inbound WhatsApp message.
  *
- * Single responsibility: translate an inbound message into a session interaction
- * and return the text reply (or null if rejected/errored).
+ * Thin adapter over the channel-agnostic {@link handleInboundChannelMessage}:
+ * maps WhatsApp's `waId` to the generic `senderId` and pins the channel type
+ * to `whatsapp` (so session keys stay `whatsapp:<channelId>:<waId>`, unchanged
+ * from before the shared handler was extracted).
  *
  * Zero Baileys imports — fully unit-testable in isolation.
  */
@@ -92,48 +32,15 @@ export async function handleInboundWhatsAppMessage(params: {
   >;
   logger: FastifyBaseLogger;
 }): Promise<string | null> {
-  const { waId, text, channelId, agentId, allowlist, sessionService, logger } =
-    params;
-  const candidateIds = params.candidateIds?.length
-    ? params.candidateIds
-    : [waId];
-  logger.debug(
-    { waId, candidateIds, text, channelId, agentId, allowlist },
-    'whatsapp: message received',
-  );
-  // 1. Allowlist gate. An empty/absent allowlist allows everyone — matching
-  //    the channel UI ("leave empty to allow everyone"). A non-empty allowlist
-  //    restricts to the listed ids, matched against any of the sender's id
-  //    forms so a phone-number allowlist works even under LID addressing.
-  if (allowlist?.length && !candidateIds.some((id) => allowlist.includes(id))) {
-    // Logged at info (not debug) so an operator can see exactly which id
-    // arrived and add it to the allowlist if a message is being dropped.
-    logger.info(
-      { waId, candidateIds, channelId },
-      'whatsapp: message rejected by allowlist',
-    );
-    return null;
-  }
-
-  // 2. Build session key and find or create session
-  const sessionKey = buildSessionKey(channelId, waId);
-  const sessionId = await findOrCreateSession(sessionKey, sessionService);
-
-  // 3. Submit message (non-streaming — channel needs full reply text)
-  const result = await sessionService.submitMessageNonStreaming({
-    sessionId,
-    role: 'user',
-    content: text,
-    agentId,
+  return handleInboundChannelMessage({
+    channelType: 'whatsapp',
+    senderId: params.waId,
+    ...(params.candidateIds ? { candidateIds: params.candidateIds } : {}),
+    text: params.text,
+    channelId: params.channelId,
+    agentId: params.agentId,
+    allowlist: params.allowlist,
+    sessionService: params.sessionService,
+    logger: params.logger,
   });
-
-  if (!result.ok) {
-    logger.error(
-      { error: result.error, sessionId, channelId },
-      'whatsapp: agent invocation failed',
-    );
-    return null;
-  }
-
-  return result.assistantMessage?.content ?? null;
 }

--- a/apps/server/src/config/service.test.ts
+++ b/apps/server/src/config/service.test.ts
@@ -7,6 +7,13 @@ import { AppConfigService } from './service.js';
 import type { ProviderServices } from '../providers';
 import type { AgentRegistry } from '../agents';
 
+// Deterministic stand-in for the AES secret-crypto so the encryption-on-save
+// tests don't depend on a real master key.
+vi.mock('../mcp/secret-crypto', () => ({
+  encryptSecret: (plaintext: string) => `enc:v1:${plaintext}`,
+  isEncryptedSecret: (value: string) => value.startsWith('enc:v1:'),
+}));
+
 /**
  * Minimal config that passes appConfigSchema without needing any real
  * providers: empty providers list + a model-less agent + no default provider
@@ -106,5 +113,74 @@ describe('AppConfigService channel reconciler', () => {
     const service = makeService();
     await service.load();
     await expect(service.save(baseConfig())).resolves.toBeDefined();
+  });
+
+  it('encrypts an inline discord bot token on save', async () => {
+    const service = makeService();
+    await service.load();
+
+    await service.save({
+      ...baseConfig(),
+      channels: [
+        {
+          type: 'discord',
+          id: 'guild-bot',
+          agentId: 'default',
+          botToken: { kind: 'inline', value: 'super-secret-token' },
+          enabled: true,
+        },
+      ],
+    });
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(written.channels[0].botToken).toEqual({
+      kind: 'inline',
+      value: 'enc:v1:super-secret-token',
+    });
+  });
+
+  it('leaves an already-encrypted token unchanged (idempotent)', async () => {
+    const service = makeService();
+    await service.load();
+
+    await service.save({
+      ...baseConfig(),
+      channels: [
+        {
+          type: 'discord',
+          id: 'guild-bot',
+          agentId: 'default',
+          botToken: { kind: 'inline', value: 'enc:v1:already' },
+          enabled: true,
+        },
+      ],
+    });
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(written.channels[0].botToken.value).toBe('enc:v1:already');
+  });
+
+  it('does not encrypt an env-var token reference on save', async () => {
+    const service = makeService();
+    await service.load();
+
+    await service.save({
+      ...baseConfig(),
+      channels: [
+        {
+          type: 'discord',
+          id: 'guild-bot',
+          agentId: 'default',
+          botToken: { kind: 'env', value: 'DISCORD_BOT_TOKEN' },
+          enabled: true,
+        },
+      ],
+    });
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(written.channels[0].botToken).toEqual({
+      kind: 'env',
+      value: 'DISCORD_BOT_TOKEN',
+    });
   });
 });

--- a/apps/server/src/config/service.ts
+++ b/apps/server/src/config/service.ts
@@ -33,6 +33,7 @@ import {
   readMcpSeedManifest,
   writeMcpSeedManifest,
 } from '../mcp/preinstall';
+import { encryptSecret, isEncryptedSecret } from '../mcp/secret-crypto';
 
 export class AppConfigService {
   private readonly configPath: string;
@@ -173,6 +174,7 @@ export class AppConfigService {
 
   async save(input: unknown): Promise<OpenAidyAppConfig> {
     const parsed = appConfigSchema.parse(input);
+    this.encryptChannelSecrets(parsed);
     this.writeConfigFile(parsed);
     await this.applyConfig(parsed);
     this.currentConfig = parsed;
@@ -216,6 +218,27 @@ export class AppConfigService {
     }
 
     return appConfigSchema.parse(parsedJson);
+  }
+
+  /**
+   * Encrypt inline channel secrets (currently the Discord bot token) before
+   * the config is written, so a plaintext token pasted in the UI never lands
+   * in openaidy.json. Idempotent: already-encrypted (`enc:v1:`) values and
+   * env-var references are left untouched. Mirrors MCP inline-secret handling
+   * (see `mcp/server-record.ts`).
+   */
+  private encryptChannelSecrets(config: OpenAidyAppConfig): void {
+    for (const channel of config.channels ?? []) {
+      if (channel.type !== 'discord') continue;
+      const token = channel.botToken;
+      if (
+        typeof token === 'object' &&
+        token.kind === 'inline' &&
+        !isEncryptedSecret(token.value)
+      ) {
+        token.value = encryptSecret(token.value);
+      }
+    }
   }
 
   private writeConfigFile(config: OpenAidyAppConfig): void {

--- a/apps/web/src/components/pages/ChannelsPage.tsx
+++ b/apps/web/src/components/pages/ChannelsPage.tsx
@@ -26,6 +26,7 @@ import {
   connectChannel,
   disconnectChannel,
   addWhatsAppChannel,
+  addDiscordChannel,
   removeChannel,
   listAgents,
 } from '../../lib/api';
@@ -159,32 +160,59 @@ function QrPanel(props: { channelId: string; onConnected: () => void }) {
 
 function AddChannelDialog(props: {
   onClose: () => void;
-  onAdded: (id: string) => void;
+  onAdded: (id: string, type: 'whatsapp' | 'discord') => void;
 }) {
   const [agents] = createResource(async () => (await listAgents()).items);
+  const [channelType, setChannelType] = createSignal<'whatsapp' | 'discord'>(
+    'whatsapp',
+  );
   const [id, setId] = createSignal('');
   const [agentId, setAgentId] = createSignal('');
   const [allowlist, setAllowlist] = createSignal('');
+  const [botToken, setBotToken] = createSignal('');
+  const [dmAllowlist, setDmAllowlist] = createSignal('');
+  const [channelAllowlist, setChannelAllowlist] = createSignal('');
+  const [respondToMentions, setRespondToMentions] = createSignal(true);
   const [saving, setSaving] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
 
-  const canSave = () => id().trim().length > 0 && agentId().length > 0;
+  const csv = (s: string) =>
+    s
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+
+  const canSave = () => {
+    if (id().trim().length === 0 || agentId().length === 0) return false;
+    if (channelType() === 'discord') return botToken().trim().length > 0;
+    return true;
+  };
 
   const handleSave = async () => {
     if (!canSave()) return;
     setSaving(true);
     setError(null);
     try {
-      const allowlistArr = allowlist()
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-      await addWhatsAppChannel({
-        id: id().trim(),
-        agentId: agentId(),
-        ...(allowlistArr.length > 0 ? { allowlist: allowlistArr } : {}),
-      });
-      props.onAdded(id().trim());
+      if (channelType() === 'discord') {
+        const dm = csv(dmAllowlist());
+        const chans = csv(channelAllowlist());
+        await addDiscordChannel({
+          id: id().trim(),
+          agentId: agentId(),
+          botToken: botToken().trim(),
+          respondToMentions: respondToMentions(),
+          ...(dm.length > 0 ? { dmAllowlist: dm } : {}),
+          ...(chans.length > 0 ? { channelAllowlist: chans } : {}),
+        });
+      } else {
+        const allowlistArr = csv(allowlist());
+        await addWhatsAppChannel({
+          id: id().trim(),
+          agentId: agentId(),
+          ...(allowlistArr.length > 0 ? { allowlist: allowlistArr } : {}),
+        });
+      }
+      props.onAdded(id().trim(), channelType());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add channel');
     } finally {
@@ -192,12 +220,15 @@ function AddChannelDialog(props: {
     }
   };
 
+  const inputClass =
+    'w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary';
+
   return (
     <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-md mx-4">
         <div class="flex items-center justify-between p-4 border-b dark:border-gray-700">
           <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-            Add WhatsApp channel
+            Add channel
           </h2>
           <button
             onClick={props.onClose}
@@ -217,6 +248,22 @@ function AddChannelDialog(props: {
 
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Channel type <span class="text-red-500">*</span>
+            </label>
+            <select
+              value={channelType()}
+              onChange={(e) =>
+                setChannelType(e.currentTarget.value as 'whatsapp' | 'discord')
+              }
+              class={inputClass}
+            >
+              <option value="whatsapp">WhatsApp</option>
+              <option value="discord">Discord</option>
+            </select>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Channel ID <span class="text-red-500">*</span>
             </label>
             <input
@@ -224,10 +271,10 @@ function AddChannelDialog(props: {
               value={id()}
               onInput={(e) => setId(e.currentTarget.value)}
               placeholder="e.g. personal"
-              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+              class={inputClass}
             />
             <p class="mt-1 text-xs text-text-tertiary">
-              A unique name for this WhatsApp connection.
+              A unique name for this connection.
             </p>
           </div>
 
@@ -238,7 +285,7 @@ function AddChannelDialog(props: {
             <select
               value={agentId()}
               onChange={(e) => setAgentId(e.currentTarget.value)}
-              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+              class={inputClass}
             >
               <option value="">Select an agent…</option>
               <For each={agents() ?? []}>
@@ -250,22 +297,88 @@ function AddChannelDialog(props: {
             </p>
           </div>
 
-          <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Allowlist
+          <Show when={channelType() === 'whatsapp'}>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Allowlist
+              </label>
+              <input
+                type="text"
+                value={allowlist()}
+                onInput={(e) => setAllowlist(e.currentTarget.value)}
+                placeholder="e.g. 15551234567, 15559876543"
+                class={inputClass}
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                Optional. Comma-separated phone numbers allowed to message this
+                channel. Leave empty to allow everyone.
+              </p>
+            </div>
+          </Show>
+
+          <Show when={channelType() === 'discord'}>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Bot token <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="password"
+                value={botToken()}
+                onInput={(e) => setBotToken(e.currentTarget.value)}
+                placeholder="Discord bot token"
+                autocomplete="off"
+                class={inputClass}
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                From the Discord Developer Portal. Stored encrypted at rest.
+                Enable the “Message Content Intent” for your bot.
+              </p>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                DM allowlist
+              </label>
+              <input
+                type="text"
+                value={dmAllowlist()}
+                onInput={(e) => setDmAllowlist(e.currentTarget.value)}
+                placeholder="e.g. 123456789012345678"
+                class={inputClass}
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                Optional. Comma-separated Discord user IDs allowed to DM the
+                bot. Leave empty to allow all DMs.
+              </p>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Server channel allowlist
+              </label>
+              <input
+                type="text"
+                value={channelAllowlist()}
+                onInput={(e) => setChannelAllowlist(e.currentTarget.value)}
+                placeholder="e.g. 987654321098765432"
+                class={inputClass}
+              />
+              <p class="mt-1 text-xs text-text-tertiary">
+                Optional. Comma-separated channel IDs the bot replies in (all
+                messages).
+              </p>
+            </div>
+
+            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={respondToMentions()}
+                onChange={(e) => setRespondToMentions(e.currentTarget.checked)}
+                class="rounded border-gray-300 dark:border-gray-600 text-primary focus:ring-primary"
+              />
+              Reply when the bot is @mentioned in a server
             </label>
-            <input
-              type="text"
-              value={allowlist()}
-              onInput={(e) => setAllowlist(e.currentTarget.value)}
-              placeholder="e.g. 15551234567, 15559876543"
-              class="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-            <p class="mt-1 text-xs text-text-tertiary">
-              Optional. Comma-separated phone numbers allowed to message this
-              channel. Leave empty to allow everyone.
-            </p>
-          </div>
+          </Show>
         </div>
 
         <div class="flex items-center justify-end gap-3 p-4 border-t dark:border-gray-700">
@@ -295,11 +408,11 @@ export function ChannelsPage() {
   const [showAdd, setShowAdd] = createSignal(false);
   const [confirmRemove, setConfirmRemove] = createSignal<string | null>(null);
 
-  const handleAdded = (id: string) => {
+  const handleAdded = (id: string, type: 'whatsapp' | 'discord') => {
     setShowAdd(false);
     void refetch();
     // Jump straight into linking the freshly-added channel.
-    void handleConnect(id);
+    void handleConnect(id, type);
   };
 
   const handleRemove = async (id: string) => {
@@ -314,11 +427,13 @@ export function ChannelsPage() {
     }
   };
 
-  const handleConnect = async (id: string) => {
+  const handleConnect = async (id: string, type: string) => {
     setPending(id);
     try {
       await connectChannel(id);
-      setQrOpen(id);
+      // Only WhatsApp needs the QR pairing panel; Discord connects via token
+      // and flips to Connected over the status WebSocket.
+      if (type === 'whatsapp') setQrOpen(id);
     } catch {
       // connect error — QR panel won't open, user can retry
     } finally {
@@ -343,7 +458,7 @@ export function ChannelsPage() {
       class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
     >
       <Plus class="w-4 h-4" />
-      Add WhatsApp
+      Add channel
     </button>
   );
 
@@ -382,15 +497,15 @@ export function ChannelsPage() {
                 No channels configured
               </h3>
               <p class="text-sm text-text-secondary mb-4 max-w-sm">
-                Connect a WhatsApp number so an agent can chat with you there.
-                Add a channel, then scan the QR code from your phone.
+                Connect WhatsApp or Discord so an agent can chat with people
+                there. Add a channel, then connect it.
               </p>
               <button
                 onClick={() => setShowAdd(true)}
                 class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
               >
                 <Plus class="w-4 h-4" />
-                Add WhatsApp channel
+                Add channel
               </button>
             </div>
           }
@@ -435,7 +550,9 @@ export function ChannelsPage() {
                         fallback={
                           <button
                             disabled={pending() === channel.id}
-                            onClick={() => handleConnect(channel.id)}
+                            onClick={() =>
+                              handleConnect(channel.id, channel.type)
+                            }
                             class="px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
                           >
                             {pending() === channel.id

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1359,6 +1359,55 @@ export async function addWhatsAppChannel(input: {
 }
 
 /**
+ * Add a Discord channel to the config. Like {@link addWhatsAppChannel}, this
+ * reads the current config, appends the entry, and persists it via the config
+ * PUT; the server encrypts the inline bot token at rest and reconciles the
+ * channel into the live registry so the caller can immediately connect it.
+ *
+ * Throws if the id already exists or the config write fails.
+ */
+export async function addDiscordChannel(input: {
+  id: string;
+  agentId: string;
+  botToken: string;
+  dmAllowlist?: string[];
+  channelAllowlist?: string[];
+  respondToMentions?: boolean;
+}): Promise<void> {
+  const current = await getConfig();
+  if (!('config' in current)) {
+    throw new Error('Failed to load config');
+  }
+  const config = current.config;
+  const channels = config.channels ?? [];
+  if (channels.some((c) => c.id === input.id)) {
+    throw new Error(`A channel with id "${input.id}" already exists`);
+  }
+  const entry: ChannelConfig = {
+    type: 'discord',
+    id: input.id,
+    agentId: input.agentId,
+    // Sent as plaintext inline; the server encrypts it to enc:v1: on save.
+    botToken: { kind: 'inline', value: input.botToken },
+    enabled: true,
+    respondToMentions: input.respondToMentions ?? true,
+    ...(input.dmAllowlist && input.dmAllowlist.length > 0
+      ? { dmAllowlist: input.dmAllowlist }
+      : {}),
+    ...(input.channelAllowlist && input.channelAllowlist.length > 0
+      ? { channelAllowlist: input.channelAllowlist }
+      : {}),
+  };
+  const result = await updateConfig({
+    ...config,
+    channels: [...channels, entry],
+  });
+  if ('error' in result) {
+    throw new Error(`Failed to save channel: ${result.error}`);
+  }
+}
+
+/**
  * Remove a channel from the config by id. The server reconciles the live
  * registry, disconnecting and dropping the channel.
  */

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -461,8 +461,8 @@ export type ProviderConfig =
   | GeminiProviderConfig;
 
 /**
- * A configured messaging channel. WhatsApp is the only type today; the shape
- * mirrors `whatsappChannelConfigSchema` in packages/config.
+ * A configured messaging channel. Shapes mirror the channel schemas in
+ * packages/config (`whatsappChannelConfigSchema` / `discordChannelConfigSchema`).
  */
 export type WhatsAppChannelConfig = {
   type: 'whatsapp';
@@ -472,7 +472,23 @@ export type WhatsAppChannelConfig = {
   enabled?: boolean;
 };
 
-export type ChannelConfig = WhatsAppChannelConfig;
+/** A secret value: env-var reference or inline (encrypted at rest server-side). */
+export type ChannelSecretValue =
+  | string
+  | { kind: 'env' | 'inline'; value: string };
+
+export type DiscordChannelConfig = {
+  type: 'discord';
+  id: string;
+  agentId: string;
+  botToken: ChannelSecretValue;
+  dmAllowlist?: string[];
+  channelAllowlist?: string[];
+  respondToMentions?: boolean;
+  enabled?: boolean;
+};
+
+export type ChannelConfig = WhatsAppChannelConfig | DiscordChannelConfig;
 
 /**
  * Application configuration

--- a/packages/config/src/app-config.test.ts
+++ b/packages/config/src/app-config.test.ts
@@ -309,6 +309,46 @@ describe('channel config validation', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts a valid discord channel config and defaults respondToMentions', () => {
+    const result = appConfigSchema.safeParse({
+      ...baseConfig,
+      channels: [
+        {
+          type: 'discord',
+          id: 'guild-bot',
+          agentId: 'my-agent',
+          botToken: { kind: 'inline', value: 'enc:v1:ciphertext' },
+          enabled: true,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    const ch = result.data?.channels?.[0];
+    expect(ch?.type).toBe('discord');
+    if (ch?.type === 'discord') {
+      expect(ch.respondToMentions).toBe(true);
+      expect(ch.botToken).toEqual({
+        kind: 'inline',
+        value: 'enc:v1:ciphertext',
+      });
+    }
+  });
+
+  it('rejects a discord channel config missing a bot token', () => {
+    const result = appConfigSchema.safeParse({
+      ...baseConfig,
+      channels: [
+        {
+          type: 'discord',
+          id: 'guild-bot',
+          agentId: 'my-agent',
+          enabled: true,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('rejects duplicate channel ids', () => {
     const result = appConfigSchema.safeParse({
       ...baseConfig,

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -2,6 +2,28 @@ import { z } from 'zod';
 import { httpTimeoutSchema, retrySchema, vendorFamilySchema } from './provider';
 
 // ============================================================================
+// Shared secret value schema (used by channels and MCP servers)
+// ============================================================================
+
+/**
+ * A single secret value. A plain string is the legacy shape (still accepted
+ * for backward compatibility with existing configs); the structured object
+ * form records whether the value is a `${VAR}`/env-var reference or an inline
+ * secret. Inline values are stored encrypted at rest — see
+ * `apps/server/src/mcp/secret-crypto.ts` — the `value` here is the
+ * `enc:v1:...` ciphertext, never the plaintext secret.
+ */
+export const mcpSecretValueSchema = z.union([
+  z.string(),
+  z.object({
+    kind: z.enum(['env', 'inline']),
+    value: z.string(),
+  }),
+]);
+
+export type McpSecretValue = z.infer<typeof mcpSecretValueSchema>;
+
+// ============================================================================
 // Channel Configuration
 // ============================================================================
 
@@ -13,13 +35,36 @@ export const whatsappChannelConfigSchema = z.object({
   enabled: z.boolean().default(true),
 });
 
+/**
+ * Discord channel. Authenticates with a bot token (no QR). The token is a
+ * secret value (env reference or inline-encrypted) stored via
+ * {@link mcpSecretValueSchema}. Trigger rules: DMs (optionally restricted to
+ * `dmAllowlist` user IDs), `@mentions` in servers when `respondToMentions`,
+ * and all messages in the server channels listed in `channelAllowlist`.
+ */
+export const discordChannelConfigSchema = z.object({
+  type: z.literal('discord'),
+  id: z.string().min(1),
+  agentId: z.string().min(1),
+  botToken: mcpSecretValueSchema,
+  /** Discord user IDs allowed to DM the bot; empty/absent = allow all DMs. */
+  dmAllowlist: z.array(z.string()).optional(),
+  /** Server channel IDs the bot responds to (all messages in them). */
+  channelAllowlist: z.array(z.string()).optional(),
+  /** In server channels, reply when the bot is @mentioned. */
+  respondToMentions: z.boolean().default(true),
+  enabled: z.boolean().default(true),
+});
+
 export const channelConfigSchema = z.discriminatedUnion('type', [
   whatsappChannelConfigSchema,
-  // Future channels added here: telegram, discord, slack, etc.
+  discordChannelConfigSchema,
+  // Future channels added here: telegram, slack, etc.
   // Adding a new channel = add its schema to this union. Zero other changes needed.
 ]);
 
 export type WhatsAppChannelConfig = z.infer<typeof whatsappChannelConfigSchema>;
+export type DiscordChannelConfig = z.infer<typeof discordChannelConfigSchema>;
 export type ChannelConfig = z.infer<typeof channelConfigSchema>;
 
 // ============================================================================
@@ -33,22 +78,6 @@ export type ChannelConfig = z.infer<typeof channelConfigSchema>;
  * See: https://github.com/imzodev/openaidy/issues/200
  */
 export const mcpServerTransportSchema = z.enum(['stdio', 'http']);
-
-/**
- * A single `env`/`headers` secret value. A plain string is the legacy shape
- * (still accepted for backward compatibility with existing configs); the
- * structured object form records whether the value is a `${VAR}` environment
- * reference or an inline secret. Inline values are stored encrypted at rest
- * — see `apps/server/src/mcp/secret-crypto.ts` — the `value` here is the
- * `enc:v1:...` ciphertext, never the plaintext secret.
- */
-export const mcpSecretValueSchema = z.union([
-  z.string(),
-  z.object({
-    kind: z.enum(['env', 'inline']),
-    value: z.string(),
-  }),
-]);
 
 /**
  * MCP server configuration schema
@@ -87,7 +116,6 @@ export const mcpServerConfigSchema = z
 
 export type McpServerConfig = z.infer<typeof mcpServerConfigSchema>;
 export type McpServerTransport = z.infer<typeof mcpServerTransportSchema>;
-export type McpSecretValue = z.infer<typeof mcpSecretValueSchema>;
 
 /**
  * MCP Server runtime status (returned by API)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,8 +3,13 @@ export * from './jwt-secret';
 export * from './provider';
 export * from './app-config';
 
-export type { WhatsAppChannelConfig, ChannelConfig } from './app-config.js';
+export type {
+  WhatsAppChannelConfig,
+  DiscordChannelConfig,
+  ChannelConfig,
+} from './app-config.js';
 export {
   whatsappChannelConfigSchema,
+  discordChannelConfigSchema,
   channelConfigSchema,
 } from './app-config.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       croner:
         specifier: ^10.0.1
         version: 10.0.1
+      discord.js:
+        specifier: ^14.16.3
+        version: 14.27.0
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -753,6 +756,34 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.3':
+    resolution: {integrity: sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -2121,6 +2152,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@selderee/plugin-htmlparser2@0.12.0':
     resolution: {integrity: sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==}
     peerDependencies:
@@ -2497,6 +2540,10 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   '@vue/compiler-core@3.5.35':
     resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
@@ -3114,6 +3161,13 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  discord-api-types@0.38.50:
+    resolution: {integrity: sha512-J2n/bpIETX3DQ6AJ7/0xbsTLmYiJQtO/LKcXKC1YDbB56OUwtDbdXOFE8Q4g8jVGHBR2VAy1+D4ngaIgkMNV9w==}
+
+  discord.js@14.27.0:
+    resolution: {integrity: sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==}
+    engines: {node: '>=18'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -4037,6 +4091,12 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -4071,6 +4131,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5100,6 +5163,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -5162,6 +5228,10 @@ packages:
 
   undici@6.26.0:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
+
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.24.3:
@@ -6000,6 +6070,55 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.50
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.50
+
+  '@discordjs/rest@2.6.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.50
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.27.0
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.50
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.3
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.50
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@docsearch/css@3.8.2': {}
 
@@ -6973,6 +7092,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.17.23
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@selderee/plugin-htmlparser2@0.12.0(selderee@0.12.0)':
     dependencies:
       domelementtype: 2.3.0
@@ -7449,6 +7577,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vladfrangu/async_event_emitter@2.4.7': {}
 
   '@vue/compiler-core@3.5.35':
     dependencies:
@@ -8068,6 +8198,27 @@ snapshots:
   didyoumean@1.2.2: {}
 
   dijkstrajs@1.0.3: {}
+
+  discord-api-types@0.38.50: {}
+
+  discord.js@14.27.0:
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.3
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.5
+      discord-api-types: 0.38.50
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.27.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   dlv@1.1.3: {}
 
@@ -9069,6 +9220,10 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.snakecase@4.1.1: {}
+
+  lodash@4.17.23: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -9100,6 +9255,8 @@ snapshots:
       solid-js: 1.9.11
 
   lz-string@1.5.0: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -10244,6 +10401,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-mixer@6.0.4: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -10312,6 +10471,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@6.26.0: {}
+
+  undici@6.27.0: {}
 
   undici@7.24.3: {}
 


### PR DESCRIPTION
## What

Adds a **Discord** messaging channel alongside WhatsApp, using `discord.js`. Discord authenticates with a **bot token** (no QR) and implements the base `IChannel`. It replies to:

- **DMs** (optionally restricted to a `dmAllowlist` of user IDs),
- **@mentions** in server channels (when `respondToMentions`), and
- **all messages** in an allowlisted set of server channel IDs (`channelAllowlist`).

## How it fits the existing design

The channel subsystem was already type-agnostic (registry, HTTP routes, WebSocket handler), so those needed **no changes**. The work is:

- **Config** (`packages/config/src/app-config.ts`): new `discordChannelConfigSchema` added to the channel discriminated union. `botToken` reuses the shared secret-value schema (`{ kind: 'env' | 'inline', value }`).
- **Token at rest** (`apps/server/src/config/service.ts`): `save()` now encrypts an inline Discord bot token before writing (`enc:v1:`), reusing the MCP `secret-crypto`. Idempotent; env-var references and already-encrypted values are left untouched.
- **Service** (`apps/server/src/channels/discord/`): `DiscordChannel` (discord.js `Client`, intents incl. the privileged `MessageContent`), token resolve/decrypt, DM/mention/channel gating, reply (chunked to Discord's 2000-char limit). Ignores `author.bot` so it never loops on its own replies.
- **Shared inbound handler** (`apps/server/src/channels/message-handler.ts`): extracted the channel-agnostic core; WhatsApp's handler is now a thin adapter over it. Session keys are namespaced by channel type (`discord:<id>:<userId>`), so nothing collides.
- **Dispatch** (`apps/server/src/channels/index.ts`): one `if (cfg.type === 'discord')` branch.
- **Frontend** (`apps/web`): channel-type selector + bot-token / DM-allowlist / channel-allowlist / respond-to-mentions fields in the Add dialog; the QR panel is gated to WhatsApp; `addDiscordChannel` API helper.

## Tests

- `channels/discord/service.test.ts` — mocks `discord.js`; covers connect/login, ready→connected, DM allow/deny, bot-message ignore, mention trigger (+ mention stripping), channel allowlist, and disconnect.
- `channels/message-handler.test.ts` — the shared handler (type-prefixed session keys, allowlist gating).
- config: Discord schema round-trip + **token-encryption-on-save** (idempotent; env refs untouched).
- `channels/reconcile.test.ts` — a Discord config entry builds a `DiscordChannel`.
- All existing WhatsApp tests stay green. Full run: **63 server + 37 config tests pass**; typecheck + eslint clean across server/web/config.

## Manual verification (for the reviewer)

1. Discord Developer Portal: create an app + bot, **enable the "Message Content Intent"** (privileged), invite the bot to a server (`bot` scope + Read/Send Messages).
2. Channels page → Add → **Discord** → paste the bot token, pick an agent, save → **Connect** (card flips to Connected, no QR).
3. DM the bot → reply. @mention it in a server (or post in an allowlisted channel) → reply; a non-allowlisted channel without a mention → no reply.
4. Confirm the token is stored as `enc:v1:…` in `openaidy.json` (never plaintext).

## Notes

- Draft pending a live smoke test against a real Discord bot.
- Changing an already-registered channel's config in place still needs a restart (reconcile only adds/removes ids) — same as WhatsApp.
- Docs/landing copy for Discord can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)