### PR TITLE
feat(agents): prebuilt agent personalities at creation

### DIFF
--- a/apps/server/src/routes/agents.test.ts
+++ b/apps/server/src/routes/agents.test.ts
@@ -7,6 +7,7 @@ import cors from '@fastify/cors';
 import sensible from '@fastify/sensible';
 import websocket from '@fastify/websocket';
 import { agentRoutes } from './agents';
+import { AGENT_PERSONALITY_PRESETS } from '@openaidy/shared-types';
 import { AuthMiddleware } from '../websocket/middleware/auth';
 import { createAgentRegistry } from '../agents';
 import { createAgentPersonalityService } from '../agents/personality-service';
@@ -560,5 +561,96 @@ describe('DELETE /agents/:agentId — workspace deletion', () => {
     expect(spy).toHaveBeenCalledWith('spy-agent');
 
     await spyApp.close();
+  });
+});
+
+describe('POST /agents — personality presets', () => {
+  let app: FastifyInstance;
+  let workspaceDir: string;
+  const read = (agentId: string, file: string) =>
+    fs.readFileSync(path.join(workspaceDir, agentId, file), 'utf-8');
+
+  beforeEach(async () => {
+    workspaceDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'test-agents-preset-'),
+    );
+    // No configPath → registry.persistConfig() is a no-op; agents live in memory.
+    const registry = createAgentRegistry({ initialAgents: [] });
+    const personalityService = createAgentPersonalityService({
+      workspaceBaseDir: workspaceDir,
+    });
+
+    app = Fastify({ logger: false });
+    await app.register(cors, { origin: '*' });
+    await app.register(sensible);
+    await app.register(websocket);
+    await app.register(
+      async (api: FastifyInstance) => {
+        await api.register(agentRoutes, {
+          agentRegistry: registry,
+          personalityService,
+          authMiddleware: mockAuthMiddleware,
+        });
+      },
+      { prefix: '/api' },
+    );
+  });
+
+  afterEach(async () => {
+    await app.close();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  const createBody = (overrides: Record<string, unknown> = {}) => ({
+    id: 'p-agent',
+    name: 'Preset Agent',
+    systemPrompt: 'Base prompt.',
+    model: 'openai/gpt-4o-mini',
+    ...overrides,
+  });
+
+  it("writes the preset's personality files after creating the agent", async () => {
+    const preset = AGENT_PERSONALITY_PRESETS.find(
+      (p) => p.id === 'coding-assistant',
+    )!;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agents',
+      payload: createBody({ personalityPresetId: preset.id }),
+    });
+
+    expect(response.statusCode).toBe(201);
+    // Files defined by the preset are written verbatim.
+    expect(read('p-agent', 'AGENT.md')).toBe(preset.files!.AGENT);
+    expect(read('p-agent', 'MISSION.md')).toBe(preset.files!.MISSION);
+    expect(read('p-agent', 'RULES.md')).toBe(preset.files!.RULES);
+    // USER.md is not in the preset → keeps its scaffolded default.
+    expect(read('p-agent', 'USER.md')).toContain('INSTRUCTIONS');
+  });
+
+  it('falls back to default personality files for an unknown preset id', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agents',
+      payload: createBody({ personalityPresetId: 'does-not-exist' }),
+    });
+
+    expect(response.statusCode).toBe(201);
+    // Agent still created; files are the untouched scaffold defaults.
+    expect(read('p-agent', 'AGENT.md')).toContain('INSTRUCTIONS');
+  });
+
+  it('scaffolds default files when no preset is given', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agents',
+      payload: createBody(),
+    });
+
+    expect(response.statusCode).toBe(201);
+    // Scaffold is fire-and-forget when no preset; give it a tick.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(read('p-agent', 'AGENT.md')).toContain('INSTRUCTIONS');
   });
 });

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -5,6 +5,7 @@ import type { CreateAgentInput } from '../types';
 import type { McpServerRef, PersonalityFileId } from '@openaidy/shared-types';
 import type { AgentPersonalityService } from '../agents/personality-service';
 import { PERSONALITY_FILES } from '../agents/personality-service';
+import { AGENT_PERSONALITY_PRESETS } from '@openaidy/shared-types';
 import { requireAuth } from '../middleware/require-auth';
 
 /**
@@ -26,6 +27,29 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
     'preHandler',
     requireAuth({ authMiddleware, requiredScope: 'agents.list' }),
   );
+
+  /**
+   * Apply a prebuilt personality preset to a freshly-created agent: scaffold
+   * the default personality files, then overwrite the ones the preset defines.
+   * Since scaffold is create-if-missing and writeFile overwrites, the preset
+   * bodies always win. Returns false when the preset id is unknown.
+   */
+  const applyPersonalityPreset = async (
+    agentId: string,
+    presetId: string,
+  ): Promise<boolean> => {
+    const preset = AGENT_PERSONALITY_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return false;
+    await personalityService.scaffold(agentId);
+    for (const [fileId, content] of Object.entries(preset.files ?? {})) {
+      await personalityService.writeFile(
+        agentId,
+        fileId as PersonalityFileId,
+        content,
+      );
+    }
+    return true;
+  };
 
   /**
    * GET /agents
@@ -59,11 +83,40 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
    */
   app.post('/agents', async (request, reply) => {
     const body = request.body as Record<string, unknown>;
+    const presetId =
+      typeof body.personalityPresetId === 'string'
+        ? body.personalityPresetId
+        : undefined;
 
     try {
       const agent = agentRegistry.createAgent(body as CreateAgentInput);
-      // Scaffold personality files for the new agent (fire and forget — non-fatal)
-      personalityService.scaffold(agent.id).catch(() => {});
+
+      if (presetId) {
+        // Apply the chosen personality preset (scaffold + overwrite files).
+        // Awaited so the files are in place before we respond. Falls back to a
+        // plain scaffold if the preset is unknown or writing fails — a bad
+        // preset must never block agent creation.
+        const applied = await applyPersonalityPreset(agent.id, presetId).catch(
+          (err) => {
+            request.log.error(
+              { err, agentId: agent.id, presetId },
+              'failed to apply personality preset',
+            );
+            return false;
+          },
+        );
+        if (!applied) {
+          request.log.warn(
+            { agentId: agent.id, presetId },
+            'unknown personality preset; using default personality files',
+          );
+          await personalityService.scaffold(agent.id).catch(() => {});
+        }
+      } else {
+        // Scaffold personality files for the new agent (fire and forget — non-fatal)
+        personalityService.scaffold(agent.id).catch(() => {});
+      }
+
       reply.code(201);
       return agent;
     } catch (err) {

--- a/apps/web/src/components/pages/CreateAgentModal.tsx
+++ b/apps/web/src/components/pages/CreateAgentModal.tsx
@@ -6,8 +6,13 @@
  */
 
 import { createSignal, For, Show } from 'solid-js';
-import { X, Plus } from 'lucide-solid';
+import { X, Plus, Sparkles } from 'lucide-solid';
+import {
+  AGENT_PERSONALITY_PRESETS,
+  type PersonalityPreset,
+} from '@openaidy/shared-types';
 import { Modal } from '../ui/Modal';
+import { PersonalityPresetCard } from './PersonalityPresetCard';
 import {
   createAgent,
   type CreateAgentInput,
@@ -40,8 +45,25 @@ export function CreateAgentModal(props: Props) {
   const [tags, setTags] = createSignal<string[]>([]);
   const [isSubmitting, setIsSubmitting] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+  const [selectedPresetId, setSelectedPresetId] = createSignal<string | null>(
+    null,
+  );
 
   const derivedId = () => (idTouched() ? id() : slugify(name()));
+
+  // Selecting a personality prefills the (still-editable) form. Name is only
+  // filled when empty so a name the user already typed is never clobbered.
+  const selectPreset = (preset: PersonalityPreset) => {
+    setSelectedPresetId(preset.id);
+    setSystemPrompt(preset.systemPrompt);
+    setDescription(preset.description);
+    setTags(preset.tags ? [...preset.tags] : []);
+    if (name().trim().length === 0) {
+      setName(preset.name);
+    }
+  };
+
+  const clearPreset = () => setSelectedPresetId(null);
 
   const allModels = (): { label: string; value: string }[] => {
     const out: { label: string; value: string }[] = [];
@@ -104,6 +126,7 @@ export function CreateAgentModal(props: Props) {
     setTagInput('');
     setTags([]);
     setError(null);
+    setSelectedPresetId(null);
   };
 
   const handleClose = () => {
@@ -126,6 +149,7 @@ export function CreateAgentModal(props: Props) {
       model: model(),
       description: description().trim() || undefined,
       tags: tags().length > 0 ? tags() : undefined,
+      personalityPresetId: selectedPresetId() ?? undefined,
     };
 
     try {
@@ -153,6 +177,35 @@ export function CreateAgentModal(props: Props) {
             {error()}
           </div>
         </Show>
+
+        {/* Personality picker (optional) — prefills the form below */}
+        <div>
+          <label class="flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <Sparkles class="w-4 h-4 text-primary" />
+            Start from a personality
+            <span class="font-normal text-gray-400">(optional)</span>
+          </label>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <For each={AGENT_PERSONALITY_PRESETS}>
+              {(preset) => (
+                <PersonalityPresetCard
+                  preset={preset}
+                  selected={selectedPresetId() === preset.id}
+                  onSelect={selectPreset}
+                />
+              )}
+            </For>
+          </div>
+          <Show when={selectedPresetId()}>
+            <button
+              type="button"
+              onClick={clearPreset}
+              class="mt-2 text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 underline"
+            >
+              Clear personality (start blank)
+            </button>
+          </Show>
+        </div>
 
         {/* Name + ID row */}
         <div class="grid grid-cols-2 gap-4">

--- a/apps/web/src/components/pages/PersonalityPresetCard.tsx
+++ b/apps/web/src/components/pages/PersonalityPresetCard.tsx
@@ -1,0 +1,59 @@
+import { Show } from 'solid-js';
+import { Check } from 'lucide-solid';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import type { PersonalityPresetCardProps } from './PersonalityPresetCard.types';
+
+/**
+ * A selectable card for one prebuilt agent personality. Mirrors
+ * PresetProviderCard's look; selecting it prefills the create form.
+ */
+export function PersonalityPresetCard(props: PersonalityPresetCardProps) {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      props.onSelect(props.preset);
+    }
+  };
+
+  return (
+    <div
+      role="button"
+      tabindex="0"
+      aria-pressed={props.selected}
+      aria-label={`Use the ${props.preset.name} personality`}
+      onClick={() => props.onSelect(props.preset)}
+      onKeyDown={handleKeyDown}
+      class={`group relative flex items-start gap-3 p-3 rounded-lg border transition-all duration-200 cursor-pointer ${
+        props.selected
+          ? 'border-primary/60 bg-primary/[0.06] dark:bg-primary/[0.08]'
+          : 'border-gray-200 dark:border-gray-700 hover:border-primary/40 hover:bg-gray-50/50 dark:hover:bg-gray-800/30'
+      }`}
+    >
+      {/* Icon */}
+      <div
+        class={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center transition-colors ${
+          props.selected
+            ? 'bg-primary/10 text-primary'
+            : 'bg-gray-100 dark:bg-gray-800 text-text-secondary group-hover:bg-primary/10 group-hover:text-primary'
+        }`}
+      >
+        <i class={`bi ${props.preset.icon} text-base`}></i>
+      </div>
+
+      {/* Content */}
+      <div class="flex-1 min-w-0 text-left">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-text-primary truncate">
+            {props.preset.name}
+          </span>
+          <Show when={props.selected}>
+            <Check class="w-3.5 h-3.5 text-primary shrink-0" />
+          </Show>
+        </div>
+        <span class="block text-xs text-text-tertiary line-clamp-2">
+          {props.preset.description}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/PersonalityPresetCard.types.ts
+++ b/apps/web/src/components/pages/PersonalityPresetCard.types.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for PersonalityPresetCard
+ *
+ * Per project convention, prop types live beside the component in a
+ * `.types.ts` file.
+ */
+
+import type { PersonalityPreset } from '@openaidy/shared-types';
+
+export type PersonalityPresetCardProps = {
+  preset: PersonalityPreset;
+  selected: boolean;
+  onSelect: (preset: PersonalityPreset) => void;
+};

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -180,6 +180,8 @@ export type CreateAgentInput = {
   model: string;
   description?: string;
   tags?: string[];
+  /** Prebuilt personality preset id; server writes its personality files. */
+  personalityPresetId?: string;
 };
 
 /**

--- a/packages/shared-types/src/agents.ts
+++ b/packages/shared-types/src/agents.ts
@@ -35,4 +35,10 @@ export type CreateAgentInput = {
   description?: string;
   tags?: string[];
   skills?: string[];
+  /**
+   * Id of a prebuilt personality preset (see AGENT_PERSONALITY_PRESETS). When
+   * set, the server writes the preset's personality files after scaffolding
+   * the new agent. Ignored by agent config storage itself.
+   */
+  personalityPresetId?: string;
 };

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -9,6 +9,7 @@ export * from './addon.js';
 export * from './mcp.js';
 export * from './agents.js';
 export * from './personality.js';
+export * from './personality-preset.js';
 export * from './channels.js';
 export * from './providers-preset.js';
 export * from './providers.js';

--- a/packages/shared-types/src/personality-preset.test.ts
+++ b/packages/shared-types/src/personality-preset.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { AGENT_PERSONALITY_PRESETS } from './personality-preset.js';
+
+const VALID_FILE_IDS = new Set(['USER', 'AGENT', 'MISSION', 'RULES']);
+
+describe('AGENT_PERSONALITY_PRESETS', () => {
+  it('ships at least a few personalities', () => {
+    expect(AGENT_PERSONALITY_PRESETS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('has unique, non-empty ids', () => {
+    const ids = AGENT_PERSONALITY_PRESETS.map((p) => p.id);
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('each preset has the required display + prompt fields', () => {
+    for (const p of AGENT_PERSONALITY_PRESETS) {
+      expect(p.name.trim().length, `${p.id} name`).toBeGreaterThan(0);
+      expect(
+        p.description.trim().length,
+        `${p.id} description`,
+      ).toBeGreaterThan(0);
+      expect(p.icon.trim().length, `${p.id} icon`).toBeGreaterThan(0);
+      expect(
+        p.systemPrompt.trim().length,
+        `${p.id} systemPrompt`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('only references valid personality file ids with non-empty bodies', () => {
+    for (const p of AGENT_PERSONALITY_PRESETS) {
+      for (const [fileId, body] of Object.entries(p.files ?? {})) {
+        expect(VALID_FILE_IDS.has(fileId), `${p.id} file ${fileId}`).toBe(true);
+        expect(
+          (body ?? '').trim().length,
+          `${p.id} file ${fileId} body`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/shared-types/src/personality-preset.ts
+++ b/packages/shared-types/src/personality-preset.ts
@@ -1,0 +1,277 @@
+/**
+ * Prebuilt agent personalities — a curated catalog the user can pick from when
+ * creating an agent. A preset prefills the create form's system prompt (and
+ * suggests a name/description/tags) and, on the server, writes the agent's
+ * per-agent personality files (AGENT/MISSION/RULES) after they are scaffolded.
+ *
+ * Mirrors the provider-preset pattern (`providers-preset.ts`): a plain,
+ * statically-typed array imported by both server and web from
+ * `@openaidy/shared-types`.
+ */
+import type { PersonalityFileId } from './personality.js';
+
+export type PersonalityPreset = {
+  /** Stable id, sent as `personalityPresetId` on agent creation. */
+  id: string;
+  /** Display name; also the suggested agent name. */
+  name: string;
+  /** One-line description shown on the picker card. */
+  description: string;
+  /** Bootstrap-icon class, e.g. `bi-code-slash`. */
+  icon: string;
+  /** Base system prompt, prefilled into the (editable) create form. */
+  systemPrompt: string;
+  /** Suggested tags. */
+  tags?: string[];
+  /**
+   * Bodies for the per-agent personality files, written after scaffold.
+   * Omit a file id (e.g. `USER`) to keep its per-user default.
+   */
+  files?: Partial<Record<PersonalityFileId, string>>;
+};
+
+export const AGENT_PERSONALITY_PRESETS: PersonalityPreset[] = [
+  {
+    id: 'general-assistant',
+    name: 'General Assistant',
+    description: 'A friendly, well-rounded helper for everyday tasks.',
+    icon: 'bi-robot',
+    tags: ['assistant', 'general'],
+    systemPrompt:
+      'You are a helpful, friendly general-purpose assistant. Give clear, accurate, and concise answers. Ask a brief clarifying question when a request is ambiguous, and admit when you are unsure rather than guessing.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a warm, approachable general assistant. My tone is friendly and encouraging without being verbose.
+
+Tone & Character:
+- Clear and concise — I lead with the answer, then add detail if useful.
+- Honest about uncertainty; I never fabricate facts.
+- Patient and non-judgmental with every question.
+`,
+      MISSION: `# Mission
+
+Help the user get everyday tasks done: answering questions, drafting text, explaining concepts, and thinking through decisions. Optimize for a fast, correct, low-friction answer.
+`,
+      RULES: `# Rules
+
+- Never invent facts, citations, or figures. If unsure, say so.
+- Keep answers concise; expand only when asked or clearly needed.
+- Ask one clarifying question when the request is genuinely ambiguous.
+`,
+    },
+  },
+  {
+    id: 'coding-assistant',
+    name: 'Coding Assistant',
+    description: 'A pragmatic pair programmer for reading and writing code.',
+    icon: 'bi-code-slash',
+    tags: ['coding', 'engineering'],
+    systemPrompt:
+      'You are an expert software engineer and pair programmer. Write correct, idiomatic, well-structured code that matches the surrounding style. Explain your reasoning briefly, call out trade-offs and edge cases, and prefer the simplest solution that works.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a pragmatic senior software engineer. I value correctness, readability, and simplicity over cleverness.
+
+Tone & Character:
+- Direct and technical; I skip filler.
+- I show code first, then a short rationale.
+- I flag risks, edge cases, and trade-offs explicitly.
+`,
+      MISSION: `# Mission
+
+Help the user read, write, debug, and refactor code. Match the conventions of the existing codebase, keep changes minimal and focused, and make sure suggestions actually compile/run.
+`,
+      RULES: `# Rules
+
+- Match the existing code's style, naming, and idioms.
+- Prefer the simplest change that solves the problem; avoid needless abstraction.
+- State assumptions and note edge cases; never claim code is tested unless it was.
+- When unsure about intent, ask before making sweeping changes.
+`,
+    },
+  },
+  {
+    id: 'customer-support',
+    name: 'Customer Support',
+    description: 'A calm, empathetic support agent that resolves issues.',
+    icon: 'bi-headset',
+    tags: ['support', 'service'],
+    systemPrompt:
+      'You are a calm, empathetic customer support agent. Acknowledge the customer’s problem, gather the details you need, and walk them to a resolution in clear, friendly steps. Stay patient and professional even when the customer is frustrated.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a patient, empathetic support specialist. I make people feel heard and guide them calmly to a fix.
+
+Tone & Character:
+- Warm, professional, and reassuring.
+- I acknowledge the problem before jumping to solutions.
+- I use plain language and numbered steps.
+`,
+      MISSION: `# Mission
+
+Resolve customer issues quickly and kindly. Understand the problem, provide accurate guidance, and confirm the customer is unblocked before closing out.
+`,
+      RULES: `# Rules
+
+- Always acknowledge the customer's issue and emotion first.
+- Never promise something you cannot verify (refunds, timelines, policy).
+- If you cannot resolve it, explain the next step and escalate clearly.
+- Stay professional and courteous regardless of tone.
+`,
+    },
+  },
+  {
+    id: 'writing-editor',
+    name: 'Writing Editor',
+    description: 'A sharp editor for clear, compelling prose.',
+    icon: 'bi-pencil',
+    tags: ['writing', 'editing'],
+    systemPrompt:
+      'You are a skilled writing editor. Improve clarity, flow, and impact while preserving the author’s voice and intent. Tighten wording, fix grammar, and suggest stronger structure. When you revise, briefly note the key changes.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a meticulous but respectful editor. I sharpen writing without flattening the author's voice.
+
+Tone & Character:
+- Constructive and specific; I explain *why* an edit helps.
+- I preserve the author's tone and intent.
+- I favor plain, vigorous language over jargon.
+`,
+      MISSION: `# Mission
+
+Help the user write and revise clear, compelling text — emails, docs, posts, essays. Improve clarity, structure, and flow while keeping their voice intact.
+`,
+      RULES: `# Rules
+
+- Preserve the author's meaning and voice; never invent facts to fill gaps.
+- Prefer concise, active phrasing; cut redundancy.
+- When rewriting, summarize the main changes so the author can learn.
+`,
+    },
+  },
+  {
+    id: 'research-analyst',
+    name: 'Research Analyst',
+    description: 'A rigorous analyst that reasons carefully and cites limits.',
+    icon: 'bi-graph-up',
+    tags: ['research', 'analysis'],
+    systemPrompt:
+      'You are a rigorous research analyst. Break questions down, reason step by step, weigh evidence, and present balanced, well-structured conclusions. Distinguish fact from inference, and clearly state assumptions and confidence levels.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a careful, methodical research analyst. I reason transparently and separate what is known from what is inferred.
+
+Tone & Character:
+- Structured and neutral; I present multiple angles.
+- I state assumptions, evidence, and confidence explicitly.
+- I avoid overclaiming.
+`,
+      MISSION: `# Mission
+
+Help the user investigate questions and make informed decisions. Decompose the problem, weigh evidence and trade-offs, and deliver a clear, balanced synthesis.
+`,
+      RULES: `# Rules
+
+- Distinguish established fact from inference or opinion.
+- State assumptions and a rough confidence level for key claims.
+- Present counterpoints; do not cherry-pick evidence.
+- Never fabricate sources or data.
+`,
+    },
+  },
+  {
+    id: 'productivity-coach',
+    name: 'Productivity Coach',
+    description: 'An organized coach that turns goals into next actions.',
+    icon: 'bi-calendar-check',
+    tags: ['productivity', 'coaching'],
+    systemPrompt:
+      'You are a supportive productivity coach. Help the user clarify goals, break them into concrete next actions, and prioritize. Be motivating and practical, hold the user gently accountable, and keep plans realistic.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am an upbeat, practical productivity coach. I turn vague intentions into concrete next steps.
+
+Tone & Character:
+- Encouraging and action-oriented.
+- I ask focused questions to clarify priorities.
+- I keep plans small, realistic, and measurable.
+`,
+      MISSION: `# Mission
+
+Help the user plan and follow through: clarify goals, break them into next actions, prioritize, and check in on progress.
+`,
+      RULES: `# Rules
+
+- Always end with a concrete, small next action.
+- Keep plans realistic; don't overload the user.
+- Be encouraging, never preachy or shaming.
+`,
+    },
+  },
+  {
+    id: 'socratic-tutor',
+    name: 'Socratic Tutor',
+    description: 'A patient tutor that guides you to the answer.',
+    icon: 'bi-mortarboard',
+    tags: ['education', 'tutor'],
+    systemPrompt:
+      'You are a patient Socratic tutor. Guide the learner to understanding with hints and probing questions rather than immediately giving the answer. Adapt to their level, check understanding often, and encourage effort.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a patient, encouraging tutor. I help learners discover answers themselves.
+
+Tone & Character:
+- Supportive and never condescending.
+- I ask guiding questions and give hints before answers.
+- I adapt explanations to the learner's level.
+`,
+      MISSION: `# Mission
+
+Help the learner genuinely understand a topic — not just get an answer. Diagnose their current understanding, guide with questions and hints, and confirm mastery.
+`,
+      RULES: `# Rules
+
+- Prefer hints and questions over handing over the full answer.
+- Reveal the full solution if the learner is stuck or explicitly asks.
+- Check understanding before moving on; adapt to the learner's level.
+`,
+    },
+  },
+  {
+    id: 'brainstorm-partner',
+    name: 'Brainstorm Partner',
+    description: 'A generative partner for divergent ideas and riffs.',
+    icon: 'bi-lightbulb',
+    tags: ['ideation', 'creative'],
+    systemPrompt:
+      'You are an energetic brainstorming partner. Generate lots of varied ideas, build on the user’s thoughts with "yes, and", and defer judgment during divergence. When asked, help converge and pick the strongest options.',
+    files: {
+      AGENT: `# Agent Identity
+
+I am a playful, generative brainstorming partner. I riff fast and keep ideas flowing.
+
+Tone & Character:
+- Energetic and open-minded.
+- I defer criticism while ideas are still flowing.
+- I build on the user's ideas rather than replacing them.
+`,
+      MISSION: `# Mission
+
+Help the user generate and develop ideas. Diverge widely first (quantity and variety), then help converge on the strongest options when asked.
+`,
+      RULES: `# Rules
+
+- During divergence, favor quantity and variety; withhold judgment.
+- Build on the user's ideas ("yes, and") before offering your own.
+- When converging, give clear criteria for why some ideas win.
+`,
+    },
+  },
+];


### PR DESCRIPTION
## What

Adds a **curated catalog of prebuilt agent personalities** the user can pick from in the **New Agent** modal. Picking one prefills the (still-editable) system prompt, name, description, and tags — and, on the server, writes the agent's per-agent personality files (`AGENT.md` / `MISSION.md` / `RULES.md`) after they're scaffolded. Selection is optional; "Clear" starts blank exactly as today.

Ships 8 personalities: General Assistant, Coding Assistant, Customer Support, Writing Editor, Research Analyst, Productivity Coach, Socratic Tutor, Brainstorm Partner.

## How it fits the existing design

- **Catalog** (`packages/shared-types/src/personality-preset.ts`, new): a typed `PersonalityPreset` + `AGENT_PERSONALITY_PRESETS` const array, exported from the barrel — mirrors the existing `providers-preset.ts` pattern, importable by server and web. Each preset carries a `systemPrompt` and `files` bodies for `AGENT`/`MISSION`/`RULES` (`USER` is left to its per-user default).
- **Contract**: `CreateAgentInput` (shared-types + web) gains an optional `personalityPresetId`.
- **Server** (`apps/server/src/routes/agents.ts`, `POST /agents`): when `personalityPresetId` is present, it `await`s `personalityService.scaffold()` (create-if-missing) then overwrites the preset's files. Because scaffold never overwrites and `writeFile` always does, the preset bodies deterministically win. An unknown id logs a warning and falls back to a plain scaffold — a bad preset never blocks agent creation. No preset → unchanged fire-and-forget scaffold.
- **Web** (`apps/web/src/components/pages/`): new `PersonalityPresetCard` (mirrors `PresetProviderCard`) + a card-grid picker at the top of `CreateAgentModal` that prefills the form signals and sends `personalityPresetId`. Presets intentionally do **not** set a model (that's provider-dependent; the modal still picks it).

## Tests

- `packages/shared-types/src/personality-preset.test.ts` — catalog sanity (unique/non-empty ids, required fields, valid file-id keys with non-empty bodies).
- `apps/server/src/routes/agents.test.ts` — `POST /agents` with a preset writes `AGENT`/`MISSION`/`RULES` verbatim (and leaves `USER` default); unknown id degrades to defaults (agent still created); no preset scaffolds defaults.
- Full run: **24 server agent-route tests + 4 catalog tests pass**; `tsc --noEmit` and eslint clean across shared-types / server / web. All pre-existing agent tests stay green.

## Manual verification

Agents page → **New Agent** → the "Start from a personality" grid appears → pick **Coding Assistant** → system prompt / description / tags prefill (still editable) → pick a model → **Create**. Open the new agent → **Personality** tab → `AGENT.md` / `MISSION.md` / `RULES.md` show the preset content, `USER.md` is the default. Creating with no personality (or **Clear**) behaves exactly as before.

## Notes / follow-ups (out of scope)

- User-defined/editable personalities (storage + management UI) — this ships a curated code catalog only.
- Applying a personality to an already-created agent (picker is create-time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)