### PR TITLE
feat(workspace): download files from the agents workspace tab

### DIFF
--- a/apps/web/src/components/workspace/FileExplorer.test.tsx
+++ b/apps/web/src/components/workspace/FileExplorer.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../lib/api', () => ({
   writeWorkspaceFile: vi.fn(),
   renameWorkspaceFile: vi.fn(),
   deleteWorkspaceFile: vi.fn(),
+  downloadWorkspaceFile: vi.fn(),
 }));
 
 describe('FileExplorer', () => {
@@ -186,6 +187,51 @@ describe('FileExplorer', () => {
     );
 
     promptSpy.mockRestore();
+  });
+
+  it('should download a file when the download button is clicked', async () => {
+    vi.mocked(api.listWorkspaceFiles).mockResolvedValue({ items: mockFiles });
+    vi.mocked(api.downloadWorkspaceFile).mockResolvedValue(undefined);
+
+    render(() => <FileExplorer agentId="test-agent" />);
+
+    await screen.findByText('file1.txt');
+    fireEvent.click(screen.getByLabelText('Download file1.txt'));
+
+    expect(api.downloadWorkspaceFile).toHaveBeenCalledWith(
+      'test-agent',
+      'file1.txt',
+      'file1.txt',
+    );
+  });
+
+  it('should not select a file when its download button is clicked', async () => {
+    vi.mocked(api.listWorkspaceFiles).mockResolvedValue({ items: mockFiles });
+    vi.mocked(api.downloadWorkspaceFile).mockResolvedValue(undefined);
+
+    const onFileSelect = vi.fn();
+    render(() => (
+      <FileExplorer agentId="test-agent" onFileSelect={onFileSelect} />
+    ));
+
+    await screen.findByText('file1.txt');
+    fireEvent.click(screen.getByLabelText('Download file1.txt'));
+
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('should show a download error in the error banner', async () => {
+    vi.mocked(api.listWorkspaceFiles).mockResolvedValue({ items: mockFiles });
+    vi.mocked(api.downloadWorkspaceFile).mockRejectedValue(
+      new Error('Network down'),
+    );
+
+    render(() => <FileExplorer agentId="test-agent" />);
+
+    await screen.findByText('file1.txt');
+    fireEvent.click(screen.getByLabelText('Download file1.txt'));
+
+    expect(await screen.findByText('Network down')).toBeInTheDocument();
   });
 
   it('should sort directories before files', async () => {

--- a/apps/web/src/components/workspace/FileExplorer.tsx
+++ b/apps/web/src/components/workspace/FileExplorer.tsx
@@ -7,12 +7,15 @@ import {
   Plus,
   Pencil,
   Trash2,
+  Download,
+  Loader2,
 } from 'lucide-solid';
 import {
   writeWorkspaceFile,
   deleteWorkspaceFile,
   renameWorkspaceFile,
   listWorkspaceFiles,
+  downloadWorkspaceFile,
   type WorkspaceFileInfo,
   type WorkspaceFileListResponse,
   type WorkspaceWriteResponse,
@@ -59,6 +62,9 @@ export function FileExplorer(props: FileExplorerProps) {
   const [isLoading, setIsLoading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [selectedFile, setSelectedFile] = createSignal<string | null>(null);
+  const [downloadingPaths, setDownloadingPaths] = createSignal<Set<string>>(
+    new Set(),
+  );
 
   const canWrite = () => props.canWrite ?? true;
 
@@ -227,6 +233,31 @@ export function FileExplorer(props: FileExplorerProps) {
     await fetchFiles(currentPath());
   };
 
+  const handleDownloadFile = async (item: FileNode, event: MouseEvent) => {
+    event.stopPropagation();
+    if (item.isDirectory) {
+      return;
+    }
+
+    setError(null);
+    setDownloadingPaths((prev) => {
+      const next = new Set(prev);
+      next.add(item.path);
+      return next;
+    });
+    try {
+      await downloadWorkspaceFile(props.agentId, item.path, item.name);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to download file');
+    } finally {
+      setDownloadingPaths((prev) => {
+        const next = new Set(prev);
+        next.delete(item.path);
+        return next;
+      });
+    }
+  };
+
   const formatSize = (bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -343,6 +374,28 @@ export function FileExplorer(props: FileExplorerProps) {
                   <span class="text-xs text-text-tertiary hidden lg:inline">
                     {formatDate(item.modifiedAt)}
                   </span>
+
+                  {/* Download — available regardless of write access since
+                      the raw route only needs read permission. */}
+                  <Show when={!item.isDirectory}>
+                    <div class="opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        type="button"
+                        class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Download file"
+                        aria-label={`Download ${item.name}`}
+                        disabled={downloadingPaths().has(item.path)}
+                        onClick={(event) => handleDownloadFile(item, event)}
+                      >
+                        <Show
+                          when={downloadingPaths().has(item.path)}
+                          fallback={<Download class="w-3.5 h-3.5" />}
+                        >
+                          <Loader2 class="w-3.5 h-3.5 animate-spin" />
+                        </Show>
+                      </button>
+                    </div>
+                  </Show>
 
                   <Show when={!item.isDirectory && canWrite()}>
                     <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/apps/web/src/components/workspace/WorkspaceEditor.test.tsx
+++ b/apps/web/src/components/workspace/WorkspaceEditor.test.tsx
@@ -27,6 +27,7 @@ vi.mock('./CodeMirrorEditor', () => ({
 vi.mock('../../lib/api', () => ({
   readWorkspaceFile: vi.fn(),
   updateWorkspaceFile: vi.fn(),
+  downloadWorkspaceFile: vi.fn(),
 }));
 
 describe('WorkspaceEditor', () => {
@@ -159,5 +160,51 @@ describe('WorkspaceEditor', () => {
       screen.getByText('Detected type: application/octet-stream'),
     ).toBeInTheDocument();
     expect(api.updateWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it('downloads the open file when the Download button is clicked', async () => {
+    vi.mocked(api.readWorkspaceFile).mockResolvedValue({
+      content: 'hello world',
+      path: 'test.txt',
+      isText: true,
+      mimeType: 'text/plain',
+      size: 11,
+      modifiedAt: '2026-04-05T10:00:00Z',
+      isTooLarge: false,
+    });
+    vi.mocked(api.downloadWorkspaceFile).mockResolvedValue(undefined);
+
+    render(() => <WorkspaceEditor agentId="default" selectedFile={file} />);
+
+    await screen.findByDisplayValue('hello world');
+    fireEvent.click(screen.getByTitle('Download file'));
+
+    expect(api.downloadWorkspaceFile).toHaveBeenCalledWith(
+      'default',
+      'test.txt',
+      'test.txt',
+    );
+  });
+
+  it('surfaces download errors via the error banner', async () => {
+    vi.mocked(api.readWorkspaceFile).mockResolvedValue({
+      content: 'hello world',
+      path: 'test.txt',
+      isText: true,
+      mimeType: 'text/plain',
+      size: 11,
+      modifiedAt: '2026-04-05T10:00:00Z',
+      isTooLarge: false,
+    });
+    vi.mocked(api.downloadWorkspaceFile).mockRejectedValue(
+      new Error('File too large'),
+    );
+
+    render(() => <WorkspaceEditor agentId="default" selectedFile={file} />);
+
+    await screen.findByDisplayValue('hello world');
+    fireEvent.click(screen.getByTitle('Download file'));
+
+    expect(await screen.findByText('File too large')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/workspace/WorkspaceEditor.tsx
+++ b/apps/web/src/components/workspace/WorkspaceEditor.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Save,
   RotateCcw,
+  Download,
   Loader2,
   FileWarning,
   Image,
@@ -20,6 +21,7 @@ import {
   readWorkspaceFile,
   updateWorkspaceFile,
   fetchWorkspaceFileBlob,
+  downloadWorkspaceFile,
   type WorkspaceErrorResponse,
   type WorkspaceFileInfo,
   type WorkspaceFileContentResponse,
@@ -63,6 +65,7 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
   >(null);
   const [isLoading, setIsLoading] = createSignal(false);
   const [isSaving, setIsSaving] = createSignal(false);
+  const [isDownloading, setIsDownloading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = createSignal<Date | null>(null);
   const [imageUrl, setImageUrl] = createSignal<string | null>(null);
@@ -254,6 +257,24 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
     setError(null);
   };
 
+  const handleDownload = async () => {
+    const filePath = currentPath();
+    const file = props.selectedFile;
+    if (!filePath || !file || isDownloading()) {
+      return;
+    }
+
+    setIsDownloading(true);
+    setError(null);
+    try {
+      await downloadWorkspaceFile(props.agentId, filePath, file.name);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to download file');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
   createEffect(
     on(
       () => [props.agentId, currentPath()],
@@ -343,6 +364,21 @@ export function WorkspaceEditor(props: WorkspaceEditorProps) {
               Read only
             </span>
           </Show>
+          <button
+            type="button"
+            onClick={() => void handleDownload()}
+            disabled={!props.selectedFile || isDownloading()}
+            class="inline-flex items-center gap-1 px-2.5 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Download file"
+          >
+            <Show
+              when={isDownloading()}
+              fallback={<Download class="w-3.5 h-3.5" />}
+            >
+              <Loader2 class="w-3.5 h-3.5 animate-spin" />
+            </Show>
+            Download
+          </button>
           <button
             type="button"
             onClick={revertChanges}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -716,6 +716,38 @@ export async function fetchWorkspaceFileBlob(
 }
 
 /**
+ * Download a workspace file to the user's machine. Streams the file via
+ * the authenticated raw endpoint, then triggers a browser save dialog
+ * with `fileName` as the suggested filename.
+ *
+ * The fetch goes through the Bearer-token wrapper, so a plain
+ * `<a href="/api/...">` won't work (the browser can't attach the auth
+ * header). We pull the bytes, build an object URL, click an anchor
+ * programmatically, and revoke the URL once the save has been kicked
+ * off — keeping the blob alive long enough for the download to start.
+ */
+export async function downloadWorkspaceFile(
+  agentId: string,
+  filePath: string,
+  fileName: string,
+): Promise<void> {
+  const blob = await fetchWorkspaceFileBlob(agentId, filePath);
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    // Firefox requires the anchor to be in the DOM for the click to
+    // be honored; appending/cleaning keeps the side effect invisible.
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
  * Write a file to an agent's workspace
  */
 export async function writeWorkspaceFile(


### PR DESCRIPTION
## Summary

Adds a way to download files from the workspace tab on the agents page. A `Download` button is shown per file row in `FileExplorer` and one is added to the `WorkspaceEditor` toolbar for the currently open file.

## How it works

The existing `GET /api/workspace/:agentId/raw/*` route already streams any file's bytes with its media type — it just needs the Bearer token, which a plain `<a href>` can't supply. So the client fetches through the authenticated wrapper, builds an object URL, clicks an anchor with the filename, and revokes the URL in a `finally` (so the blob is freed even if the click throws).

No server changes.

## Where the buttons live

- **FileExplorer row** — `Download` button next to `Rename` / `Delete`, shown for files regardless of `canWrite` (download is a read action; works on read-only workspaces). Per-row spinner while the download is in flight; `event.stopPropagation` so clicking Download doesn't also open the file in the editor. Errors surface in the existing error banner.
- **WorkspaceEditor toolbar** — `Download` button between the read-only badge and `Revert`, enabled whenever a file is selected, with spinner + error banner.

## Tests

5 new component tests:

- FileExplorer: download fires with the right `(agentId, path, filename)`; clicking Download does **not** select the file (`stopPropagation`); download errors land in the error banner.
- WorkspaceEditor: Download button calls the helper; download errors land in the error banner.

The component test mock factories were updated to expose `downloadWorkspaceFile` (the helper wasn't in the minimal factory before).

A standalone `api.test.ts`-style test for the helper's DOM save flow was attempted but dropped: jsdom doesn't implement `URL.createObjectURL` / `revokeObjectURL`, and the project's `apiFetch` wrapper streams the response, so faithfully mocking the end-to-end helper in jsdom was disproportionate to the value. The wiring (filename, error propagation) is locked in by the component tests, and the helper itself is ~15 lines.

## Verification

- `tsc -b` clean, `eslint` clean, `prettier` clean
- Full web suite: **56 files, 507 tests passed** (was 502, +5)
- `pnpm build` succeeds

## Follow-up (deferred)

Folder / whole-workspace zip downloads aren't included — they'd need a new server archive endpoint and a zip lib. Happy to add that in a follow-up if you want it.