### PR TITLE
feat(chat): agents can share image/audio/video media in chat

### DIFF
--- a/apps/server/src/attachments/service.test.ts
+++ b/apps/server/src/attachments/service.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { kindForMimeType, mimeTypeForPath } from './service';
+
+describe('kindForMimeType', () => {
+  it('classifies images', () => {
+    expect(kindForMimeType('image/png')).toBe('image');
+    expect(kindForMimeType('image/jpeg')).toBe('image');
+    expect(kindForMimeType('image/gif')).toBe('image');
+    expect(kindForMimeType('image/webp')).toBe('image');
+  });
+
+  it('classifies audio', () => {
+    expect(kindForMimeType('audio/mpeg')).toBe('audio');
+    expect(kindForMimeType('audio/wav')).toBe('audio');
+    expect(kindForMimeType('audio/ogg')).toBe('audio');
+    expect(kindForMimeType('audio/flac')).toBe('audio');
+  });
+
+  it('classifies video', () => {
+    expect(kindForMimeType('video/mp4')).toBe('video');
+    expect(kindForMimeType('video/webm')).toBe('video');
+    expect(kindForMimeType('video/ogg')).toBe('video');
+  });
+
+  it('returns null for unsupported types', () => {
+    expect(kindForMimeType('text/plain')).toBeNull();
+    expect(kindForMimeType('application/pdf')).toBeNull();
+    expect(kindForMimeType('video/quicktime')).toBeNull();
+  });
+});
+
+describe('mimeTypeForPath', () => {
+  it('maps media extensions to mime types', () => {
+    expect(mimeTypeForPath('media/chart.png')).toBe('image/png');
+    expect(mimeTypeForPath('photo.jpg')).toBe('image/jpeg');
+    expect(mimeTypeForPath('voice-note.mp3')).toBe('audio/mpeg');
+    expect(mimeTypeForPath('song.m4a')).toBe('audio/mp4');
+    expect(mimeTypeForPath('clip.mp4')).toBe('video/mp4');
+    expect(mimeTypeForPath('reel.webm')).toBe('video/webm');
+    expect(mimeTypeForPath('movie.ogv')).toBe('video/ogg');
+  });
+
+  it('is case-insensitive', () => {
+    expect(mimeTypeForPath('CLIP.MP4')).toBe('video/mp4');
+    expect(mimeTypeForPath('Pic.JPG')).toBe('image/jpeg');
+  });
+
+  it('returns null for unsupported or extensionless paths', () => {
+    expect(mimeTypeForPath('notes.txt')).toBeNull();
+    expect(mimeTypeForPath('archive.zip')).toBeNull();
+    expect(mimeTypeForPath('README')).toBeNull();
+  });
+});

--- a/apps/server/src/attachments/service.ts
+++ b/apps/server/src/attachments/service.ts
@@ -1,12 +1,12 @@
 /**
  * Attachment service
  *
- * Stores and serves image/audio media attached to session messages.
+ * Stores and serves image/audio/video media attached to session messages.
  * Bytes live on local disk under a dedicated attachments directory
  * (`<baseDir>/<sessionId>/<id>.<ext>`); only metadata goes to the DB
  * (`message_attachments` table). Tool-produced media (e.g. screenshots
- * persisted into an agent workspace) is registered here too, pointing at
- * its existing on-disk location.
+ * persisted into an agent workspace, or files shared via media_share) is
+ * registered here too, pointing at its existing on-disk location.
  */
 
 import { mkdir, writeFile, readFile, stat, unlink } from 'node:fs/promises';
@@ -20,6 +20,13 @@ import type {
 
 /** Max upload size (decoded bytes). */
 export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Max size for agent-shared media (tool_output registrations). Higher
+ * than the upload cap because videos are the common case here; still
+ * bounded so a runaway generation can't push a multi-GB file into chat.
+ */
+export const MAX_TOOL_OUTPUT_BYTES = 100 * 1024 * 1024;
 
 /** Allowed mime types by kind. */
 const ALLOWED_MIME_TYPES: Record<AttachmentKind, readonly string[]> = {
@@ -35,6 +42,9 @@ const ALLOWED_MIME_TYPES: Record<AttachmentKind, readonly string[]> = {
     'audio/flac',
     'audio/aac',
   ],
+  // Browser-playable formats only — the UI promise is that shared media
+  // can be viewed or played inline.
+  video: ['video/mp4', 'video/webm', 'video/ogg'],
 };
 
 const EXT_BY_MIME: Record<string, string> = {
@@ -51,13 +61,44 @@ const EXT_BY_MIME: Record<string, string> = {
   'audio/webm': 'webm',
   'audio/flac': 'flac',
   'audio/aac': 'aac',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/ogg': 'ogv',
 };
+
+/**
+ * Extension → mime lookup, derived from {@link EXT_BY_MIME} so the two
+ * directions never drift. Where several mimes share an extension (e.g.
+ * audio/mpeg vs audio/mp3) the first — canonical — entry wins.
+ */
+const MIME_BY_EXT: Record<string, string> = {};
+for (const [mime, ext] of Object.entries(EXT_BY_MIME)) {
+  if (!(ext in MIME_BY_EXT)) {
+    MIME_BY_EXT[ext] = mime;
+  }
+}
+// .webm is ambiguous — the same extension is used for audio-only and
+// video files. Prefer video: a <video> element plays both correctly,
+// while an <audio> element can't show the picture of a video webm.
+MIME_BY_EXT['webm'] = 'video/webm';
 
 /** Derive the attachment kind from a mime type, or null if unsupported. */
 export function kindForMimeType(mimeType: string): AttachmentKind | null {
   if (ALLOWED_MIME_TYPES.image.includes(mimeType)) return 'image';
   if (ALLOWED_MIME_TYPES.audio.includes(mimeType)) return 'audio';
+  if (ALLOWED_MIME_TYPES.video.includes(mimeType)) return 'video';
   return null;
+}
+
+/**
+ * Best-effort mime type for a file path, from its extension. Returns null
+ * for unknown/unsupported extensions. Used by the media_share tool, where
+ * the agent names the file it created — extension is the honest contract.
+ */
+export function mimeTypeForPath(filePath: string): string | null {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  if (!ext || ext === filePath.toLowerCase()) return null;
+  return MIME_BY_EXT[ext] ?? null;
 }
 
 export class AttachmentError extends Error {
@@ -150,6 +191,11 @@ export class AttachmentService {
   /**
    * Register media that already exists on disk (e.g. a screenshot a tool
    * persisted into an agent workspace) as an attachment on a message.
+   *
+   * Returns null when the file can't be registered: unsupported mime
+   * type, vanished file, or over {@link MAX_TOOL_OUTPUT_BYTES}. Callers
+   * that need to surface *why* (like the media_share tool) validate
+   * before calling so they can return an actionable error themselves.
    */
   async registerToolOutput(input: {
     sessionId: string;
@@ -166,6 +212,9 @@ export class AttachmentService {
       sizeBytes = (await stat(input.storagePath)).size;
     } catch {
       return null; // file vanished — nothing to register
+    }
+    if (sizeBytes > MAX_TOOL_OUTPUT_BYTES) {
+      return null; // backstop — the media_share tool checks this first
     }
 
     return this.repo.create({

--- a/apps/server/src/routes/attachments.ts
+++ b/apps/server/src/routes/attachments.ts
@@ -40,8 +40,8 @@ export const attachmentRoutes: FastifyPluginAsync<
 
   /**
    * POST /sessions/:sessionId/attachments
-   * Upload an image/audio file for a pending message. The attachment is
-   * stored unlinked; submitting a message with its id links it.
+   * Upload an image/audio/video file for a pending message. The attachment
+   * is stored unlinked; submitting a message with its id links it.
    */
   app.post(
     '/sessions/:sessionId/attachments',

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -12,6 +12,7 @@ import {
   type PersistedImage,
 } from '../mcp/screenshot-capture';
 import type { BuiltinToolRegistry } from '../tools';
+import type { MediaShareResult } from '../tools/media/share';
 import type { AttachmentService } from '../attachments/service';
 import type {
   ToolDefinition,
@@ -1177,7 +1178,15 @@ export class SessionMessageService {
         const inline: RuntimeMessageAttachment[] = [];
         const degradedNotes: string[] = [];
         for (const att of msgAttachments) {
-          if (att.kind !== 'image' && att.kind !== 'audio') continue;
+          // Video (and any future non-vision/audio kind) never inlines into
+          // provider requests — degrade to a file-path note so the model
+          // knows the file exists and can reach it with tools.
+          if (att.kind !== 'image' && att.kind !== 'audio') {
+            degradedNotes.push(
+              `[Attached ${att.kind}${att.name ? ` "${att.name}"` : ''} (${att.mimeType}) is saved at ${att.storagePath} — this model cannot process it natively; use an available tool to analyze the file.]`,
+            );
+            continue;
+          }
           const supported =
             att.kind === 'image' ? modelSupportsVision : modelSupportsAudio;
           if (!supported) {
@@ -1660,6 +1669,9 @@ export class SessionMessageService {
             let toolContent: string | undefined;
             let toolIsError = false;
             let absolutePathFromTool: string | undefined;
+            // Media a tool asked to share in chat (media_share) — registered
+            // as an attachment on the tool result message below.
+            let mediaShareFromTool: MediaShareResult | undefined;
             // Inline images a tool returned and we persisted to disk —
             // registered as attachments on the tool result message below.
             let persistedImages: PersistedImage[] = [];
@@ -1812,15 +1824,20 @@ export class SessionMessageService {
                 toolIsError = true;
               } else {
                 toolContent = builtinResult.content;
-                // workspace_write returns absolutePath but the BuiltinTool type
-                // doesn't expose it, so we need to cast to access it
+                // workspace_write returns absolutePath and media_share returns
+                // a media payload, but the BuiltinTool type doesn't expose
+                // them, so we need to cast to access them
                 const resultWithPath = builtinResult as {
                   ok: true;
                   content: string;
                   absolutePath?: string;
+                  media?: MediaShareResult;
                 };
                 if (resultWithPath.absolutePath) {
                   absolutePathFromTool = resultWithPath.absolutePath;
+                }
+                if (resultWithPath.media) {
+                  mediaShareFromTool = resultWithPath.media;
                 }
               }
             } else {
@@ -1939,6 +1956,32 @@ export class SessionMessageService {
                 ...(toolIsError ? { isError: true } : {}),
                 metadata: toolMetadata,
               });
+
+              // Register media a tool explicitly shared (media_share) as an
+              // attachment on the tool result message so the chat renders it
+              // inline. The tool already validated the file (exists, supported
+              // type, size cap) — a null return here means it raced a delete.
+              if (mediaShareFromTool && this.attachments) {
+                const shared = mediaShareFromTool;
+                await this.attachments
+                  .registerToolOutput({
+                    sessionId: input.sessionId,
+                    messageId: toolMessage.id,
+                    mimeType: shared.mimeType,
+                    storagePath: shared.absolutePath,
+                    name: shared.name,
+                  })
+                  .catch((e: unknown) => {
+                    this.logger?.warn(
+                      {
+                        messageId: toolMessage.id,
+                        path: shared.absolutePath,
+                        error: e instanceof Error ? e.message : String(e),
+                      },
+                      'Failed to register shared media attachment',
+                    );
+                  });
+              }
 
               // Register tool-produced images as attachments on the tool
               // result message so the chat renders them inline (instead of

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -116,6 +116,20 @@ export const workspaceDeleteMeta: ToolMeta = {
   description: 'Delete a file from the agent workspace.',
 };
 
+// ── Media ─────────────────────────────────────────────────────────────────────
+
+export const mediaShareMeta: ToolMeta = {
+  name: 'media_share',
+  category: 'Media',
+  description:
+    'Share a media file (image, audio, or video) from the agent workspace in the chat, ' +
+    'so the user can see or play it inline. The file must already exist in the workspace — ' +
+    'create it first with workspace_write, exec_run, or another tool. ' +
+    'Supported: png/jpg/gif/webp images, wav/mp3/m4a/ogg/webm/flac/aac audio, mp4/webm/ogv video. ' +
+    'Use this whenever the user would benefit from viewing a generated chart, image, ' +
+    'audio clip, or video rather than reading a file path.',
+};
+
 // ── Execution ─────────────────────────────────────────────────────────────────
 
 export const execRunMeta: ToolMeta = {

--- a/apps/server/src/tools/index.ts
+++ b/apps/server/src/tools/index.ts
@@ -22,6 +22,7 @@
 
 import { BuiltinToolRegistry } from './registry';
 import { createWorkspaceTools } from './workspace';
+import { createMediaTools } from './media';
 import { createCodeTools } from './code';
 import { createExecTools } from './exec';
 import { createSkillTools } from './skills';
@@ -47,6 +48,7 @@ import type { TaskScheduleService } from '../tasks/schedule-service.js';
 
 export { BuiltinToolRegistry } from './registry';
 export { createWorkspaceTools } from './workspace';
+export { createMediaTools } from './media';
 export { createCodeTools } from './code';
 export { createExecTools } from './exec';
 export { createSkillTools } from './skills';
@@ -99,6 +101,10 @@ export function createBuiltinToolRegistry(
   const registry = new BuiltinToolRegistry();
 
   for (const tool of createWorkspaceTools(deps.workspace)) {
+    registry.register(tool);
+  }
+
+  for (const tool of createMediaTools(deps.workspace)) {
     registry.register(tool);
   }
 

--- a/apps/server/src/tools/media/index.ts
+++ b/apps/server/src/tools/media/index.ts
@@ -1,0 +1,16 @@
+import type { WorkspaceService } from '../../workspace/service';
+import type { BuiltinTool } from '@openaidy/runtime';
+import { createMediaShareTool } from './share';
+
+export { createMediaShareTool } from './share';
+export type { MediaShareResult } from './share';
+
+/**
+ * Returns all media builtin tools backed by the given services.
+ *
+ * Register them selectively per-agent via `tools` in the agent config:
+ *   "tools": ["media_share"]
+ */
+export function createMediaTools(workspace: WorkspaceService): BuiltinTool[] {
+  return [createMediaShareTool(workspace)];
+}

--- a/apps/server/src/tools/media/share.test.ts
+++ b/apps/server/src/tools/media/share.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createWorkspaceService } from '../../workspace/service';
+import { createMediaShareTool, createMediaTools } from './index';
+import { MAX_TOOL_OUTPUT_BYTES } from '../../attachments/service';
+
+const CTX = { agentId: 'test-agent', sessionId: 'test-session' };
+
+describe('media tools', () => {
+  let testBaseDir: string;
+  let workspace: ReturnType<typeof createWorkspaceService>;
+
+  beforeEach(async () => {
+    testBaseDir = join(
+      tmpdir(),
+      `media-tools-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testBaseDir, { recursive: true });
+    workspace = createWorkspaceService({ baseDir: testBaseDir });
+    await workspace.ensureWorkspace(CTX.agentId);
+  });
+
+  afterEach(async () => {
+    await rm(testBaseDir, { recursive: true, force: true });
+  });
+
+  const writeFixture = (relPath: string, contents = 'x') =>
+    workspace.writeFile(CTX.agentId, relPath, contents);
+
+  describe('createMediaTools', () => {
+    it('returns the media_share tool', () => {
+      const tools = createMediaTools(workspace);
+      expect(tools.map((t) => t.name)).toEqual(['media_share']);
+    });
+  });
+
+  describe('media_share', () => {
+    it('shares a video file and returns the media payload', async () => {
+      await writeFixture('media/clip.mp4');
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: 'media/clip.mp4' }, CTX);
+
+      expect(result.ok).toBe(true);
+      const ok = result as {
+        ok: true;
+        content: string;
+        media: { absolutePath: string; mimeType: string; name: string };
+      };
+      expect(ok.content).toContain('clip.mp4');
+      expect(ok.media.mimeType).toBe('video/mp4');
+      expect(ok.media.name).toBe('clip.mp4');
+      expect(ok.media.absolutePath).toBe(
+        join(testBaseDir, CTX.agentId, 'media', 'clip.mp4'),
+      );
+    });
+
+    it('detects image and audio kinds from the extension', async () => {
+      await writeFixture('chart.png');
+      await writeFixture('voice-note.mp3');
+      const tool = createMediaShareTool(workspace);
+
+      const image = (await tool.execute({ path: 'chart.png' }, CTX)) as {
+        ok: true;
+        content: string;
+        media: { mimeType: string };
+      };
+      const audio = (await tool.execute({ path: 'voice-note.mp3' }, CTX)) as {
+        ok: true;
+        content: string;
+        media: { mimeType: string };
+      };
+
+      expect(image.ok).toBe(true);
+      expect(image.media.mimeType).toBe('image/png');
+      expect(image.content).toContain('image');
+      expect(audio.ok).toBe(true);
+      expect(audio.media.mimeType).toBe('audio/mpeg');
+      expect(audio.content).toContain('audio');
+    });
+
+    it('honors a custom display name', async () => {
+      await writeFixture('media/clip.webm');
+      const tool = createMediaShareTool(workspace);
+
+      const result = (await tool.execute(
+        { path: 'media/clip.webm', name: 'Demo reel' },
+        CTX,
+      )) as { ok: true; content: string; media: { name: string } };
+
+      expect(result.ok).toBe(true);
+      expect(result.media.name).toBe('Demo reel');
+    });
+
+    it('rejects a missing file', async () => {
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: 'nope.mp4' }, CTX);
+
+      expect(result.ok).toBe(false);
+      expect((result as { ok: false; error: string }).error).toContain(
+        'File not found',
+      );
+    });
+
+    it('rejects a directory path', async () => {
+      await writeFixture('media/placeholder.txt'); // creates media/
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: 'media' }, CTX);
+
+      expect(result.ok).toBe(false);
+      expect((result as { ok: false; error: string }).error).toContain(
+        'is not a file',
+      );
+    });
+
+    it('rejects unsupported file types', async () => {
+      await writeFixture('notes.txt');
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: 'notes.txt' }, CTX);
+
+      expect(result.ok).toBe(false);
+      expect((result as { ok: false; error: string }).error).toContain(
+        'not a supported media file',
+      );
+    });
+
+    it('rejects paths escaping the workspace', async () => {
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: '../outside.mp4' }, CTX);
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects files over the size cap', async () => {
+      // Sparse file: reports the capped size without writing real bytes.
+      const bigPath = join(testBaseDir, CTX.agentId, 'huge.mp4');
+      const handle = await open(bigPath, 'w');
+      await handle.truncate(MAX_TOOL_OUTPUT_BYTES + 1);
+      await handle.close();
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({ path: 'huge.mp4' }, CTX);
+
+      expect(result.ok).toBe(false);
+      expect((result as { ok: false; error: string }).error).toContain(
+        'over the 100MB limit',
+      );
+    });
+
+    it('requires a path argument', async () => {
+      const tool = createMediaShareTool(workspace);
+
+      const result = await tool.execute({}, CTX);
+
+      expect(result.ok).toBe(false);
+      expect((result as { ok: false; error: string }).error).toContain(
+        'path is required',
+      );
+    });
+  });
+});

--- a/apps/server/src/tools/media/share.ts
+++ b/apps/server/src/tools/media/share.ts
@@ -1,0 +1,122 @@
+import { stat } from 'node:fs/promises';
+import { basename } from 'node:path';
+import type { BuiltinTool } from '@openaidy/runtime';
+import type { WorkspaceService } from '../../workspace/service';
+import { WorkspaceError } from '../../workspace/service';
+import {
+  MAX_TOOL_OUTPUT_BYTES,
+  kindForMimeType,
+  mimeTypeForPath,
+} from '../../attachments/service';
+import { mediaShareMeta } from '../catalog';
+
+/**
+ * Payload the session service reads off the tool result to register the
+ * shared file as a message attachment (the tool itself can't — the tool
+ * result message doesn't exist until after execution).
+ */
+export type MediaShareResult = {
+  /** Absolute path of the file on disk (stays in place, never copied). */
+  absolutePath: string;
+  mimeType: string;
+  /** Display name shown in the chat (defaults to the file basename). */
+  name: string;
+};
+
+/**
+ * media_share
+ *
+ * Shares an existing workspace media file (image, audio, or video) in the
+ * chat so the user can see or play it inline. The tool validates the file
+ * (exists, is a file, is a supported media type, fits the size cap) and
+ * returns a {@link MediaShareResult} payload; the session service then
+ * registers the attachment on the tool result message.
+ *
+ * Validation lives here (not in the attachment service) so failures come
+ * back as tool errors the agent can read and act on.
+ */
+export function createMediaShareTool(workspace: WorkspaceService): BuiltinTool {
+  return {
+    name: mediaShareMeta.name,
+    description: mediaShareMeta.description,
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description:
+            'Relative path of the media file within the workspace, e.g. "media/chart.png"',
+        },
+        name: {
+          type: 'string',
+          description:
+            'Optional display name for the chat attachment. Defaults to the file name.',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args, ctx) {
+      const filePath = args['path'];
+      const displayName = args['name'];
+
+      if (typeof filePath !== 'string' || !filePath) {
+        return { ok: false, error: 'path is required and must be a string' };
+      }
+      if (displayName !== undefined && typeof displayName !== 'string') {
+        return { ok: false, error: 'name must be a string when provided' };
+      }
+
+      // Resolve inside the workspace (blocks ../ traversal).
+      let absolutePath: string;
+      try {
+        absolutePath = workspace.validatePath(ctx.agentId, filePath);
+      } catch (err) {
+        if (err instanceof WorkspaceError) {
+          return { ok: false, error: err.message };
+        }
+        throw err;
+      }
+
+      // Must exist and be a regular file.
+      let sizeBytes: number;
+      try {
+        const stats = await stat(absolutePath);
+        if (!stats.isFile()) {
+          return { ok: false, error: `"${filePath}" is not a file` };
+        }
+        sizeBytes = stats.size;
+      } catch {
+        return { ok: false, error: `File not found: "${filePath}"` };
+      }
+
+      if (sizeBytes > MAX_TOOL_OUTPUT_BYTES) {
+        const limitMb = Math.floor(MAX_TOOL_OUTPUT_BYTES / (1024 * 1024));
+        const sizeMb = (sizeBytes / (1024 * 1024)).toFixed(1);
+        return {
+          ok: false,
+          error: `"${filePath}" is ${sizeMb}MB — over the ${limitMb}MB limit for chat media. Compress or trim it, then try again.`,
+        };
+      }
+
+      // Must be a media type the chat can render.
+      const mimeType = mimeTypeForPath(filePath);
+      const kind = mimeType ? kindForMimeType(mimeType) : null;
+      if (!mimeType || !kind) {
+        return {
+          ok: false,
+          error:
+            `"${filePath}" is not a supported media file. ` +
+            'Supported: png/jpg/gif/webp images, wav/mp3/m4a/ogg/webm/flac/aac audio, mp4/webm/ogv video.',
+        };
+      }
+
+      const name = displayName?.trim() || basename(filePath);
+      const media: MediaShareResult = { absolutePath, mimeType, name };
+      return {
+        ok: true,
+        content: `Shared ${kind} "${name}" in chat.`,
+        media,
+      };
+    },
+  };
+}

--- a/apps/web/src/components/AttachmentList.test.tsx
+++ b/apps/web/src/components/AttachmentList.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@solidjs/testing-library';
+import { AttachmentList } from './AttachmentList';
+import * as api from '../lib/api';
+import type { SessionMessageAttachment } from '../lib/api';
+
+// Only the object-URL fetch is used by this component; everything else in
+// the api module is irrelevant here.
+vi.mock('../lib/api', () => ({
+  fetchAttachmentObjectUrl: vi.fn(),
+}));
+
+function attachment(
+  overrides: Partial<SessionMessageAttachment>,
+): SessionMessageAttachment {
+  return {
+    id: overrides.id ?? 'att-1',
+    kind: overrides.kind ?? 'image',
+    source: overrides.source ?? 'tool_output',
+    mimeType: overrides.mimeType ?? 'image/png',
+    sizeBytes: overrides.sizeBytes ?? 128,
+    ...(overrides.name !== undefined ? { name: overrides.name } : {}),
+  };
+}
+
+// jsdom lacks URL.createObjectURL/revokeObjectURL; the component revokes
+// on cleanup, so install a no-op for the test run.
+const originalRevoke = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    value: vi.fn(),
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalRevoke) {
+    Object.defineProperty(URL, 'revokeObjectURL', originalRevoke);
+  } else {
+    delete (URL as unknown as Record<string, unknown>)['revokeObjectURL'];
+  }
+});
+
+describe('AttachmentList', () => {
+  it('renders an image attachment as an <img> inside a link', async () => {
+    vi.mocked(api.fetchAttachmentObjectUrl).mockResolvedValue('blob:img');
+
+    const { container } = render(() => (
+      <AttachmentList
+        attachments={[attachment({ kind: 'image', name: 'chart.png' })]}
+      />
+    ));
+
+    const img = await screen.findByRole('img', { name: 'chart.png' });
+    expect(img).toHaveAttribute('src', 'blob:img');
+    expect(container.querySelector('a[href="blob:img"]')).not.toBeNull();
+  });
+
+  it('renders an audio attachment as an <audio controls> player', async () => {
+    vi.mocked(api.fetchAttachmentObjectUrl).mockResolvedValue('blob:audio');
+
+    const { container } = render(() => (
+      <AttachmentList
+        attachments={[
+          attachment({
+            kind: 'audio',
+            mimeType: 'audio/mpeg',
+            name: 'voice.mp3',
+          }),
+        ]}
+      />
+    ));
+
+    await screen.findByTitle('voice.mp3');
+    const audio = container.querySelector('audio');
+    expect(audio).not.toBeNull();
+    expect(audio).toHaveAttribute('controls');
+    expect(audio).toHaveAttribute('src', 'blob:audio');
+  });
+
+  it('renders a video attachment as a <video controls> player', async () => {
+    vi.mocked(api.fetchAttachmentObjectUrl).mockResolvedValue('blob:video');
+
+    const { container } = render(() => (
+      <AttachmentList
+        attachments={[
+          attachment({
+            kind: 'video',
+            mimeType: 'video/mp4',
+            name: 'demo.mp4',
+          }),
+        ]}
+      />
+    ));
+
+    await screen.findByTitle('demo.mp4');
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video).toHaveAttribute('controls');
+    expect(video).toHaveAttribute('src', 'blob:video');
+    // Lazy: don't pull the whole file until the user hits play.
+    expect(video).toHaveAttribute('preload', 'metadata');
+  });
+
+  it('shows an unavailable chip when the bytes fail to load', async () => {
+    vi.mocked(api.fetchAttachmentObjectUrl).mockRejectedValue(
+      new Error('gone'),
+    );
+
+    render(() => (
+      <AttachmentList
+        attachments={[attachment({ kind: 'video', name: 'lost.mp4' })]}
+      />
+    ));
+
+    expect(
+      await screen.findByText('lost.mp4 (unavailable)'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders one item per attachment', async () => {
+    vi.mocked(api.fetchAttachmentObjectUrl).mockResolvedValue('blob:x');
+
+    const { container } = render(() => (
+      <AttachmentList
+        attachments={[
+          attachment({ id: 'a1', kind: 'image', name: 'one.png' }),
+          attachment({
+            id: 'a2',
+            kind: 'video',
+            mimeType: 'video/mp4',
+            name: 'two.mp4',
+          }),
+        ]}
+      />
+    ));
+
+    await screen.findByRole('img', { name: 'one.png' });
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('video')).not.toBeNull();
+    expect(api.fetchAttachmentObjectUrl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/AttachmentList.tsx
+++ b/apps/web/src/components/AttachmentList.tsx
@@ -1,26 +1,45 @@
 /**
  * AttachmentList
  *
- * Renders a message's image/audio attachments. Bytes are served by the
- * authenticated raw endpoint, so each item fetches through the auth-aware
- * wrapper and renders from an object URL (same pattern as the workspace
- * file preview) — a bare <img src="/api/..."> would miss the Bearer token.
+ * Renders a message's media attachments (image, audio, video). Bytes are
+ * served by the authenticated raw endpoint, so each item fetches through
+ * the auth-aware wrapper and renders from an object URL (same pattern as
+ * the workspace file preview) — a bare <img src="/api/..."> would miss
+ * the Bearer token.
  */
 
-import { createSignal, onCleanup, onMount, Show, For } from 'solid-js';
+import {
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  For,
+  Switch,
+  Match,
+} from 'solid-js';
 import { FileWarning, Music } from 'lucide-solid';
 import {
   fetchAttachmentObjectUrl,
   type SessionMessageAttachment,
 } from '../lib/api';
 
-function AttachmentItem(props: { attachment: SessionMessageAttachment }) {
+/** Display label for an attachment: its name, or a kind-based fallback. */
+function attachmentLabel(attachment: SessionMessageAttachment): string {
+  return attachment.name ?? `${attachment.kind} attachment`;
+}
+
+/**
+ * Fetches an attachment's bytes into an object URL, revoked on cleanup.
+ * Shared by every kind renderer so the fetch/revoke dance lives in one
+ * place.
+ */
+function useAttachmentUrl(attachmentId: string) {
   const [url, setUrl] = createSignal<string>();
   const [failed, setFailed] = createSignal(false);
 
   onMount(async () => {
     try {
-      setUrl(await fetchAttachmentObjectUrl(props.attachment.id));
+      setUrl(await fetchAttachmentObjectUrl(attachmentId));
     } catch {
       setFailed(true);
     }
@@ -31,8 +50,91 @@ function AttachmentItem(props: { attachment: SessionMessageAttachment }) {
     if (u) URL.revokeObjectURL(u);
   });
 
-  const label = () =>
-    props.attachment.name ?? `${props.attachment.kind} attachment`;
+  return { url, failed };
+}
+
+function ImageAttachment(props: {
+  attachment: SessionMessageAttachment;
+  url?: string;
+}) {
+  const label = () => attachmentLabel(props.attachment);
+  return (
+    <Show
+      when={props.url}
+      fallback={
+        <div class="w-32 h-24 rounded-lg bg-gray-100 dark:bg-gray-700 animate-pulse" />
+      }
+    >
+      {(u) => (
+        <a
+          href={u()}
+          target="_blank"
+          rel="noopener"
+          title={label()}
+          class="block"
+        >
+          <img
+            src={u()}
+            alt={label()}
+            class="max-h-64 max-w-full rounded-lg border border-gray-200 dark:border-gray-700 object-contain"
+          />
+        </a>
+      )}
+    </Show>
+  );
+}
+
+function AudioAttachment(props: {
+  attachment: SessionMessageAttachment;
+  url?: string;
+}) {
+  const label = () => attachmentLabel(props.attachment);
+  return (
+    <div class="flex items-center gap-2">
+      <Music class="w-4 h-4 text-text-tertiary flex-shrink-0" />
+      <Show
+        when={props.url}
+        fallback={
+          <span class="text-xs text-text-tertiary">Loading {label()}…</span>
+        }
+      >
+        {(u) => (
+          <audio controls src={u()} class="h-9 max-w-full" title={label()} />
+        )}
+      </Show>
+    </div>
+  );
+}
+
+function VideoAttachment(props: {
+  attachment: SessionMessageAttachment;
+  url?: string;
+}) {
+  const label = () => attachmentLabel(props.attachment);
+  return (
+    <Show
+      when={props.url}
+      fallback={
+        <div class="w-64 h-36 rounded-lg bg-gray-100 dark:bg-gray-700 animate-pulse" />
+      }
+    >
+      {(u) => (
+        // preload="metadata" — don't pull the whole file until the user
+        // hits play; shared videos can be tens of MB.
+        <video
+          controls
+          preload="metadata"
+          src={u()}
+          title={label()}
+          class="max-h-64 max-w-full rounded-lg border border-gray-200 dark:border-gray-700"
+        />
+      )}
+    </Show>
+  );
+}
+
+function AttachmentItem(props: { attachment: SessionMessageAttachment }) {
+  const { url, failed } = useAttachmentUrl(props.attachment.id);
 
   return (
     <Show
@@ -40,54 +142,21 @@ function AttachmentItem(props: { attachment: SessionMessageAttachment }) {
       fallback={
         <div class="flex items-center gap-1.5 rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1.5 text-xs text-text-tertiary">
           <FileWarning class="w-4 h-4" />
-          <span>{label()} (unavailable)</span>
+          <span>{attachmentLabel(props.attachment)} (unavailable)</span>
         </div>
       }
     >
-      <Show
-        when={props.attachment.kind === 'image'}
-        fallback={
-          <div class="flex items-center gap-2">
-            <Music class="w-4 h-4 text-text-tertiary flex-shrink-0" />
-            <Show
-              when={url()}
-              fallback={
-                <span class="text-xs text-text-tertiary">
-                  Loading {label()}…
-                </span>
-              }
-            >
-              <audio
-                controls
-                src={url()}
-                class="h-9 max-w-full"
-                title={label()}
-              />
-            </Show>
-          </div>
-        }
-      >
-        <Show
-          when={url()}
-          fallback={
-            <div class="w-32 h-24 rounded-lg bg-gray-100 dark:bg-gray-700 animate-pulse" />
-          }
-        >
-          <a
-            href={url()}
-            target="_blank"
-            rel="noopener"
-            title={label()}
-            class="block"
-          >
-            <img
-              src={url()}
-              alt={label()}
-              class="max-h-64 max-w-full rounded-lg border border-gray-200 dark:border-gray-700 object-contain"
-            />
-          </a>
-        </Show>
-      </Show>
+      <Switch>
+        <Match when={props.attachment.kind === 'image'}>
+          <ImageAttachment attachment={props.attachment} url={url()} />
+        </Match>
+        <Match when={props.attachment.kind === 'audio'}>
+          <AudioAttachment attachment={props.attachment} url={url()} />
+        </Match>
+        <Match when={props.attachment.kind === 'video'}>
+          <VideoAttachment attachment={props.attachment} url={url()} />
+        </Match>
+      </Switch>
     </Show>
   );
 }

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -21,7 +21,7 @@ type ChatComposerProps = {
 };
 
 /** Mime prefixes accepted as chat attachments. */
-const ACCEPTED_MIME_PREFIXES = ['image/', 'audio/'];
+const ACCEPTED_MIME_PREFIXES = ['image/', 'audio/', 'video/'];
 
 function isAcceptedFile(file: File): boolean {
   return ACCEPTED_MIME_PREFIXES.some((p) => file.type.startsWith(p));
@@ -231,7 +231,7 @@ export function ChatComposer(props: ChatComposerProps) {
           fileInputRef = el;
         }}
         type="file"
-        accept="image/*,audio/*"
+        accept="image/*,audio/*,video/*"
         multiple
         class="hidden"
         onChange={handleFileInputChange}

--- a/apps/web/src/components/pages/AgentsPage.tsx
+++ b/apps/web/src/components/pages/AgentsPage.tsx
@@ -970,6 +970,7 @@ export function AgentsPage(props: AgentsPageProps) {
                       'Memory',
                       'Tasks',
                       'Workspace',
+                      'Media',
                       'Code',
                       'Execution',
                       'Skills',

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -53,20 +53,14 @@ import type {
   SessionMessage as SharedSessionMessage,
   RunStatus as SharedRunStatus,
   SessionRun as SharedSessionRun,
+  SessionMessageAttachment,
 } from '@openaidy/shared-types';
 
-/**
- * Attachment metadata on a session message. Bytes are fetched separately
- * via GET /api/attachments/:id/raw (through the authenticated fetch).
- */
-export type SessionMessageAttachment = {
-  id: string;
-  kind: 'image' | 'audio';
-  source: 'user_upload' | 'tool_output';
-  name?: string | null;
-  mimeType: string;
-  sizeBytes: number;
-};
+// Attachment metadata on a session message. Declared in shared-types
+// (single source of truth) and re-exported so existing './types' imports
+// keep working. Bytes are fetched separately via GET /api/attachments/:id/raw
+// (through the authenticated fetch).
+export type { SessionMessageAttachment };
 
 /**
  * Session message — extends shared type with UI-only reasoning content field

--- a/packages/db/src/schema/sessions.ts
+++ b/packages/db/src/schema/sessions.ts
@@ -228,6 +228,6 @@ export type MessageAttachment = typeof messageAttachments.$inferSelect;
 export type NewMessageAttachment = typeof messageAttachments.$inferInsert;
 
 /** Attachment media kind */
-export type AttachmentKind = 'image' | 'audio';
+export type AttachmentKind = 'image' | 'audio' | 'video';
 /** How the attachment entered the system */
 export type AttachmentSource = 'user_upload' | 'tool_output';

--- a/packages/shared-types/src/websocket.ts
+++ b/packages/shared-types/src/websocket.ts
@@ -207,7 +207,7 @@ export type SessionDeleteRequest = WSMessage<
  */
 export type SessionMessageAttachment = {
   id: string;
-  kind: 'image' | 'audio';
+  kind: 'image' | 'audio' | 'video';
   source: 'user_upload' | 'tool_output';
   name?: string | null;
   mimeType: string;


### PR DESCRIPTION
## Summary

Agents can now put **images, audio, and video** into the chat, and the chat renders them so the user can see or play them inline.

## How it works

A new builtin tool, `media_share`, is the agent's way in:

```
media_share({ path: "media/chart.png" })
```

The tool validates the file — exists, is a regular file, is a supported media type, and fits the **100MB** cap — and returns a media payload. The session service then registers the file as an attachment on the tool result message (the exact pattern tool-produced screenshots already use), and the chat renders the attachment.

Validation lives in the tool so failures come back as agent-actionable errors, e.g. *"huge.mp4 is 120MB — over the 100MB limit for chat media. Compress or trim it, then try again."* The tool is opt-in per agent via the Tools tab, like every other builtin (a new **Media** category).

## Chat rendering

- Images: inline `<img>` (unchanged)
- Audio: `<audio controls>` (unchanged)
- **Video: `<video controls preload="metadata">`** — doesn't pull the whole file until the user hits play

`AttachmentList` was refactored from nested `<Show>`s into a shared `useAttachmentUrl` hook + per-kind renderers, so a future media kind is a ~15-line addition.

## DRY / shared types

- `AttachmentKind` / `SessionMessageAttachment.kind` gained `'video'` in `packages/db` and `packages/shared-types`. The db column is plain `text` — **no migration**.
- The web client had a **duplicate local declaration** of `SessionMessageAttachment` in `lib/types.ts`; it now re-exports the shared type (matching that file's existing convention).
- One mime↔extension map in the attachments service feeds both directions: `mimeTypeForPath()` (new, for the tool) is derived from the existing `EXT_BY_MIME`. `.webm` is deliberately mapped to `video/webm` — a `<video>` element plays audio-only webms too, while `<audio>` can't show picture.
- One size constant (`MAX_TOOL_OUTPUT_BYTES`, 100MB) shared by the tool's agent-facing check and the attachment service's backstop.

## Also in scope

- **User video uploads**: the composer accept list and the upload endpoint (via the shared `kindForMimeType`) now accept video. Since models can't ingest video natively, user-uploaded videos degrade to a file-path note for the model (same mechanism as unsupported image/audio) instead of being silently dropped.

## Tests

- **Server** (17 new): `media_share` — success/image/audio/custom-name/missing-file/directory/unsupported-type/traversal/100MB-cap/missing-arg — plus `kindForMimeType`/`mimeTypeForPath` mappings.
- **Web** (5 new): `AttachmentList` — image/audio/video render, failure chip, multiple attachments.
- Full suites green: server **3325 passed**, web **507 passed**; `tsc` clean across server/web/shared-types/db, eslint + prettier clean, monorepo `pnpm build` passes.

## Notes for reviewers

- The tool message must be (re)fetched for the attachment to appear — identical to the existing screenshot attachments (same registration point, same `session.messages` grouping).
- The runtime provider-facing `MessageAttachment` stays `image | audio` on purpose: video never inlines into model requests.