### PR TITLE
chore(release): bump version to 0.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Release **v0.3.10**. Bumps root `package.json` `0.3.9 → 0.3.10` (the app reads its running version from `package.json`, which the in-app self-update compares against the latest GitHub release).

Once this is merged, the `v0.3.10` tag + GitHub release will be cut from the merge commit.

## What's in v0.3.10 (since v0.3.9)

### Features
- **memories**: agent memory management UI (browse/search/create/edit/delete)
- **chat**: agents can share image/audio/video media in chat
- **workspace**: download files from the agent's workspace tab
- **agents**: prebuilt agent personalities at creation
- **channels**: add Discord channel
- **usage**: redesigned usage chart bars; model colors tied to legend and table
- **branding**: logo image (webp-optimized) and fixed app tab title

### Fixes
- **whatsapp**: reply to self-chat messages, allow-all on empty allowlist, stop history flood
- **whatsapp**: resolve LID-addressed senders so the bot replies
- **addons**: re-inject Tailwind CDN on `addon_update`; share create/update logic

### Docs & DX
- **readme**: SEO-optimized landing page rewrite; promote the official one-line installer; badge URL typo fix
- **dx**: add `.env.example`, `dev:setup` script, and Node version pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)