### PR TITLE
fix(server): stop printing structured log context as [object Object]

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -15,7 +15,11 @@ import {
   createDatabaseAdapter,
 } from '@openaidy/db';
 import { env } from './lib/env';
-import { createLogger, registerHttpLogger } from './lib/logger';
+import {
+  createLogger,
+  registerHttpLogger,
+  toPinoStyleLogger,
+} from './lib/logger';
 import { ensureEncryptionKey } from './mcp/secret-crypto';
 import {
   buildCredentialResolver,
@@ -103,6 +107,11 @@ import type { AppServices } from './types';
 export async function buildApp() {
   const app = Fastify({ logger: false });
   const log = createLogger();
+  // Services typed against `FastifyBaseLogger` log pino-style
+  // (`logger.warn({ ctx }, 'message')`). Adapt once here rather than casting
+  // `log` directly at each injection site, where the argument order silently
+  // flipped and printed `[object Object]` in place of the message.
+  const pinoLog = toPinoStyleLogger(log) as unknown as FastifyBaseLogger;
   const wsConfig = {
     enabled: env.WS_ENABLED,
     port: env.WS_PORT,
@@ -237,7 +246,7 @@ export async function buildApp() {
 
   // Create MCP client service (before sessionService so it can be injected)
   const mcpService = createMcpClientService({
-    logger: log as unknown as FastifyBaseLogger,
+    logger: pinoLog,
   });
 
   // Create workspace service before sessionService so it can be injected into builtin tools
@@ -350,7 +359,7 @@ export async function buildApp() {
 
   sessionService = new SessionMessageService({
     providers: providerServices,
-    logger: log as unknown as FastifyBaseLogger,
+    logger: pinoLog,
     agents: agentRegistry,
     mcp: mcpService,
     workspace: workspaceService,
@@ -375,7 +384,7 @@ export async function buildApp() {
   const channelDeps = {
     sessionService,
     authBaseDir: path.join(env.OPENAIDY_HOME, 'channels'),
-    logger: log as unknown as FastifyBaseLogger,
+    logger: pinoLog,
   };
   const channelRegistry = createChannelRegistry(
     configService.getConfig().channels,
@@ -403,16 +412,12 @@ export async function buildApp() {
     }
   }
   const bootstrapAdmin = env.BOOTSTRAP_ADMIN_ENABLED
-    ? new BootstrapAdminManager(
-        new AuthMiddleware(wsConfig),
-        log as unknown as FastifyBaseLogger,
-        {
-          enabled: env.BOOTSTRAP_ADMIN_ENABLED,
-          tokenPath: env.BOOTSTRAP_ADMIN_TOKEN_PATH,
-          clientId: env.BOOTSTRAP_ADMIN_CLIENT_ID,
-          tokenExpiryMs: env.BOOTSTRAP_ADMIN_TOKEN_EXPIRY_MS,
-        },
-      )
+    ? new BootstrapAdminManager(new AuthMiddleware(wsConfig), pinoLog, {
+        enabled: env.BOOTSTRAP_ADMIN_ENABLED,
+        tokenPath: env.BOOTSTRAP_ADMIN_TOKEN_PATH,
+        clientId: env.BOOTSTRAP_ADMIN_CLIENT_ID,
+        tokenExpiryMs: env.BOOTSTRAP_ADMIN_TOKEN_EXPIRY_MS,
+      })
     : undefined;
 
   await bootstrapAdmin?.ensureToken();
@@ -424,7 +429,7 @@ export async function buildApp() {
       jobRunsRepo,
       sessionService,
       sessionsRepo,
-      log as unknown as FastifyBaseLogger,
+      pinoLog,
       { pollIntervalMs: 5000 },
     );
 
@@ -439,7 +444,7 @@ export async function buildApp() {
         jobRunsRepo,
         sessionsStore: sessionsRepo,
         sessionMessageService: sessionService,
-        logger: log as unknown as FastifyBaseLogger,
+        logger: pinoLog,
       }),
     );
   }

--- a/apps/server/src/lib/logger.test.ts
+++ b/apps/server/src/lib/logger.test.ts
@@ -7,6 +7,7 @@ import {
   createLogger,
   setCorrelationContext,
   clearCorrelationContext,
+  toPinoStyleLogger,
 } from './logger';
 
 describe('LogBuffer', () => {
@@ -279,6 +280,68 @@ describe('createLogger', () => {
     expect(result.items[0]?.runId).toBe('run-456');
 
     clearCorrelationContext();
+  });
+});
+
+describe('toPinoStyleLogger', () => {
+  beforeEach(() => {
+    resetLogBuffer();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the message as the message when context comes first (pino order)', () => {
+    const log = toPinoStyleLogger(createLogger('mcp'));
+    log.warn(
+      { serverId: 'MiniMax', stderr: 'ModuleNotFoundError' },
+      'MCP server stderr',
+    );
+
+    const entry = getLogBuffer().query().items[0];
+    expect(entry?.message).toBe('MCP server stderr');
+    expect(entry?.args).toEqual([
+      { serverId: 'MiniMax', stderr: 'ModuleNotFoundError' },
+    ]);
+  });
+
+  it('passes (message, meta) calls through untouched', () => {
+    const log = toPinoStyleLogger(createLogger('mcp'));
+    log.info('MCP server connected', { serverId: 'MiniMax' });
+
+    const entry = getLogBuffer().query().items[0];
+    expect(entry?.message).toBe('MCP server connected');
+    expect(entry?.args).toEqual([{ serverId: 'MiniMax' }]);
+  });
+
+  it('keeps the context when a bare object is logged with no message', () => {
+    const log = toPinoStyleLogger(createLogger('mcp'));
+    log.error({ err: 'boom' });
+
+    const entry = getLogBuffer().query().items[0];
+    expect(entry?.message).toBe('');
+    expect(entry?.args).toEqual([{ err: 'boom' }]);
+  });
+
+  it('never stringifies the context into the message', () => {
+    const log = toPinoStyleLogger(createLogger('mcp'));
+    log.info({ serverId: 'MiniMax' }, 'Connecting');
+
+    const entry = getLogBuffer().query().items[0];
+    expect(entry?.message).not.toContain('[object Object]');
+  });
+
+  it('preserves the log level of the wrapped logger', () => {
+    const log = toPinoStyleLogger(createLogger('mcp'));
+    log.warn({ a: 1 }, 'warned');
+    log.error({ b: 2 }, 'errored');
+
+    const items = getLogBuffer().query().items;
+    expect(items.map((i) => i.level)).toEqual(['error', 'warn']);
   });
 });
 

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -22,6 +22,24 @@ interface Logger {
   error: (message: string, ...args: unknown[]) => void;
 }
 
+type LogFn = (message: string, ...args: unknown[]) => void;
+
+/**
+ * A log function that accepts either this module's `(message, ...args)` order
+ * or pino's `(mergeObject, message)` order. See {@link toPinoStyleLogger}.
+ */
+type PinoStyleLogFn = {
+  (message: string, ...args: unknown[]): void;
+  (context: object, message?: string, ...args: unknown[]): void;
+};
+
+export interface PinoStyleLogger {
+  debug: PinoStyleLogFn;
+  info: PinoStyleLogFn;
+  warn: PinoStyleLogFn;
+  error: PinoStyleLogFn;
+}
+
 // ============================================================================
 // Internal helpers
 // ============================================================================
@@ -89,6 +107,45 @@ export function createLogger(context: string = ''): Logger {
 }
 
 export const logger = createLogger();
+
+/**
+ * Wrap a {@link Logger} so it also accepts pino's `(mergeObject, message)`
+ * calling convention.
+ *
+ * Services typed against Fastify's `FastifyBaseLogger` — the MCP client, the
+ * scheduler, the channels, `SessionMessageService` — log structured context
+ * first: `logger.warn({ serverId, stderr }, 'MCP server stderr')`. Handing them
+ * this module's `(message, ...args)` logger made the context object the
+ * *message*, so every such line printed `[object Object]` and the real text was
+ * demoted to an argument. The context itself (an MCP server's stderr, a job id,
+ * a provider error) reached neither the console nor the log buffer's `message`
+ * field, which is how a failing MCP server's Python traceback stayed invisible.
+ *
+ * Both orders are accepted, so a consumer that logs `(message, meta)` is
+ * unaffected.
+ */
+export function toPinoStyleLogger(base: Logger): PinoStyleLogger {
+  const adapt =
+    (fn: LogFn): PinoStyleLogFn =>
+    (first: string | object, ...rest: unknown[]) => {
+      // Already `(message, ...args)` — pass through untouched.
+      if (typeof first === 'string') {
+        fn(first, ...rest);
+        return;
+      }
+      // pino order: the message (when present) follows the merge object.
+      const [message, ...others] = rest;
+      const text = typeof message === 'string' ? message : '';
+      fn(text, first, ...others);
+    };
+
+  return {
+    debug: adapt(base.debug),
+    info: adapt(base.info),
+    warn: adapt(base.warn),
+    error: adapt(base.error),
+  };
+}
 
 // ============================================================================
 // Fastify HTTP Logging Plugin


### PR DESCRIPTION
## Summary

Six services in `buildApp` are typed against Fastify's `FastifyBaseLogger` and log pino-style, context first:

```ts
this.logger?.warn({ serverId: id, stderr: data.toString() }, 'MCP server stderr');
```

They were handed this project's `(message, ...args)` logger behind an `as unknown as FastifyBaseLogger` cast. `formatMessage` then interpolated the context object into the message slot, so every one of those lines printed `[object Object]` and the real message was demoted to a trailing argument. The context — an MCP server's stderr, a job id, a provider error — reached neither the console nor the log buffer's `message` field.

This is not cosmetic. It is why a failing stdio MCP server was undebuggable: the child's stderr *was* captured and *was* handed to the logger, then discarded. What an operator actually saw:

```
[WARN] [object Object] MCP server stderr
[INFO] [object Object] MCP process exited
[WARN] Failed to connect MCP server on startup { serverId: 'MiniMax', err: McpError: MCP error -32000: Connection closed }
```

The Python traceback naming the real cause was in that first line and never made it out. After this change:

```
[INFO] Connecting to MCP server via stdio { serverId: 'MiniMax', command: 'uvx' }
[WARN] MCP server stderr { serverId: 'MiniMax', stderr: "ModuleNotFoundError: No module named 'mcp.server.fastmcp'" }
```

## Approach

`toPinoStyleLogger` wraps the project logger and accepts **both** argument orders — object-first is swapped, string-first passes through untouched — so consumers that log `(message, meta)` are unaffected. Applied once in `buildApp` rather than at each of the six injection sites, which is also where the six identical casts collapse into one.

Affected consumers, all of which log pino-style: `McpClientService` (22 call sites), `SessionMessageService`, `SchedulerService`, the pulse runnable adapter, the WhatsApp/Discord channels, and `BootstrapAdminManager`. The WebSocket handlers were already fine — they receive `fastify.log`, a real pino instance.

## Testing

- Five unit tests on the adapter: pino order, `(message, meta)` order, bare object with no message, level preservation, and an explicit assertion that the message never contains `[object Object]`.
- `pnpm --filter @openaidy/server test`: 3386 passed. The one failure, `update/service.test.ts` "passes the version as a single argv element", reproduces identically on unmodified `main` on Windows — it asserts `shell: false` and is unrelated to this change.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)