### PR TITLE
chore(release): bump version to 0.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
Version bump for the 0.3.11 release. One line in the root `package.json`, which `RELEASING.md` names as the single source of truth.

No other file needs it: `apps/server/src/lib/version.ts` resolves the version at runtime by walking up to the nearest `package.json` with a `version` field, so there is no compiled constant to keep in sync. `0.3.10` appears exactly once in the repo (`package.json:3`) and this changes that occurrence.

## Shipping in 0.3.11

| PR | Change |
|----|--------|
| #479 | Session organization — rename, favorite, archive |
| #480 | MiniMax streaming tool-call markup stripped; SKILL.md validation surfaced in the UI; jpeg media support |
| #481 | `skill_update` agent tool |
| #483 | Structured log context no longer prints as `[object Object]` |
| #484 | `uvx` MCP server environments repaired instead of failing the connect |
| #482 | Installer provisions the `uv` toolchain |
| #485 | Addon iframes follow the host theme |

## After merging

Per `RELEASING.md`, the tag has to point at the commit as it lands on `main`, so it can't be created ahead of the merge:

```
git checkout main && git pull
git tag v0.3.11
git push origin main --tags
```

Pushing the tag triggers `.github/workflows/release.yml`, which re-runs the full gate and then creates the GitHub Release with auto-generated notes. The installer's default path resolves the newest release tag, so this is what `curl -fsSL https://openaidy.com/install.sh | bash` picks up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)