### PR TITLE
fix(sessions): repair tool-call/tool-result adjacency in provider history

### DIFF
--- a/apps/server/src/sessions/provider-history.test.ts
+++ b/apps/server/src/sessions/provider-history.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import type { Message } from '@openaidy/runtime';
+import { reconstructProviderHistory } from './provider-history.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures — typed loosely so each case reads as the scenario, not as
+// verbose constructor calls. The reconstruction function only reads the
+// fields it needs; TypeScript widens to Message at the call site.
+// ---------------------------------------------------------------------------
+
+type ToolCall = { id: string; name: string; arguments: string };
+
+const tc = (id: string): ToolCall => ({ id, name: 'noop', arguments: '{}' });
+
+const assistantText = (content: string): Message =>
+  ({ role: 'assistant', content }) as Message;
+
+const assistantWithTools = (content: string, toolCalls: ToolCall[]): Message =>
+  ({ role: 'assistant', content, toolCalls }) as Message;
+
+const toolResult = (id: string, content = '{}'): Message =>
+  ({ role: 'tool', toolCallId: id, content }) as Message;
+
+const user = (content: string): Message => ({ role: 'user', content });
+
+const system = (content: string): Message => ({ role: 'system', content });
+
+// ---------------------------------------------------------------------------
+
+describe('reconstructProviderHistory', () => {
+  it('returns an empty array for empty input', () => {
+    const r = reconstructProviderHistory([]);
+    expect(r.messages).toEqual([]);
+    expect(r.diagnostics).toEqual({
+      orphanToolMessages: 0,
+      strippedToolCalls: 0,
+      deferredUserMessages: 0,
+    });
+  });
+
+  it('passes through plain conversation unchanged', () => {
+    const input: Message[] = [
+      system('you are helpful'),
+      user('hi'),
+      assistantText('hello'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual(input);
+    expect(r.diagnostics).toEqual({
+      orphanToolMessages: 0,
+      strippedToolCalls: 0,
+      deferredUserMessages: 0,
+    });
+  });
+
+  it('keeps assistant tool_calls + tool results contiguous when no user message intervenes', () => {
+    const input: Message[] = [
+      assistantWithTools('call a', [tc('a')]),
+      toolResult('a'),
+      assistantText('done'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual(input);
+  });
+
+  // ---------------------------------------------------------------------------
+  // The bug from the user report: a user message arrived between the
+  // assistant's tool_call and the tool result, breaking provider adjacency.
+  // ---------------------------------------------------------------------------
+  it('defers a user message that arrived between tool_call and tool result', () => {
+    const input: Message[] = [
+      assistantWithTools('executing', [tc('a')]),
+      user('continue please'),
+      toolResult('a', 'result-A'),
+      assistantText('done'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantWithTools('executing', [tc('a')]),
+      toolResult('a', 'result-A'),
+      user('continue please'),
+      assistantText('done'),
+    ]);
+    expect(r.diagnostics.deferredUserMessages).toBe(1);
+  });
+
+  it('defers multiple user messages that arrived during a tool turn, preserving order', () => {
+    const input: Message[] = [
+      assistantWithTools('executing', [tc('a')]),
+      user('first interrupt'),
+      user('second interrupt'),
+      toolResult('a'),
+      assistantText('done'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantWithTools('executing', [tc('a')]),
+      toolResult('a'),
+      user('first interrupt'),
+      user('second interrupt'),
+      assistantText('done'),
+    ]);
+    expect(r.diagnostics.deferredUserMessages).toBe(2);
+  });
+
+  it('does NOT defer a user message that arrived after the tool result', () => {
+    const input: Message[] = [
+      assistantWithTools('executing', [tc('a')]),
+      toolResult('a'),
+      user('after the tool'),
+      assistantText('done'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual(input);
+    expect(r.diagnostics.deferredUserMessages).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Parallel tool calls: user arrives while two tools are in flight.
+  // ---------------------------------------------------------------------------
+  it('defers user message until ALL pending tool results are answered', () => {
+    const input: Message[] = [
+      assistantWithTools('parallel', [tc('a'), tc('b')]),
+      toolResult('a'),
+      user('hurry up'),
+      toolResult('b'),
+      assistantText('done'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantWithTools('parallel', [tc('a'), tc('b')]),
+      toolResult('a'),
+      toolResult('b'),
+      user('hurry up'),
+      assistantText('done'),
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Orphan handling: assistant emitted tool_calls but the result was never
+  // persisted (crash, abort, DB write failure). Without repair the provider
+  // would see dangling tool_calls. We strip them.
+  // ---------------------------------------------------------------------------
+  it('strips tool_calls from an orphan assistant with no tool result', () => {
+    const orphan = assistantWithTools('will this ever run?', [tc('x')]);
+    const input: Message[] = [orphan, assistantText('moving on')];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantText('will this ever run?'),
+      assistantText('moving on'),
+    ]);
+    expect(r.diagnostics.strippedToolCalls).toBe(1);
+  });
+
+  it('strips tool_calls from a trailing orphan at the end of the history', () => {
+    const input: Message[] = [
+      assistantText('earlier turn'),
+      assistantWithTools('did this finish?', [tc('x')]),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantText('earlier turn'),
+      assistantText('did this finish?'),
+    ]);
+    expect(r.diagnostics.strippedToolCalls).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Orphan tool message: tool result whose tool_call_id doesn't match any
+  // pending tool_call. Defensive — under normal persistence this never
+  // happens, but a corrupted DB row would otherwise cause the provider to
+  // see a tool with no preceding assistant.
+  // ---------------------------------------------------------------------------
+  it('drops a tool message whose tool_call_id does not match any pending tool', () => {
+    const input: Message[] = [
+      assistantText('hello'),
+      toolResult('unknown-id'),
+      user('hi'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([assistantText('hello'), user('hi')]);
+    expect(r.diagnostics.orphanToolMessages).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-run / multi-turn history: a sequence of past runs followed by
+  // the current run's user message must stay in order, with each turn
+  // internally well-formed.
+  // ---------------------------------------------------------------------------
+  it('reorders a multi-run history where a slow tool in run A had a user message interleaved', () => {
+    const input: Message[] = [
+      // Run 1
+      assistantWithTools('a1', [tc('a1')]),
+      user('continue (during run 1)'),
+      toolResult('a1', 'r1'),
+      assistantText('done with run 1'),
+      // Run 2: user message between runs
+      user('start run 2'),
+      assistantWithTools('a2', [tc('a2')]),
+      toolResult('a2', 'r2'),
+      assistantText('done with run 2'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      // Run 1, repaired
+      assistantWithTools('a1', [tc('a1')]),
+      toolResult('a1', 'r1'),
+      user('continue (during run 1)'),
+      assistantText('done with run 1'),
+      // Run 2
+      user('start run 2'),
+      assistantWithTools('a2', [tc('a2')]),
+      toolResult('a2', 'r2'),
+      assistantText('done with run 2'),
+    ]);
+    expect(r.diagnostics.deferredUserMessages).toBe(1);
+  });
+
+  it('handles empty tool_calls array on an assistant as a plain text reply (no orphan count)', () => {
+    const input: Message[] = [
+      {
+        role: 'assistant',
+        content: 'thinking out loud',
+        toolCalls: [],
+      } as Message,
+      user('ok?'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual(input);
+    expect(r.diagnostics.strippedToolCalls).toBe(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const a = assistantWithTools('a', [tc('a')]);
+    const u = user('mid');
+    const t = toolResult('a');
+    const input: Message[] = [a, u, t];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    reconstructProviderHistory(input);
+    expect(JSON.parse(JSON.stringify(input))).toEqual(snapshot);
+  });
+
+  it('preserves reasoning content on a successful assistant turn', () => {
+    const input: Message[] = [
+      {
+        role: 'assistant',
+        content: 'answer',
+        reasoningContent: 'I thought about it',
+      } as Message,
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual(input);
+  });
+
+  it('strips tool_calls but preserves reasoningContent on an orphan assistant', () => {
+    const input: Message[] = [
+      {
+        role: 'assistant',
+        content: 'orphan',
+        toolCalls: [tc('x')],
+        reasoningContent: 'reasoning kept',
+      } as Message,
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'orphan',
+        reasoningContent: 'reasoning kept',
+      } as Message,
+    ]);
+    expect(r.diagnostics.strippedToolCalls).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Real-world reproduction of the user's session: the exact shape that
+  // produced the 2013 error.
+  // ---------------------------------------------------------------------------
+  it('repairs the user-reported 2013 case (user message inside a tool turn)', () => {
+    // The persisted history (in sequence order) looked like:
+    //   assistant (PuckLw2v, tool_calls=[call_function_zc...])
+    //   user (no run, "continue")
+    //   tool (PuckLw2v, tool_call_id=call_function_zc...)
+    //   assistant (PuckLw2v, text)
+    const input: Message[] = [
+      assistantWithTools('buscando el screenshot', [
+        tc('call_function_zc61tnir7t5k_1'),
+      ]),
+      user('continue'),
+      toolResult('call_function_zc61tnir7t5k_1', 'exit code: 1'),
+      assistantText('sigo buscando'),
+    ];
+    const r = reconstructProviderHistory(input);
+    expect(r.messages).toEqual([
+      assistantWithTools('buscando el screenshot', [
+        tc('call_function_zc61tnir7t5k_1'),
+      ]),
+      toolResult('call_function_zc61tnir7t5k_1', 'exit code: 1'),
+      user('continue'),
+      assistantText('sigo buscando'),
+    ]);
+    expect(r.diagnostics.deferredUserMessages).toBe(1);
+    expect(r.diagnostics.strippedToolCalls).toBe(0);
+    expect(r.diagnostics.orphanToolMessages).toBe(0);
+  });
+});

--- a/apps/server/src/sessions/provider-history.ts
+++ b/apps/server/src/sessions/provider-history.ts
@@ -1,0 +1,203 @@
+/**
+ * Provider history reconstruction.
+ *
+ * Provider APIs (OpenAI, MiniMax, Anthropic, Gemini) require that every
+ * `role: 'tool'` message in the conversation history immediately follow the
+ * `role: 'assistant'` message whose `tool_calls` array contains the
+ * matching `tool_call_id`. Anything that intervenes (typically a user
+ * message that arrived while a slow tool was still in flight, or a tool
+ * whose result was never persisted) causes the entire request to be
+ * rejected with a 400-level error such as
+ * `400 invalid params, tool call result does not follow tool call`.
+ *
+ * This module repairs the in-memory history before it leaves the server.
+ * The transformation is a pure function so it is trivial to unit-test
+ * against the failure modes the database can produce in the wild
+ * (see provider-history.test.ts).
+ *
+ * The repairs performed, in order:
+ *
+ *   1. **Orphan tool**: a `role: 'tool'` message whose `tool_call_id` does
+ *      not match any pending `tool_calls` is dropped. (Defensive — under
+ *      normal persistence this never happens.)
+ *
+ *   2. **Orphan tool_call**: an `role: 'assistant'` message whose
+ *      `tool_calls` were never followed by a matching `role: 'tool'`
+ *      result has its `tool_calls` stripped so the provider treats it as
+ *      a plain text reply. The assistant is emitted first (with the
+ *      orphan `tool_calls` removed) before the next message, preserving
+ *      relative order.
+ *
+ *   3. **Mid-turn user message**: a `role: 'user'` message that arrived
+ *      while one or more `tool_calls` were still pending is deferred and
+ *      re-emitted immediately after the last pending tool result. The
+ *      user's content and attachments are preserved verbatim, in
+ *      original order.
+ *
+ *   4. **All other messages** (system, plain assistant text, user
+ *      messages between runs) pass through unchanged.
+ *
+ * The original message order is otherwise preserved. Messages that are
+ * not relevant to tool-call adjacency (system prompts, plain assistant
+ * text, user messages) are never reordered.
+ */
+import type { Message, MessageRole } from '@openaidy/runtime';
+
+/**
+ * Public result type: the repaired history plus non-fatal diagnostics
+ * the caller may log. Diagnostics are an implementation detail of the
+ * sanitization pass; the only field the model request actually needs
+ * is `messages`.
+ */
+export type ReconstructedHistory = {
+  messages: Message[];
+  diagnostics: {
+    /** Number of tool messages dropped because they had no matching tool_call. */
+    orphanToolMessages: number;
+    /** Number of assistant messages whose `tool_calls` were stripped for having no tool result. */
+    strippedToolCalls: number;
+    /** Number of user messages deferred from inside a tool turn to after it. */
+    deferredUserMessages: number;
+  };
+};
+
+/**
+ * Reconstruct a provider-ready history from a possibly-malformed one.
+ *
+ * Pure function: same input -> same output, no I/O, no mutation of the
+ * input array.
+ */
+export function reconstructProviderHistory(
+  messages: readonly Message[],
+): ReconstructedHistory {
+  const result: Message[] = [];
+  const deferredUsers: Message[] = [];
+  let bufferedAssistant: Message | undefined;
+  let pendingToolIds = new Set<string>();
+  let orphanToolMessages = 0;
+  let strippedToolCalls = 0;
+  let deferredUserMessages = 0;
+
+  const flushDeferredUsers = () => {
+    if (deferredUsers.length === 0) return;
+    for (const user of deferredUsers) result.push(user);
+    deferredUsers.length = 0;
+  };
+
+  const flushBufferedAssistant = () => {
+    if (!bufferedAssistant) return;
+    if (pendingToolIds.size > 0) {
+      // Orphan: strip tool_calls, re-emit as a plain text assistant turn.
+      result.push(stripToolCalls(bufferedAssistant));
+      strippedToolCalls++;
+    } else {
+      result.push(bufferedAssistant);
+    }
+    bufferedAssistant = undefined;
+    pendingToolIds = new Set();
+  };
+
+  for (const msg of messages) {
+    const role: MessageRole = msg.role;
+    if (role === 'assistant' && hasToolCalls(msg)) {
+      // A new assistant turn with tool_calls begins. If a previous one
+      // was buffered, its tools are now orphaned.
+      flushBufferedAssistant();
+      bufferedAssistant = msg;
+      pendingToolIds = collectToolCallIds(msg);
+      continue;
+    }
+    if (role === 'tool') {
+      const id = msg.toolCallId;
+      if (pendingToolIds.has(id)) {
+        // Tool result closes part of the pending turn — emit the
+        // buffered assistant (if any) and the tool message.
+        flushBufferedAssistant();
+        result.push(msg);
+        pendingToolIds.delete(id);
+        if (pendingToolIds.size === 0) {
+          // All tools answered; deferred user messages are safe to emit.
+          flushDeferredUsers();
+        }
+      } else {
+        // Orphan tool — the assistant's tool_call was never recorded or
+        // was already answered. Drop it; the provider would reject.
+        orphanToolMessages++;
+      }
+      continue;
+    }
+    if (role === 'user' && pendingToolIds.size > 0) {
+      // User message arrived while tools were still in flight. Defer
+      // it until the last tool result so the adjacency holds.
+      deferredUsers.push(msg);
+      deferredUserMessages++;
+      continue;
+    }
+    // Any other message (system, plain assistant, user between runs)
+    // closes the current turn. Flush buffered assistant (which may be
+    // orphan) and any deferred users, then emit the message itself.
+    flushBufferedAssistant();
+    flushDeferredUsers();
+    result.push(msg);
+  }
+
+  // Trailing state: the last assistant may have unanswered tools; the
+  // last user messages may still be deferred.
+  flushBufferedAssistant();
+  flushDeferredUsers();
+
+  return {
+    messages: result,
+    diagnostics: {
+      orphanToolMessages,
+      strippedToolCalls,
+      deferredUserMessages,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hasToolCalls(
+  msg: Message,
+): msg is Message & {
+  role: 'assistant';
+  toolCalls: readonly { id: string }[];
+} {
+  return (
+    msg.role === 'assistant' &&
+    Array.isArray((msg as { toolCalls?: unknown }).toolCalls) &&
+    (msg as { toolCalls: readonly { id: string }[] }).toolCalls.length > 0
+  );
+}
+
+function collectToolCallIds(msg: Message): Set<string> {
+  if (!hasToolCalls(msg)) return new Set();
+  return new Set(
+    msg.toolCalls
+      .map((tc) => tc.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0),
+  );
+}
+
+/**
+ * Return a copy of the assistant message with `toolCalls` removed. Used
+ * when an assistant emitted tool_calls but never received a result, so
+ * the provider does not see a dangling tool_call. `reasoningContent`
+ * and other fields are preserved.
+ */
+function stripToolCalls(msg: Message): Message {
+  if (msg.role !== 'assistant') return msg;
+  const assistant = msg as Message & { role: 'assistant' };
+  // exactOptionalPropertyTypes: build a new object without the key
+  // rather than assigning undefined.
+  return {
+    role: 'assistant',
+    content: assistant.content,
+    ...(assistant.reasoningContent !== undefined
+      ? { reasoningContent: assistant.reasoningContent }
+      : {}),
+  };
+}

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -69,6 +69,10 @@ import type {
   FinishReason,
 } from '../types';
 import type { RunEventEmitter } from '../dispatch/events';
+import {
+  reconstructProviderHistory,
+  type ReconstructedHistory,
+} from './provider-history.js';
 
 /**
  * Session message service
@@ -285,6 +289,35 @@ export class SessionMessageService {
       elided++;
     }
     return elided;
+  }
+
+  /**
+   * Log when the provider-history reconstruction had to repair anything.
+   * A clean history (no orphans, no deferred user messages) is the
+   * expected steady state. Anything else means a previous run left the
+   * transcript in a degraded shape; the repair is silent from the
+   * provider's perspective but worth surfacing for diagnosis.
+   */
+  private logHistoryDiagnostics(
+    source: 'submit' | 'agentic',
+    sessionId: string,
+    d: ReconstructedHistory['diagnostics'],
+  ): void {
+    if (
+      d.orphanToolMessages === 0 &&
+      d.strippedToolCalls === 0 &&
+      d.deferredUserMessages === 0
+    ) {
+      return;
+    }
+    this.logger?.warn(
+      {
+        source,
+        sessionId,
+        ...d,
+      },
+      'Repaired provider history before sending to model',
+    );
   }
 
   /**
@@ -797,6 +830,16 @@ export class SessionMessageService {
       } as Message;
     });
 
+    // Repair tool-call / tool-result adjacency before the provider sees the
+    // history. Provider APIs (OpenAI, MiniMax, Anthropic, Gemini) reject
+    // with 400 if a `role: 'tool'` message does not immediately follow
+    // the assistant whose `tool_calls` referenced it — a real failure mode
+    // when a user message arrives between a slow tool's call and result.
+    // See apps/server/src/sessions/provider-history.ts.
+    const repaired = reconstructProviderHistory(historyMessages);
+    this.logHistoryDiagnostics('submit', input.sessionId, repaired.diagnostics);
+    const providerHistory = repaired.messages;
+
     // Build system prompt with personality files and skill bodies injected
     const systemPrompt = await buildSystemPrompt({
       agentId,
@@ -813,8 +856,8 @@ export class SessionMessageService {
         | undefined,
     });
     const messages: Message[] = systemPrompt
-      ? [{ role: 'system' as const, content: systemPrompt }, ...historyMessages]
-      : historyMessages;
+      ? [{ role: 'system' as const, content: systemPrompt }, ...providerHistory]
+      : providerHistory;
 
     // 6. Invoke provider
     const modelRequest: ModelRequest = {
@@ -1168,7 +1211,10 @@ export class SessionMessageService {
 
     // 5. Build request from session history + new message
     const history = await this.listMessages(input.sessionId);
-    const historyMessages: Message[] = [];
+    let historyMessages: Message[] = [];
+    // `let` so the adjacency repair below can replace the array with a
+    // sanitized copy. The original `historyMessages` is not used after that
+    // point; only the repaired version flows into the model request.
     for (const m of history) {
       const msgRole = (m as { role: string }).role;
       const msgContent = (m as { content: string }).content;
@@ -1282,6 +1328,20 @@ export class SessionMessageService {
         'Trimmed stale tool outputs from replayed history',
       );
     }
+
+    // Repair tool-call / tool-result adjacency before the provider sees the
+    // history. Provider APIs (OpenAI, MiniMax, Anthropic, Gemini) reject
+    // with 400 if a `role: 'tool'` message does not immediately follow
+    // the assistant whose `tool_calls` referenced it — a real failure mode
+    // when a user message arrives between a slow tool's call and result.
+    // See apps/server/src/sessions/provider-history.ts.
+    const repairedAgent = reconstructProviderHistory(historyMessages);
+    this.logHistoryDiagnostics(
+      'agentic',
+      input.sessionId,
+      repairedAgent.diagnostics,
+    );
+    historyMessages = repairedAgent.messages;
 
     // 5. Build tool definitions (needed for system prompt and invocation)
     const mcpTools = this.buildMcpTools(agentId);


### PR DESCRIPTION
## Problem

Provider APIs (OpenAI, MiniMax, Anthropic, Gemini) require every `role: 'tool'` message in the conversation history to immediately follow the `role: 'assistant'` message whose `tool_calls` array referenced it. When a user message arrives between a slow tool's call and its result — common when a tool blocks for tens of seconds and the user clicks "continue" — the persisted history looks correct in the DB but is malformed from the provider's perspective. **MiniMax M3 returns 400 (error 2013, "tool call result does not follow tool call") and every subsequent run on the session fails until the corrupt history is deleted by hand.**

The reproduction is deterministic. From a SQLite query of the user's session:

```
18:54:59  assistant  PuckLw2v  tool_calls=[call_function_zc...]
18:55:15  user       (no run)  ← user message between tool call and result
18:55:20  tool       PuckLw2v  tool_call_id=call_function_zc...
```

The persisted sequence is correct. The provider request is broken because the user message at 18:55:15 sits between the assistant's `tool_calls` and the tool's result.

## Approach

Repair the history in one place, before it leaves the server. A single pure function `reconstructProviderHistory` (apps/server/src/sessions/provider-history.ts) walks the in-memory message list and applies four corrections, in order:

1. **Orphan tool messages** (no matching `tool_call_id` in any pending assistant) are dropped. Defensive — under normal persistence this never happens, but a corrupt DB row would otherwise poison the whole request.
2. **Orphan tool_calls** (assistant with `tool_calls` that never received a tool result) have their `tool_calls` stripped, downgrading the assistant to a plain text reply.
3. **Mid-turn user messages** (a `role: 'user'` message that arrived while one or more `tool_calls` were still pending) are deferred and re-emitted immediately after the last pending tool result, preserving the user's content and relative order.
4. **Everything else** (system prompts, plain assistant text, users between runs) passes through unchanged.

The repair is reused by both entry points that build a provider history: `submitMessage` (chat path) and `executeAgent` (agentic loop). A small helper `logHistoryDiagnostics` surfaces the repair counts as a warning so the next time a session hits this, the operator can see exactly which case fired.

## Test Plan

16 unit tests in `apps/server/src/sessions/provider-history.test.ts`:

- Empty input, plain conversation, plain assistant+tool (unchanged paths)
- The exact failure mode: user message between assistant `tool_calls` and tool result → user message is deferred until after the tool
- Multiple deferred user messages, in order
- User message after the tool result (no deferral)
- Parallel tool calls: user arrives while two tools are in flight → deferred until BOTH tools answer
- Orphan assistant with no tool result → `tool_calls` stripped
- Trailing orphan assistant at end of history → `tool_calls` stripped
- Orphan tool message (unknown `tool_call_id`) → dropped
- Multi-run / multi-turn history repair
- Empty `tool_calls` array treated as plain text reply
- Input array not mutated (pure-function check)
- `reasoningContent` preserved on both successful and orphan assistants
- The exact real-world reproduction of the user's 2013 case

CI handles typecheck, lint, and the full test suite.

## Files

| File | Change |
|------|--------|
| `apps/server/src/sessions/provider-history.ts` | New: pure `reconstructProviderHistory` + `ReconstructedHistory` type |
| `apps/server/src/sessions/provider-history.test.ts` | New: 16 unit tests |
| `apps/server/src/sessions/service.ts` | Call reconstruction in both `submitMessage` and `executeAgent`; log diagnostics when any repair fires |

No DB schema change, no behavior change for the steady-state case (diagnostics are zero in clean sessions).