### PR TITLE
feat(skills): auto-activate newly created skills on the creating agent

### DIFF
--- a/apps/server/src/agents/registry.ts
+++ b/apps/server/src/agents/registry.ts
@@ -321,6 +321,41 @@ export class AgentRegistry {
   }
 
   /**
+   * Append a skill ID to an agent's skills list.
+   * Patches both the in-memory registry and the main openaidy.json config file on disk.
+   *
+   * - Throws if the agent does not exist.
+   * - No-op (returns the existing agent) if the skill is already attached.
+   * - Otherwise appends the skillId, persists the change, and returns the updated agent.
+   */
+  addSkillToAgent(agentId: string, skillId: string): Agent {
+    this.ensureLoaded();
+    const agent = this.agents.get(agentId);
+    if (!agent) {
+      throw new Error(`Agent with ID "${agentId}" not found`);
+    }
+
+    const currentSkills = agent.skills ?? [];
+    if (currentSkills.includes(skillId)) {
+      return agent;
+    }
+
+    const newSkills = [...currentSkills, skillId];
+    const updated: Agent = {
+      ...agent,
+      skills: newSkills,
+    };
+    this.agents.set(agentId, updated);
+    this.persistConfig((agents) => {
+      const idx = agents.findIndex((a) => a['id'] === agentId);
+      if (idx !== -1) {
+        agents[idx]!['skills'] = newSkills;
+      }
+    });
+    return updated;
+  }
+
+  /**
    * Update the MCP server references for an agent.
    * Patches both the in-memory registry and the main openaidy.json config file on disk.
    * Returns the updated AgentSummary or undefined if the agent was not found.

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -200,6 +200,9 @@ export const skillCreateMeta: ToolMeta = {
   description:
     'Create a new skill and save it to the skills directory. ' +
     'A skill is a reusable set of instructions that can be assigned to agents. ' +
+    'The new skill is automatically activated for the calling agent — no ' +
+    'follow-up agent_update call is needed unless the tool result says ' +
+    'activation failed. ' +
     'REQUIRED parameters: id (lowercase, hyphens), name (human-readable), ' +
     'description (one-line summary used by the skill registry and by agents ' +
     'to decide when to load the skill — frontmatter is generated from these), ' +

--- a/apps/server/src/tools/index.ts
+++ b/apps/server/src/tools/index.ts
@@ -119,7 +119,13 @@ export function createBuiltinToolRegistry(
   }
 
   if (deps.skills) {
-    for (const tool of createSkillTools(deps.skills.registry, deps.workspace)) {
+    // deps.agents is always co-configured with deps.skills in app.ts
+    // (skill auto-activation requires the agent registry).
+    for (const tool of createSkillTools(
+      deps.skills.registry,
+      deps.agents!.registry,
+      deps.workspace,
+    )) {
       registry.register(tool);
     }
   }

--- a/apps/server/src/tools/skills/create.ts
+++ b/apps/server/src/tools/skills/create.ts
@@ -190,25 +190,30 @@ export function createSkillCreateTool(
         companionList.length > 0
           ? ` Companion files written: ${companionList.join(', ')}.`
           : '';
-      const successMessage = `Skill "${id}" created and activated for agent "${ctx.agentId}".${companionNote}`;
-
       try {
         agentRegistry.addSkillToAgent(ctx.agentId, id);
       } catch (err) {
         const errMessage = err instanceof Error ? err.message : String(err);
+        // `content` is the only field the caller (the model, via the tool
+        // result) actually reads — `warning` has no consumer anywhere in the
+        // codebase (same as the pre-existing `web_fetch` warning field), so
+        // it must not be the sole place the failure is reported. Say plainly
+        // that activation did NOT happen; claiming success here would leave
+        // the model believing the skill's instructions are already loaded
+        // into its context when they are not.
         logger.warn(
           `Skill "${id}" registered but failed to auto-activate on agent "${ctx.agentId}": ${errMessage}`,
         );
         return {
           ok: true,
-          content: successMessage,
+          content: `Skill "${id}" created${companionNote} but NOT activated for agent "${ctx.agentId}": ${errMessage}. Call agent_update to add it manually.`,
           warning: `Skill registered but failed to auto-activate on agent "${ctx.agentId}": ${errMessage}. Call agent_update to add it manually.`,
         };
       }
 
       return {
         ok: true,
-        content: successMessage,
+        content: `Skill "${id}" created and activated for agent "${ctx.agentId}".${companionNote}`,
       };
     },
   };

--- a/apps/server/src/tools/skills/create.ts
+++ b/apps/server/src/tools/skills/create.ts
@@ -3,8 +3,12 @@ import { join, basename } from 'node:path';
 import type { BuiltinTool } from '@openaidy/runtime';
 import { parseSkillMd } from '../../skills/parser.js';
 import type { SkillRegistry } from '../../skills/index.js';
+import type { AgentRegistry } from '../../agents/registry.js';
 import type { WorkspaceService } from '../../workspace/service.js';
+import { createLogger } from '../../lib/logger.js';
 import { skillCreateMeta } from '../catalog.js';
+
+const logger = createLogger('skill_create');
 
 /**
  * skill_create
@@ -20,6 +24,7 @@ import { skillCreateMeta } from '../catalog.js';
  */
 export function createSkillCreateTool(
   skillRegistry: SkillRegistry,
+  agentRegistry: AgentRegistry,
   workspace: WorkspaceService,
 ): BuiltinTool {
   return {
@@ -185,10 +190,25 @@ export function createSkillCreateTool(
         companionList.length > 0
           ? ` Companion files written: ${companionList.join(', ')}.`
           : '';
+      const successMessage = `Skill "${id}" created and activated for agent "${ctx.agentId}".${companionNote}`;
+
+      try {
+        agentRegistry.addSkillToAgent(ctx.agentId, id);
+      } catch (err) {
+        const errMessage = err instanceof Error ? err.message : String(err);
+        logger.warn(
+          `Skill "${id}" registered but failed to auto-activate on agent "${ctx.agentId}": ${errMessage}`,
+        );
+        return {
+          ok: true,
+          content: successMessage,
+          warning: `Skill registered but failed to auto-activate on agent "${ctx.agentId}": ${errMessage}. Call agent_update to add it manually.`,
+        };
+      }
 
       return {
         ok: true,
-        content: `Skill "${id}" created successfully.${companionNote} It is now available to assign to agents.`,
+        content: successMessage,
       };
     },
   };

--- a/apps/server/src/tools/skills/index.ts
+++ b/apps/server/src/tools/skills/index.ts
@@ -1,5 +1,6 @@
 import type { BuiltinTool } from '@openaidy/runtime';
 import type { SkillRegistry } from '../../skills/index.js';
+import type { AgentRegistry } from '../../agents/registry.js';
 import type { WorkspaceService } from '../../workspace/service.js';
 import { createSkillCreateTool } from './create.js';
 import { createSkillUpdateTool } from './update.js';
@@ -9,10 +10,11 @@ export { createSkillUpdateTool } from './update.js';
 
 export function createSkillTools(
   skillRegistry: SkillRegistry,
+  agentRegistry: AgentRegistry,
   workspace: WorkspaceService,
 ): BuiltinTool[] {
   return [
-    createSkillCreateTool(skillRegistry, workspace),
+    createSkillCreateTool(skillRegistry, agentRegistry, workspace),
     createSkillUpdateTool(skillRegistry, workspace),
   ];
 }

--- a/apps/server/src/tools/skills/tools.test.ts
+++ b/apps/server/src/tools/skills/tools.test.ts
@@ -440,6 +440,13 @@ describe('skill tools', () => {
         // but a `warning` field surfaces the auto-activation failure.
         expect(result.ok).toBe(true);
         expect(result.content).toContain('partial-success-skill');
+        // `content` is the only field the model actually reads back (no
+        // caller anywhere consumes `warning`), so it must say plainly that
+        // activation did NOT happen — not the success wording, which would
+        // leave the model believing the skill is already loaded into its
+        // context when it isn't.
+        expect(result.content).toContain('NOT activated');
+        expect(result.content).not.toContain('created and activated');
         expect(result.warning).toBeDefined();
         expect(result.warning).toMatch(/failed to auto-activate/);
         expect(result.warning).toContain(CTX.agentId);

--- a/apps/server/src/tools/skills/tools.test.ts
+++ b/apps/server/src/tools/skills/tools.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createSkillRegistry, parseSkillMd } from '../../skills/index';
 import { WorkspaceService } from '../../workspace/service';
+import { AgentRegistry } from '../../agents/registry';
 import {
   createSkillCreateTool,
   createSkillTools,
@@ -17,6 +18,7 @@ describe('skill tools', () => {
   let workspace: WorkspaceService;
   let agentSkillsDir: string;
   let registry: ReturnType<typeof createSkillRegistry>;
+  let agentRegistry: AgentRegistry;
 
   beforeEach(async () => {
     baseDir = join(tmpdir(), `skill-tools-test-${Date.now()}`);
@@ -25,6 +27,23 @@ describe('skill tools', () => {
     agentSkillsDir = join(baseDir, CTX.agentId, 'skills');
     registry = createSkillRegistry({ skillsDir: agentSkillsDir });
     registry.load();
+    // Provide an in-memory agent registry that already contains the
+    // agentId from CTX. This is what `createSkillCreateTool` targets for
+    // auto-activation; without this entry addSkillToAgent would throw
+    // "Agent with ID ... not found" and the new auto-activation path
+    // would always degrade to a warning.
+    agentRegistry = new AgentRegistry({
+      initialAgents: [
+        {
+          id: CTX.agentId,
+          name: 'Test Agent',
+          enabled: true,
+          systemPrompt: 'You are a test agent.',
+          model: 'openai/gpt-4o-mini',
+          version: 1,
+        },
+      ],
+    });
   });
 
   afterEach(async () => {
@@ -35,7 +54,7 @@ describe('skill tools', () => {
 
   describe('createSkillTools', () => {
     it('returns skill_create and skill_update tools', () => {
-      const tools = createSkillTools(registry, workspace);
+      const tools = createSkillTools(registry, agentRegistry, workspace);
       const names = tools.map((t) => t.name);
       expect(names).toContain('skill_create');
       expect(names).toContain('skill_update');
@@ -47,7 +66,7 @@ describe('skill tools', () => {
 
   describe('skill_create', () => {
     it('creates a valid skill and writes SKILL.md to disk', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'my-skill',
@@ -71,7 +90,7 @@ describe('skill tools', () => {
     });
 
     it('registers the skill in the registry immediately', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       await tool.execute(
         {
           id: 'instant-skill',
@@ -89,7 +108,7 @@ describe('skill tools', () => {
     });
 
     it('uses the provided version in the file', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       await tool.execute(
         {
           id: 'versioned-skill',
@@ -109,7 +128,7 @@ describe('skill tools', () => {
     });
 
     it('defaults version to 1.0.0 when omitted', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       await tool.execute(
         {
           id: 'no-version-skill',
@@ -128,7 +147,7 @@ describe('skill tools', () => {
     });
 
     it('records created_by with the agent id', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       await tool.execute(
         {
           id: 'attributed-skill',
@@ -147,7 +166,7 @@ describe('skill tools', () => {
     });
 
     it('produces a SKILL.md that round-trips through parseSkillMd', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'roundtrip-skill',
@@ -176,7 +195,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when id already exists', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const args = {
         id: 'duplicate-skill',
         name: 'Duplicate',
@@ -193,7 +212,7 @@ describe('skill tools', () => {
     });
 
     it('returns error for invalid id format', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'Invalid ID!',
@@ -211,7 +230,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when id is missing', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         { name: 'No ID', description: 'Missing id', body: 'Body.' },
         CTX,
@@ -220,7 +239,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when name is missing', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         { id: 'no-name', description: 'No name', body: 'Body.' },
         CTX,
@@ -229,7 +248,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when description is missing', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         { id: 'no-desc', name: 'No Desc', body: 'Body.' },
         CTX,
@@ -238,7 +257,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when body is missing', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         { id: 'no-body', name: 'No Body', description: 'Missing body' },
         CTX,
@@ -249,7 +268,7 @@ describe('skill tools', () => {
     // ─── companion files ─────────────────────────────────────────────────────
 
     it('writes companion files alongside SKILL.md', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'api-skill',
@@ -283,7 +302,7 @@ describe('skill tools', () => {
     });
 
     it('succeeds with no companion files', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'plain-skill',
@@ -298,7 +317,7 @@ describe('skill tools', () => {
     });
 
     it('returns error for companion filename with path separator', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'traversal-skill',
@@ -316,7 +335,7 @@ describe('skill tools', () => {
     });
 
     it('returns error when trying to pass SKILL.md as companion file', async () => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id: 'override-skill',
@@ -332,6 +351,131 @@ describe('skill tools', () => {
         /body parameter/,
       );
     });
+
+    // ─── auto-activation on the creating agent ──────────────────────────
+
+    it('auto-activates the skill on ctx.agentId after creation', async () => {
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
+
+      // Sanity check: the agent's skills list is empty before the call.
+      const agentBefore = agentRegistry.getAgent(CTX.agentId);
+      expect(agentBefore?.skills ?? []).toEqual([]);
+
+      const result = (await tool.execute(
+        {
+          id: 'auto-activated-skill',
+          name: 'Auto Activated',
+          description: 'Should land on the agent automatically',
+          body: 'Body.',
+        },
+        CTX,
+      )) as { ok: true; content: string; warning?: string };
+
+      // Tool reports success (no warning) — the auto-activation succeeded.
+      expect(result.ok).toBe(true);
+      expect(result.warning).toBeUndefined();
+      expect(result.content).toContain('auto-activated-skill');
+      expect(result.content).toContain('activated for agent');
+      expect(result.content).toContain(CTX.agentId);
+
+      // The created skill ID now appears in the agent's skills array.
+      const agentAfter = agentRegistry.getAgent(CTX.agentId);
+      expect(agentAfter?.skills).toContain('auto-activated-skill');
+    });
+
+    it('idempotent re-creation errors with "already exists" and does not mutate the agent', async () => {
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
+      const args = {
+        id: 'recreate-skill',
+        name: 'Recreate',
+        description: 'First time succeeds; second time must error',
+        body: 'Body.',
+      };
+
+      // First call: succeeds and auto-activates the skill on the agent.
+      const first = await tool.execute(args, CTX);
+      expect(first.ok).toBe(true);
+      expect(agentRegistry.getAgent(CTX.agentId)?.skills).toEqual([
+        'recreate-skill',
+      ]);
+
+      // Second call: must error with the exact "already exists" message and
+      // must not have invoked addSkillToAgent (so the agent's skills array
+      // is unchanged — still the single-element list from the first call).
+      const second = await tool.execute(args, CTX);
+      expect(second.ok).toBe(false);
+      expect((second as { ok: false; error: string }).error).toBe(
+        `Skill "recreate-skill" already exists`,
+      );
+      expect(agentRegistry.getAgent(CTX.agentId)?.skills).toEqual([
+        'recreate-skill',
+      ]);
+    });
+
+    it('returns ok:true with a warning when addSkillToAgent throws — and the skill is still registered', async () => {
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
+
+      // Simulate a transient failure in the agent registry: this is the
+      // "partial success" scenario. The skill registration has already
+      // succeeded in skillRegistry; the auto-activation step then fails.
+      const spy = vi
+        .spyOn(agentRegistry, 'addSkillToAgent')
+        .mockImplementation(() => {
+          throw new Error('disk full');
+        });
+
+      try {
+        const result = (await tool.execute(
+          {
+            id: 'partial-success-skill',
+            name: 'Partial Success',
+            description:
+              'Registration must survive even when auto-activation fails',
+            body: 'Body.',
+          },
+          CTX,
+        )) as { ok: true; content: string; warning: string };
+
+        // The tool degrades gracefully: ok:true so the caller proceeds,
+        // but a `warning` field surfaces the auto-activation failure.
+        expect(result.ok).toBe(true);
+        expect(result.content).toContain('partial-success-skill');
+        expect(result.warning).toBeDefined();
+        expect(result.warning).toMatch(/failed to auto-activate/);
+        expect(result.warning).toContain(CTX.agentId);
+        expect(result.warning).toContain('disk full');
+        // The warning must point the caller at a recovery path.
+        expect(result.warning).toMatch(/agent_update/);
+
+        // The skill IS still registered (registration precedes auto-activation).
+        const registered = registry.getSkill('partial-success-skill');
+        expect(registered).toBeDefined();
+        expect(registered?.name).toBe('Partial Success');
+        expect(registered?.description).toBe(
+          'Registration must survive even when auto-activation fails',
+        );
+      } finally {
+        spy.mockRestore();
+      }
+
+      // After restoring the spy, a fresh call to the tool with a different
+      // id succeeds end-to-end — confirming the mock did not corrupt
+      // registry state.
+      const recovered = (await tool.execute(
+        {
+          id: 'recovery-skill',
+          name: 'Recovery',
+          description: 'Succeeds once the registry is healthy again',
+          body: 'Body.',
+        },
+        CTX,
+      )) as { ok: true; content: string; warning?: string };
+      expect(recovered.ok).toBe(true);
+      expect(recovered.warning).toBeUndefined();
+      expect(agentRegistry.getAgent(CTX.agentId)?.skills).toContain(
+        'recovery-skill',
+      );
+    });
   });
 
   // ─── skill_update ──────────────────────────────────────────────────────────
@@ -344,7 +488,7 @@ describe('skill tools', () => {
       body = 'Original instructions.',
       files: Record<string, string> = {},
     ): Promise<void> => {
-      const tool = createSkillCreateTool(registry, workspace);
+      const tool = createSkillCreateTool(registry, agentRegistry, workspace);
       const result = await tool.execute(
         {
           id,


### PR DESCRIPTION
## Summary

When an agent calls `skill_create`, the new skill is now automatically attached to the agent that created it (in addition to being registered in the `SkillRegistry`). This removes the manual two-step workflow of creating a skill then calling `agent_update` to add it.

## Changes

- **`apps/server/src/agents/registry.ts`** — new method `addSkillToAgent(agentId, skillId): Agent`
  - Appends the skill id to the agent's `skills` array using the same `persistConfig` pattern as `createAgent` / `updateAgentSkills`.
  - Throws `Agent with ID "<id>" not found` on unknown `agentId`.
  - No-op (returns the existing agent) if the skill is already attached.

- **`apps/server/src/tools/skills/create.ts`** — `createSkillCreateTool` factory now accepts `agentRegistry`.
  - On successful `skillRegistry.register(parsed)`, calls `agentRegistry.addSkillToAgent(ctx.agentId, id)` inside a `try/catch`.
  - On catch: logs at WARN and returns `{ ok: true, content, warning: 'Skill registered but failed to auto-activate on agent "<ctx.agentId>": <err>. Call agent_update to add it manually.' }` so the caller can recover without losing the skill.
  - Updated success message to `Skill "<id>" created and activated for agent "<ctx.agentId>".`

- **`apps/server/src/tools/skills/index.ts`** — threads `agentRegistry` through `createSkillTools` to `createSkillCreateTool`.

- **`apps/server/src/tools/index.ts`** — wires `deps.agents!.registry` into the `createSkillTools` call site in `createBuiltinToolRegistry`. `deps.agents` is always co-configured with `deps.skills` in `app.ts`, so the non-null assertion is safe.

- **`apps/server/src/tools/skills/tools.test.ts`** — updates the 18 existing `createSkillCreateTool` call sites for the new signature, and adds three new test cases:
  1. **Successful auto-activation** — the created skill id appears in `ctx.agentId`'s `skills` array after the tool returns.
  2. **Idempotent re-creation** — a second call with the same id errors with the exact `Skill "<id>" already exists` message and does not mutate the agent's `skills` array.
  3. **Partial-success path** — when `addSkillToAgent` is mocked to throw, the tool degrades to `{ ok: true, warning }` while the skill remains registered; once the spy is restored, a fresh call succeeds end-to-end.

## Diff stat

```
 apps/server/src/agents/registry.ts         |  35 ++++++
 apps/server/src/tools/index.ts             |   8 +-
 apps/server/src/tools/skills/create.ts     |  22 +++-
 apps/server/src/tools/skills/index.ts      |   4 +-
 apps/server/src/tools/skills/tools.test.ts | 182 ++++++++++++++++++++++++++---
 5 files changed, 229 insertions(+), 22 deletions(-)
```

## Test plan

- [x] Existing `skill_create` and `skill_update` tests updated for the new factory signature
- [x] New tests for auto-activation, idempotent re-creation, and partial-success
- [ ] CI (`pnpm test` and `pnpm lint`) — this branch is pushed to run in GitHub Actions
