### PR TITLE
feat(agents): give agents context on the installed addons

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -369,6 +369,34 @@ export async function buildApp() {
     getDefaultAgentId: () => configService.getConfig().defaults.agentId,
     runEvents,
     workspaceBaseDir: env.WORKSPACE_BASE_DIR,
+    // Lets the agent see which addons exist (and their ids) so it can review or
+    // change one — addons live outside the workspace, so nothing else in the
+    // prompt reveals them. Absent when there is no DB, i.e. no addons at all.
+    ...(addonService
+      ? {
+          listAddons: async () => {
+            const { addons } = await addonService.listAddons();
+            return addons.map((addon) => {
+              // `description` is manifest-only (not a column), and the manifest
+              // column is typed `unknown` at the repository boundary.
+              const manifest = addon.manifest as
+                | { description?: string }
+                | null
+                | undefined;
+              return {
+                // addonId, not id: the row id means nothing to the addon tools.
+                id: addon.addonId,
+                name: addon.name,
+                version: addon.version,
+                ...(manifest?.description
+                  ? { description: manifest.description }
+                  : {}),
+                status: addon.status,
+              };
+            });
+          },
+        }
+      : {}),
     ...(attachmentService ? { attachments: attachmentService } : {}),
     ...(modelPricingConfig ? { modelPricing: modelPricingConfig } : {}),
     repositories: dbAdapter

--- a/apps/server/src/prompts/build-system-prompt.test.ts
+++ b/apps/server/src/prompts/build-system-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildSystemPrompt } from './build-system-prompt';
 import type { AgentPersonalityService } from '../agents/personality-service';
+import type { ToolDefinition } from '@openaidy/runtime';
 
 function mockPersonality(blank: string[]): AgentPersonalityService {
   return {
@@ -57,5 +58,87 @@ describe('buildSystemPrompt — onboarding block (#373)', () => {
       onboardingMessagesRemaining: 2,
     });
     expect(prompt).not.toContain('[ONBOARDING]');
+  });
+});
+
+describe('buildSystemPrompt — [ADDONS_AVAILABLE] block', () => {
+  const ADDON_TOOL = {
+    name: 'addon_update',
+    description: 'update an addon',
+    parameters: { type: 'object', properties: {} },
+  } as unknown as ToolDefinition;
+
+  const OTHER_TOOL = {
+    name: 'workspace_read',
+    description: 'read a file',
+    parameters: { type: 'object', properties: {} },
+  } as unknown as ToolDefinition;
+
+  const ADDONS = [
+    {
+      id: 'weather',
+      name: 'Weather Widget',
+      description: 'Shows the weather',
+      version: '1.2.0',
+      status: 'enabled',
+    },
+    { id: 'broken-one', name: 'Broken', status: 'error' },
+  ];
+
+  it('lists the installed addons when the agent holds an addon tool', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [ADDON_TOOL],
+      addons: ADDONS,
+    });
+    expect(prompt).toContain('[ADDONS_AVAILABLE]');
+    expect(prompt).toContain(
+      '- weather: Weather Widget v1.2.0 — Shows the weather',
+    );
+    // The id the addon_* tools take must be what is listed.
+    expect(prompt).toContain('addon_read({ addon_id: "<id>" })');
+  });
+
+  it('reports a non-enabled addon with its actual state, not just "disabled"', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [ADDON_TOOL],
+      addons: ADDONS,
+    });
+    // An agent asked to fix a broken addon has to be able to see it is broken.
+    expect(prompt).toContain('- broken-one: Broken (error)');
+  });
+
+  it('warns that addon_update overwrites, so files must be read first', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [ADDON_TOOL],
+      addons: ADDONS,
+    });
+    expect(prompt).toContain('OVERWRITES');
+    expect(prompt).toContain('OUTSIDE your workspace');
+  });
+
+  it('omits the block for an agent with no addon tool', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [OTHER_TOOL],
+      addons: ADDONS,
+    });
+    expect(prompt).not.toContain('[ADDONS_AVAILABLE]');
+  });
+
+  it('omits the block when no addons are installed', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [ADDON_TOOL],
+      addons: [],
+    });
+    expect(prompt).not.toContain('[ADDONS_AVAILABLE]');
   });
 });

--- a/apps/server/src/prompts/build-system-prompt.ts
+++ b/apps/server/src/prompts/build-system-prompt.ts
@@ -13,6 +13,27 @@ import { join } from 'node:path';
 import { parseSkillMd } from '../skills/parser';
 import { logger } from '../lib/logger';
 
+/**
+ * The facts about an installed addon an agent needs before it can review or
+ * change one: which addons exist, what each is for, and whether it is currently
+ * running. File contents are deliberately not included — the agent pulls those
+ * with `addon_read` for the one addon it is working on, instead of every
+ * addon's source landing in every prompt.
+ */
+export type AddonPromptSummary = {
+  /** The addon identifier the addon_* tools take (not the DB row id). */
+  id: string;
+  name: string;
+  description?: string | undefined;
+  version?: string | undefined;
+  /**
+   * Lifecycle state, verbatim: `enabled`, `disabled`, `installed` or `error`.
+   * Passed through rather than collapsed to a boolean — an agent asked to fix a
+   * broken addon needs to see `error`, not "disabled".
+   */
+  status: string;
+};
+
 export type BuildSystemPromptOptions = {
   agentId: string;
   basePrompt: string;
@@ -33,6 +54,16 @@ export type BuildSystemPromptOptions = {
   workspaceBaseDir?: string | undefined;
   /** Session type - used to inject context-specific reminders */
   sessionType?: SessionType | undefined;
+  /**
+   * Addons installed on this instance, for the [ADDONS_AVAILABLE] block.
+   *
+   * Without this the agent has no way to know an addon exists: addons live
+   * outside the workspace, so no workspace_* tool can see them, and
+   * `addon_update` requires an id it would otherwise have to guess. Injected
+   * only when the agent actually holds an addon tool (see below), so an agent
+   * with no addon access doesn't pay for the list.
+   */
+  addons?: AddonPromptSummary[] | undefined;
   /**
    * Number of remaining messages that should receive ONBOARDING injection.
    * Onboarding runs until this reaches 0 or all personality files are configured.
@@ -111,6 +142,7 @@ export async function buildSystemPrompt(
     workspacePermissions,
     workspaceBaseDir,
     sessionType,
+    addons,
     onboardingMessagesRemaining = 0,
   } = options;
 
@@ -276,6 +308,32 @@ Your response will be automatically evaluated. Work is judged complete only if t
     if (allBodies) {
       prompt += '\n\n[SKILL_CONTEXTS]\n' + allBodies + '\n[/SKILL_CONTEXTS]';
     }
+  }
+
+  // Addons the agent can review or change. Gated on the agent actually holding
+  // an addon tool: an agent without one can neither read nor modify an addon,
+  // so listing them would only burn context. Disabled addons are listed too —
+  // an agent asked to fix a broken addon needs to see the one that is off.
+  if (addons?.length && tools?.some((t) => t.name.startsWith('addon_'))) {
+    const entries = addons
+      .map((a) => {
+        const version = a.version ? ` v${a.version}` : '';
+        const state = a.status === 'enabled' ? '' : ` (${a.status})`;
+        const description = a.description ? ` — ${a.description}` : '';
+        return `- ${a.id}: ${a.name}${version}${state}${description}`;
+      })
+      .join('\n');
+
+    prompt += `
+
+[ADDONS_AVAILABLE]
+The following addons are installed on this instance:
+${entries}
+
+Addons live in a directory managed by OpenAidy, OUTSIDE your workspace — no workspace_* or code_* tool can see or change them.
+To inspect one before changing it, call addon_read({ addon_id: "<id>" }) for its file list, then addon_read({ addon_id: "<id>", paths: ["app/index.js"] }) for contents.
+Never rewrite a file from memory: addon_update OVERWRITES whole files, so read first or you will silently drop code you did not author.
+[/ADDONS_AVAILABLE]`;
   }
 
   // Inject tool guidelines with honest information about available tools and workspace permissions

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -59,6 +59,7 @@ import type {
   SessionMessageServiceOptions,
 } from './types';
 import { buildSystemPrompt } from '../prompts/build-system-prompt';
+import type { AddonPromptSummary } from '../prompts/build-system-prompt';
 import type { AgentPersonalityService } from '../agents/personality-service';
 import type {
   WorkspacePermissionsInfo,
@@ -98,6 +99,9 @@ export class SessionMessageService {
   private readonly personalityService: AgentPersonalityService | undefined;
   private readonly runEvents: RunEventEmitter | undefined;
   private readonly workspaceBaseDir: string | undefined;
+  private readonly listAddons:
+    | (() => Promise<AddonPromptSummary[]>)
+    | undefined;
   private readonly attachments: AttachmentService | undefined;
   private readonly modelPricing: Record<string, ModelPricing> | undefined;
   private readonly maxToolRounds: number;
@@ -129,6 +133,7 @@ export class SessionMessageService {
     this.personalityService = options.personality;
     this.runEvents = options.runEvents;
     this.workspaceBaseDir = options.workspaceBaseDir;
+    this.listAddons = options.listAddons;
     this.attachments = options.attachments;
     this.modelPricing = options.modelPricing;
     this.maxToolRounds = options.maxToolRounds ?? 25;
@@ -1321,6 +1326,20 @@ export class SessionMessageService {
       : undefined;
 
     // Build system prompt with personality files, skill bodies, and tool guidelines injected
+    // Addons the agent may review or change. Best-effort: an unavailable list
+    // costs the agent that context, never the run.
+    let addonSummaries: AddonPromptSummary[] = [];
+    if (this.listAddons) {
+      try {
+        addonSummaries = await this.listAddons();
+      } catch (err) {
+        this.logger?.warn(
+          { err },
+          'Could not load the addon list for the system prompt',
+        );
+      }
+    }
+
     const systemPrompt = await buildSystemPrompt({
       agentId,
       basePrompt: agent?.systemPrompt ?? '',
@@ -1333,6 +1352,7 @@ export class SessionMessageService {
       tools: allTools,
       workspacePermissions,
       workspaceBaseDir: this.workspaceBaseDir,
+      ...(addonSummaries.length > 0 ? { addons: addonSummaries } : {}),
       sessionType: (session as { type?: string }).type as
         | SessionType
         | undefined,

--- a/apps/server/src/sessions/types.ts
+++ b/apps/server/src/sessions/types.ts
@@ -120,6 +120,16 @@ export type SessionMessageServiceOptions = {
   runEvents?: RunEventEmitter;
   /** Base directory for agent workspaces (for loading agent workspace skills) */
   workspaceBaseDir?: string;
+  /**
+   * Resolves the addons installed on this instance, for the
+   * [ADDONS_AVAILABLE] block in the system prompt. A narrow callback rather
+   * than the AddonService itself: this service only needs to read the list,
+   * and the DB may be absent (no addons at all). Failures are swallowed at the
+   * call site — a run must never die because the addon list was unavailable.
+   */
+  listAddons?: () => Promise<
+    import('../prompts/build-system-prompt').AddonPromptSummary[]
+  >;
   /** Attachment storage for image/audio chat media (requires DB) */
   attachments?: import('../attachments/service').AttachmentService;
   /**

--- a/apps/server/src/tools/addons/index.ts
+++ b/apps/server/src/tools/addons/index.ts
@@ -1,10 +1,12 @@
 import type { BuiltinTool } from '@openaidy/runtime';
 import { createAddonCreateTool, type AddonToolDeps } from './create.js';
 import { createAddonUpdateTool } from './update.js';
+import { createAddonReadTool } from './read.js';
 import { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 
 export { createAddonCreateTool } from './create.js';
 export { createAddonUpdateTool } from './update.js';
+export { createAddonReadTool } from './read.js';
 export { createAddonRunTool, createAddonListQueriesTool } from './run.js';
 export type { AddonToolDeps } from './create.js';
 
@@ -12,11 +14,12 @@ export type { AddonToolDeps } from './create.js';
  * Returns all addon builtin tools.
  *
  * Register selectively per-agent via `tools` in the agent config:
- *   "tools": ["addon_create", "addon_update", "addon_run", "addon_list_queries"]
+ *   "tools": ["addon_create", "addon_read", "addon_update", "addon_run", "addon_list_queries"]
  */
 export function createAddonTools(deps: AddonToolDeps): BuiltinTool[] {
   return [
     createAddonCreateTool(deps),
+    createAddonReadTool(deps),
     createAddonUpdateTool(deps),
     createAddonRunTool(deps),
     createAddonListQueriesTool(deps),

--- a/apps/server/src/tools/addons/read.test.ts
+++ b/apps/server/src/tools/addons/read.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAddonReadTool } from './read';
+
+const CTX = { agentId: 'test-agent', sessionId: 'test-session' };
+
+/**
+ * Narrow a tool result to its success shape. Keeps each assertion focused on
+ * the content instead of repeating `if (result.ok)` (the convention in the
+ * sibling addon tests) and fails loudly with the tool's own error when the
+ * call unexpectedly failed.
+ */
+function okContent(
+  result: { ok: true; content: string } | { ok: false; error: string },
+): string {
+  if (!result.ok) throw new Error(`expected ok, got error: ${result.error}`);
+  return result.content;
+}
+
+describe('addon_read', () => {
+  let addonsDir: string;
+  let tool: ReturnType<typeof createAddonReadTool>;
+
+  beforeEach(async () => {
+    addonsDir = await mkdtemp(join(tmpdir(), 'addon-read-test-'));
+    tool = createAddonReadTool({ addonsDir });
+
+    const dir = join(addonsDir, 'weather');
+    await mkdir(join(dir, 'app'), { recursive: true });
+    await writeFile(
+      join(dir, 'addon.json'),
+      JSON.stringify({
+        id: 'weather',
+        name: 'Weather Widget',
+        description: 'Shows the weather',
+        version: '1.2.0',
+        permissions: ['agents.list'],
+        externalDomains: ['api.weather.test'],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(dir, 'app/index.html'),
+      '<html><body>hi</body></html>',
+      'utf-8',
+    );
+    await writeFile(
+      join(dir, 'app/index.js'),
+      'console.log("original");',
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(addonsDir, { recursive: true, force: true });
+  });
+
+  describe('inventory mode', () => {
+    it('returns the manifest fields and the file list', async () => {
+      const result = await tool.execute({ addon_id: 'weather' }, CTX);
+      expect(result.ok).toBe(true);
+      const content = okContent(result);
+      expect(content).toContain('name: Weather Widget');
+      expect(content).toContain('version: 1.2.0');
+      expect(content).toContain('permissions: agents.list');
+      expect(content).toContain('externalDomains: api.weather.test');
+      expect(content).toContain('app/index.js');
+      expect(content).toContain('app/index.html');
+    });
+
+    it('does not dump file contents in inventory mode', async () => {
+      const result = await tool.execute({ addon_id: 'weather' }, CTX);
+      expect(okContent(result)).not.toContain('console.log');
+    });
+
+    it('leaves addon.json out of the inventory (changed via addon_update fields)', async () => {
+      const result = await tool.execute({ addon_id: 'weather' }, CTX);
+      expect(okContent(result)).not.toMatch(/^\s+addon\.json/m);
+    });
+
+    it('reports (none) for manifest lists that are absent', async () => {
+      const dir = join(addonsDir, 'bare');
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, 'addon.json'),
+        JSON.stringify({ id: 'bare', name: 'Bare' }),
+        'utf-8',
+      );
+      const result = await tool.execute({ addon_id: 'bare' }, CTX);
+      expect(okContent(result)).toContain('externalDomains: (none)');
+      expect(okContent(result)).toContain('version: (unset)');
+    });
+  });
+
+  describe('content mode', () => {
+    it('returns the requested file contents', async () => {
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['app/index.js'] },
+        CTX,
+      );
+      expect(result.ok).toBe(true);
+      expect(okContent(result)).toContain('console.log("original");');
+    });
+
+    it('reads several files in one call', async () => {
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['app/index.js', 'app/index.html'] },
+        CTX,
+      );
+      const content = okContent(result);
+      expect(content).toContain('console.log("original");');
+      expect(content).toContain('<html>');
+    });
+
+    it('reports missing files but still returns the ones that exist', async () => {
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['app/index.js', 'app/nope.js'] },
+        CTX,
+      );
+      expect(result.ok).toBe(true);
+      const content = okContent(result);
+      expect(content).toContain('console.log("original");');
+      expect(content).toContain('Not found (skipped): app/nope.js');
+    });
+
+    it('errors when none of the requested files exist', async () => {
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['app/nope.js'] },
+        CTX,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain(
+        'None of the requested files exist',
+      );
+    });
+
+    it('truncates a file that would flood the context', async () => {
+      await writeFile(
+        join(addonsDir, 'weather', 'app/huge.js'),
+        'x'.repeat(25_000),
+        'utf-8',
+      );
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['app/huge.js'] },
+        CTX,
+      );
+      expect(result.ok).toBe(true);
+      expect(okContent(result)).toContain('truncated at 20000 characters');
+    });
+  });
+
+  describe('safety', () => {
+    it('rejects a path that escapes the addon directory', async () => {
+      const result = await tool.execute(
+        { addon_id: 'weather', paths: ['../../../etc/passwd'] },
+        CTX,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain('must be relative');
+    });
+
+    it('rejects an invalid addon id', async () => {
+      const result = await tool.execute({ addon_id: '../escape' }, CTX);
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain('lowercase alphanumeric');
+    });
+
+    it('errors clearly for an addon that does not exist', async () => {
+      const result = await tool.execute({ addon_id: 'ghost' }, CTX);
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain('not found');
+    });
+
+    it('requires addon_id', async () => {
+      const result = await tool.execute({}, CTX);
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain('addon_id is required');
+    });
+
+    it('reports an unparseable manifest instead of crashing', async () => {
+      const dir = join(addonsDir, 'busted');
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, 'addon.json'), '{ not json', 'utf-8');
+      const result = await tool.execute({ addon_id: 'busted' }, CTX);
+      expect(result.ok).toBe(false);
+      expect(result.ok ? '' : result.error).toContain('unreadable addon.json');
+    });
+  });
+});

--- a/apps/server/src/tools/addons/read.ts
+++ b/apps/server/src/tools/addons/read.ts
@@ -1,0 +1,261 @@
+/**
+ * addon_read
+ *
+ * Read an installed addon: its manifest and the files it is built from.
+ *
+ * This closes the gap that made `addon_update` dangerous to use. That tool
+ * takes a map of path → content and OVERWRITES each file wholesale, but until
+ * now an agent had no way to see what a file contained first — addons live in a
+ * directory outside the agent workspace, so `workspace_read` and `code_read`
+ * cannot reach them. The only safe move was to rewrite a file from scratch,
+ * which silently discarded whatever the agent had not authored itself.
+ *
+ * Two shapes, so reviewing an addon never costs more context than it has to:
+ *   addon_read({ addon_id })                  → manifest + file inventory
+ *   addon_read({ addon_id, paths: [...] })    → contents of those files
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import type { BuiltinTool } from '@openaidy/runtime';
+import { addonReadMeta } from '../catalog.js';
+import type { AddonToolDeps } from './create.js';
+import { isValidId, relativePathError } from './shared.js';
+
+/** Largest single file returned in full; longer ones are truncated with a note. */
+const MAX_FILE_CHARS = 20_000;
+
+/**
+ * Ceiling on the combined size of one response. A built addon can carry a
+ * vendored bundle, and dumping it would evict the conversation it was meant to
+ * inform.
+ */
+const MAX_TOTAL_CHARS = 60_000;
+
+/** Directories never worth reporting — noise, not addon source. */
+const SKIPPED_DIRS = new Set(['node_modules', '.git', 'dist', '.cache']);
+
+type FileEntry = { path: string; bytes: number };
+
+/**
+ * Every file under `dir`, as addon-root-relative POSIX paths. Depth-limited so
+ * a symlink loop or a pathological tree cannot spin here.
+ */
+async function listFiles(
+  root: string,
+  dir: string,
+  depth = 0,
+): Promise<FileEntry[]> {
+  if (depth > 6) return [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: FileEntry[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRS.has(entry.name)) continue;
+      files.push(...(await listFiles(root, full, depth + 1)));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    let bytes = 0;
+    try {
+      bytes = (await stat(full)).size;
+    } catch {
+      // Unreadable size is not worth failing the listing over.
+    }
+    files.push({ path: relative(root, full).split('\\').join('/'), bytes });
+  }
+  return files;
+}
+
+export function createAddonReadTool(deps: AddonToolDeps): BuiltinTool {
+  return {
+    name: addonReadMeta.name,
+
+    description: [
+      'Read an EXISTING OpenAidy addon — its manifest and its files.',
+      '',
+      'WHY THIS EXISTS',
+      '───────────────',
+      'Addons live in a directory managed by OpenAidy, SEPARATE from your agent',
+      'workspace. workspace_read and code_read cannot see them. This is the only',
+      'way to read an addon.',
+      '',
+      'ALWAYS READ BEFORE YOU WRITE',
+      '────────────────────────────',
+      'addon_update OVERWRITES each file you pass it. If you write app/index.js',
+      'from memory you will drop everything already in it. Read the file, change',
+      'what you need, and pass the full new content back.',
+      '',
+      'TWO WAYS TO CALL IT',
+      '───────────────────',
+      '  addon_read({ addon_id: "weather" })',
+      '      → manifest fields + the list of files (paths and sizes)',
+      '  addon_read({ addon_id: "weather", paths: ["app/index.js"] })',
+      '      → the contents of those files',
+      '',
+      'Start with the inventory, then ask for the files you actually need — a',
+      'large file comes back truncated, and the response as a whole is capped.',
+    ].join('\n'),
+
+    parameters: {
+      type: 'object',
+      properties: {
+        addon_id: {
+          type: 'string',
+          description:
+            'Identifier of the addon to read (see the [ADDONS_AVAILABLE] list in your context).',
+        },
+        paths: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Addon-root-relative file paths to read (e.g. ["app/index.js", "app/index.html"]). ' +
+            'Omit to get the manifest and the file inventory instead of contents.',
+        },
+      },
+      required: ['addon_id'],
+    },
+
+    async execute(args) {
+      const addonId = args['addon_id'];
+      const pathsArg = args['paths'];
+
+      if (typeof addonId !== 'string' || !addonId) {
+        return {
+          ok: false,
+          error: 'addon_id is required and must be a non-empty string',
+        };
+      }
+      if (!isValidId(addonId)) {
+        return {
+          ok: false,
+          error:
+            'addon_id must be lowercase alphanumeric with hyphens only (e.g. "my-addon")',
+        };
+      }
+
+      const addonDir = join(deps.addonsDir, addonId);
+      let manifestRaw: string;
+      try {
+        manifestRaw = await readFile(join(addonDir, 'addon.json'), 'utf-8');
+      } catch {
+        return {
+          ok: false,
+          error: `Addon "${addonId}" not found. Check the [ADDONS_AVAILABLE] list in your context, or use addon_create to make a new one.`,
+        };
+      }
+
+      let manifest: Record<string, unknown>;
+      try {
+        manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
+      } catch (err) {
+        return {
+          ok: false,
+          error: `Addon "${addonId}" has an unreadable addon.json: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+
+      const requestedPaths: string[] = Array.isArray(pathsArg)
+        ? pathsArg.filter((p): p is string => typeof p === 'string')
+        : [];
+
+      // ── Inventory mode ──────────────────────────────────────────────────
+      if (requestedPaths.length === 0) {
+        const files = await listFiles(addonDir, addonDir);
+        const inventory = files
+          .filter((f) => f.path !== 'addon.json')
+          .sort((a, b) => a.path.localeCompare(b.path))
+          .map((f) => `  ${f.path} (${f.bytes} bytes)`)
+          .join('\n');
+
+        const manifestSummary = [
+          `id: ${addonId}`,
+          `name: ${String(manifest['name'] ?? '(unset)')}`,
+          `description: ${String(manifest['description'] ?? '(unset)')}`,
+          `version: ${String(manifest['version'] ?? '(unset)')}`,
+          `permissions: ${formatList(manifest['permissions'])}`,
+          `externalDomains: ${formatList(manifest['externalDomains'])}`,
+          `externalImageDomains: ${formatList(manifest['externalImageDomains'])}`,
+        ].join('\n');
+
+        return {
+          ok: true,
+          content: [
+            `Addon "${addonId}" manifest:`,
+            manifestSummary,
+            '',
+            'Files:',
+            inventory || '  (none)',
+            '',
+            `Read a file with addon_read({ addon_id: "${addonId}", paths: ["app/index.js"] }).`,
+          ].join('\n'),
+        };
+      }
+
+      // ── Content mode ────────────────────────────────────────────────────
+      for (const filePath of requestedPaths) {
+        const pathError = relativePathError(filePath);
+        if (pathError) return { ok: false, error: pathError };
+      }
+
+      const sections: string[] = [];
+      let totalChars = 0;
+      const missing: string[] = [];
+
+      for (const filePath of requestedPaths) {
+        let content: string;
+        try {
+          content = await readFile(join(addonDir, filePath), 'utf-8');
+        } catch {
+          missing.push(filePath);
+          continue;
+        }
+
+        let body = content;
+        let note = '';
+        if (body.length > MAX_FILE_CHARS) {
+          body = body.slice(0, MAX_FILE_CHARS);
+          note = `\n… truncated at ${MAX_FILE_CHARS} characters of ${content.length}. Ask for a narrower set of files if you need the rest.`;
+        }
+        if (totalChars + body.length > MAX_TOTAL_CHARS) {
+          sections.push(
+            `── ${filePath} ──\n(skipped: response size limit reached — request this file on its own)`,
+          );
+          continue;
+        }
+        totalChars += body.length;
+        sections.push(`── ${filePath} ──\n${body}${note}`);
+      }
+
+      if (sections.length === 0) {
+        return {
+          ok: false,
+          error: `None of the requested files exist in addon "${addonId}": ${missing.join(', ')}. Call addon_read({ addon_id: "${addonId}" }) for the file list.`,
+        };
+      }
+
+      const missingNote =
+        missing.length > 0
+          ? `\n\nNot found (skipped): ${missing.join(', ')}`
+          : '';
+
+      return {
+        ok: true,
+        content: `Addon "${addonId}" files:\n\n${sections.join('\n\n')}${missingNote}`,
+      };
+    },
+  };
+}
+
+/** Render a manifest array field for the summary, or note that it is empty. */
+function formatList(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) return '(none)';
+  return value.map((v) => String(v)).join(', ');
+}

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -257,6 +257,16 @@ export const addonUpdateMeta: ToolMeta = {
     'This is the ONLY way to update an addon — never use workspace_write, code_edit, or exec_run to patch addon files (the loader will not see changes made outside this tool).',
 };
 
+export const addonReadMeta: ToolMeta = {
+  name: 'addon_read',
+  category: 'Addons',
+  description:
+    'Inspect an installed addon: its manifest (name, description, version, permissions, external domains) and the files it is built from. ' +
+    'Call with just addon_id for the file inventory, then again with paths for the contents you need. ' +
+    'Read before addon_update — that tool OVERWRITES whole files, so editing without reading first silently drops code. ' +
+    'Addons live outside the agent workspace, so workspace_read and code_read cannot see them; this is the only way to read one.',
+};
+
 export const addonListQueriesMeta: ToolMeta = {
   name: 'addon_list_queries',
   category: 'Addons',
@@ -503,6 +513,7 @@ export const ALL_TOOL_METAS: ToolMeta[] = [
   skillUpdateMeta,
   webFetchMeta,
   addonCreateMeta,
+  addonReadMeta,
   addonUpdateMeta,
   addonListQueriesMeta,
   addonRunMeta,


### PR DESCRIPTION
## Problem

An agent could create and update addons but had no way to know which ones exist.

`addon_update` requires an `id` that "must already exist", and its `files` parameter **overwrites** each file wholesale. Meanwhile addons live in a directory outside the agent workspace — the tool descriptions are emphatic that `workspace_write` / `code_edit` / `exec_run` cannot touch them, and the same is true for reading. So an agent asked to "add a button to my weather addon" had to guess the id and rewrite `app/index.js` from memory, silently discarding whatever it had not authored itself.

## Approach

Two additions, each following a pattern already in the repo.

**1. `[ADDONS_AVAILABLE]` in the system prompt** — the same shape as `[SKILLS_AVAILABLE]`: a bracketed list plus a line on how to act on it.

```
[ADDONS_AVAILABLE]
The following addons are installed on this instance:
- weather: Weather Widget v1.2.0 — Shows the weather for a city
- inventory: Inventory Tracker v0.2.0 (error) — Tracks stock levels

Addons live in a directory managed by OpenAidy, OUTSIDE your workspace — no workspace_* or code_* tool can see or change them.
To inspect one before changing it, call addon_read({ addon_id: "<id>" }) for its file list, then addon_read({ addon_id: "<id>", paths: ["app/index.js"] }) for contents.
Never rewrite a file from memory: addon_update OVERWRITES whole files, so read first or you will silently drop code you did not author.
[/ADDONS_AVAILABLE]
```

Gated on the agent actually holding an addon tool (`tools.some(t => t.name.startsWith('addon_'))`), so an agent with no addon access doesn't pay for the list. `status` is passed through verbatim instead of collapsed to a boolean — an agent asked to fix a broken addon needs to see `error`, not "disabled".

**2. `addon_read`** — the discovery half of the `addon_list_queries` / `addon_run` pattern already used for addon data:

```
addon_read({ addon_id: "weather" })                        → manifest + file inventory
addon_read({ addon_id: "weather", paths: ["app/index.js"] }) → contents
```

Inventory first, contents second, so reviewing an addon costs only the files actually needed. Per-file (20k chars) and per-response (60k) caps keep a vendored bundle from evicting the conversation it was meant to inform; `node_modules` / `dist` / `.git` are skipped. Path safety reuses the existing `isValidId` / `relativePathError` helpers, so `../` escapes and bad ids are rejected the same way `addon_update` rejects them.

## Wiring notes

- Added to the one `buildSystemPrompt` call site that passes `tools` (the agent-run path in `sessions/service.ts`). The other two call sites pass no tools, so the gate would suppress the block there anyway — left untouched rather than pretending to cover paths I can't exercise.
- The addon list arrives via a narrow `listAddons?: () => Promise<AddonPromptSummary[]>` callback rather than handing `SessionMessageService` the whole `AddonService`; it only needs to read a list, and there may be no DB at all.
- Loading the list is best-effort: a failure logs a warning and costs the agent that context, never the run.
- The mapping uses `addon.addonId` (what the addon tools take), not the DB row `id`, and pulls `description` from the manifest since it isn't a column.

## Testing

- 14 tests on `addon_read`: both modes, multi-file reads, partial-miss reporting, truncation, and the safety paths (`../` escape, invalid id, missing addon, unparseable `addon.json`, missing argument).
- 5 tests on the prompt block: the listing format, that a non-enabled addon shows its real state, that the overwrite warning is present, and that the block is omitted both for an agent without an addon tool and when no addons are installed.
- `pnpm --filter @openaidy/server test`: 3426 passed. The one failure, `update/service.test.ts` "passes the version as a single argv element", reproduces identically on unmodified `main` on Windows and is unrelated.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)