### PR TITLE
fix(providers): repair tool-call/tool-result adjacency before invocation

### DIFF
--- a/apps/server/src/providers/history-repair.test.ts
+++ b/apps/server/src/providers/history-repair.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import type { Message } from '@openaidy/runtime';
+import { repairProviderHistory } from './history-repair';
+
+const user = (content: string): Message => ({ role: 'user', content });
+const system = (content: string): Message => ({ role: 'system', content });
+const assistant = (
+  content: string,
+  toolCalls?: Array<{ id: string; name?: string }>,
+): Message => ({
+  role: 'assistant',
+  content,
+  ...(toolCalls
+    ? {
+        toolCalls: toolCalls.map((tc) => ({
+          id: tc.id,
+          name: tc.name ?? 'some_tool',
+          arguments: '{}',
+        })),
+      }
+    : {}),
+});
+const tool = (toolCallId: string, content = 'result'): Message => ({
+  role: 'tool',
+  toolCallId,
+  content,
+});
+
+describe('repairProviderHistory', () => {
+  describe('healthy histories pass through unchanged', () => {
+    it('a single resolved tool call keeps toolCalls intact', () => {
+      const input = [
+        user('hi'),
+        assistant('checking', [{ id: 'call_A' }]),
+        tool('call_A'),
+        assistant('done'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics).toEqual({
+        orphanToolResults: 0,
+        strippedToolCallTurns: 0,
+        deferredUserMessages: 0,
+      });
+    });
+
+    // Regression test for the bug in the discarded first attempt at this
+    // repair: it decided orphan-vs-complete by checking the pending set
+    // BEFORE deleting the id that had just matched, so the set still looked
+    // non-empty at the exact moment a multi-tool-call turn was about to
+    // resolve completely — stripping toolCalls from a perfectly healthy
+    // turn and turning its own tool results into fresh orphans. Reproduced
+    // and confirmed against the discarded implementation before writing
+    // this one; see the PR description for the reproduction.
+    it('parallel tool calls, all resolved, keep toolCalls intact', () => {
+      const input = [
+        user('hi'),
+        assistant('checking two things', [{ id: 'call_A' }, { id: 'call_B' }]),
+        tool('call_A', 'result A'),
+        tool('call_B', 'result B'),
+        assistant('done'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics.strippedToolCallTurns).toBe(0);
+      expect(diagnostics.orphanToolResults).toBe(0);
+    });
+
+    it('three-plus parallel tool calls, all resolved, keep toolCalls intact', () => {
+      const input = [
+        assistant('checking three things', [
+          { id: 'call_A' },
+          { id: 'call_B' },
+          { id: 'call_C' },
+        ]),
+        tool('call_A'),
+        tool('call_B'),
+        tool('call_C'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics.strippedToolCallTurns).toBe(0);
+    });
+
+    it('several consecutive resolved tool-call rounds all pass through unchanged', () => {
+      const input = [
+        user('go'),
+        assistant('round 1', [{ id: 'call_A' }, { id: 'call_B' }]),
+        tool('call_A'),
+        tool('call_B'),
+        assistant('round 2', [{ id: 'call_C' }]),
+        tool('call_C'),
+        assistant('round 3', [{ id: 'call_D' }, { id: 'call_E' }]),
+        tool('call_D'),
+        tool('call_E'),
+        assistant('final answer'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics.strippedToolCallTurns).toBe(0);
+      expect(diagnostics.orphanToolResults).toBe(0);
+    });
+
+    it('a plain conversation with no tool calls at all is untouched', () => {
+      const input = [system('be nice'), user('hi'), assistant('hello!')];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics.strippedToolCallTurns).toBe(0);
+      expect(diagnostics.orphanToolResults).toBe(0);
+      expect(diagnostics.deferredUserMessages).toBe(0);
+    });
+  });
+
+  describe('genuinely broken histories are repaired', () => {
+    it('drops a tool result whose id no assistant ever declared', () => {
+      const input = [
+        user('hi'),
+        assistant('no tools here'),
+        tool('call_ghost'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual([user('hi'), assistant('no tools here')]);
+      expect(diagnostics.orphanToolResults).toBe(1);
+    });
+
+    it('strips toolCalls from a turn interrupted before any result arrives', () => {
+      const input = [
+        assistant('checking', [{ id: 'call_A' }]),
+        user('actually never mind, do something else'),
+        assistant('ok'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual([
+        assistant('checking'),
+        user('actually never mind, do something else'),
+        assistant('ok'),
+      ]);
+      expect(diagnostics.strippedToolCallTurns).toBe(1);
+      expect(diagnostics.orphanToolResults).toBe(0);
+    });
+
+    it('strips toolCalls AND drops the already-matched result when only some of a parallel turn resolves', () => {
+      const input = [
+        assistant('checking two things', [{ id: 'call_A' }, { id: 'call_B' }]),
+        tool('call_A', 'result A'), // B's result never arrives
+        user('never mind'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      // result A would orphan itself if kept (the stripped assistant no
+      // longer declares call_A), so it must be dropped along with the strip.
+      expect(messages).toEqual([
+        assistant('checking two things'),
+        user('never mind'),
+      ]);
+      expect(diagnostics.strippedToolCallTurns).toBe(1);
+      expect(diagnostics.orphanToolResults).toBe(1);
+    });
+
+    it('strips a trailing unresolved tool-call turn at end of history', () => {
+      const input = [user('hi'), assistant('checking', [{ id: 'call_A' }])];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual([user('hi'), assistant('checking')]);
+      expect(diagnostics.strippedToolCallTurns).toBe(1);
+    });
+
+    it('a new tool-calling turn abandons an unresolved previous one', () => {
+      const input = [
+        assistant('first', [{ id: 'call_A' }]),
+        assistant('second', [{ id: 'call_B' }]),
+        tool('call_B'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual([
+        assistant('first'),
+        assistant('second', [{ id: 'call_B' }]),
+        tool('call_B'),
+      ]);
+      expect(diagnostics.strippedToolCallTurns).toBe(1);
+    });
+  });
+
+  describe('mid-turn user messages are deferred, not dropped', () => {
+    it('defers a user message that arrives while a tool call is in flight', () => {
+      const input = [
+        assistant('checking', [{ id: 'call_A' }]),
+        user('any update?'),
+        tool('call_A'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual([
+        assistant('checking', [{ id: 'call_A' }]),
+        tool('call_A'),
+        user('any update?'),
+      ]);
+      expect(diagnostics.deferredUserMessages).toBe(1);
+      expect(diagnostics.strippedToolCallTurns).toBe(0);
+    });
+
+    it('preserves the order of multiple deferred user messages', () => {
+      const input = [
+        assistant('checking', [{ id: 'call_A' }, { id: 'call_B' }]),
+        user('first interjection'),
+        tool('call_A'),
+        user('second interjection'),
+        tool('call_B'),
+      ];
+      const { messages } = repairProviderHistory(input);
+      expect(messages).toEqual([
+        assistant('checking', [{ id: 'call_A' }, { id: 'call_B' }]),
+        tool('call_A'),
+        tool('call_B'),
+        user('first interjection'),
+        user('second interjection'),
+      ]);
+    });
+  });
+
+  describe('purity', () => {
+    it('never mutates the input array or its messages', () => {
+      const input = Object.freeze([
+        Object.freeze(assistant('checking', [{ id: 'call_A' }])),
+        Object.freeze(tool('call_A')),
+      ]);
+      expect(() => repairProviderHistory(input)).not.toThrow();
+    });
+
+    it('same input produces the same output on repeated calls', () => {
+      const input = [
+        assistant('checking two things', [{ id: 'call_A' }, { id: 'call_B' }]),
+        tool('call_A'),
+        tool('call_B'),
+      ];
+      const first = repairProviderHistory(input);
+      const second = repairProviderHistory(input);
+      expect(first).toEqual(second);
+    });
+  });
+
+  describe('real-world reproduction (MiniMax error 2013)', () => {
+    // The exact shape that triggered `invalid params, tool result's tool
+    // id(...) not found (2013)` in production: a healthy, already-persisted
+    // history — several rounds, some with parallel tool calls — that must
+    // reach the provider byte-for-byte unchanged. Pulled from the actual
+    // session structure (ids shortened for readability).
+    it('passes a realistic multi-round session through unchanged', () => {
+      const input: Message[] = [
+        user('fix my price-comparison addon'),
+        assistant('let me look', [
+          { id: 'call_1', name: 'workspace_list' },
+          { id: 'call_2', name: 'code_glob' },
+        ]),
+        tool('call_1', 'listing'),
+        tool('call_2', 'glob results'),
+        assistant('reading the addon', [{ id: 'call_3', name: 'code_read' }]),
+        tool('call_3', 'file contents'),
+        assistant('here is what I found'),
+        user('yes, please fix it'),
+        assistant('applying the fix', [
+          { id: 'call_4', name: 'code_edit' },
+          { id: 'call_5', name: 'addon_update' },
+          { id: 'call_6', name: 'addon_run' },
+        ]),
+        tool('call_4', 'edited'),
+        tool('call_5', 'updated'),
+        tool('call_6', 'ran'),
+        assistant('done, try it now'),
+      ];
+      const { messages, diagnostics } = repairProviderHistory(input);
+      expect(messages).toEqual(input);
+      expect(diagnostics).toEqual({
+        orphanToolResults: 0,
+        strippedToolCallTurns: 0,
+        deferredUserMessages: 0,
+      });
+    });
+  });
+});

--- a/apps/server/src/providers/history-repair.ts
+++ b/apps/server/src/providers/history-repair.ts
@@ -1,0 +1,187 @@
+/**
+ * Provider history repair.
+ *
+ * Every OpenAI-compatible provider (OpenAI, MiniMax, DeepSeek, …) rejects a
+ * request with a 400 if a `role: 'tool'` message's `tool_call_id` is not
+ * declared by an immediately-preceding `role: 'assistant'` message's
+ * `toolCalls`. MiniMax's exact wording is `invalid params, tool result's
+ * tool id(<id>) not found (2013)`.
+ *
+ * The persisted transcript can develop exactly this shape in the wild:
+ *
+ *   - A user message arrives while a slow tool call is still in flight
+ *     (the tool blocks for tens of seconds and the user sends "continue" or
+ *     a new instruction before it resolves).
+ *   - A tool result is never persisted — a crash, an aborted run, or a bug
+ *     elsewhere leaves an assistant's `toolCalls` declared with no matching
+ *     `tool` row.
+ *
+ * This module repairs the in-memory history immediately before it leaves
+ * the server, so a malformed transcript degrades gracefully (the offending
+ * assistant turn becomes plain text) instead of taking every future request
+ * on that session down with a 400.
+ *
+ * Algorithm: a `role: 'assistant'` message with `toolCalls` opens a group.
+ * Every message is buffered until the group is *closed* — either because
+ * every declared id has a matching `tool` result, or because a
+ * non-matching message (system, plain assistant, a new tool-calling
+ * assistant, or end of input) forces the question. The close decision reads
+ * the FINAL state of the group, once, and is the only place `toolCalls` can
+ * be stripped. This point matters: an earlier version of this repair made
+ * that decision on every partial match (the moment the *first* of several
+ * parallel tool results arrived), while the group's pending set still held
+ * the other ids — so it stripped `toolCalls` from a turn that was, in fact,
+ * about to resolve completely. A single-tool-call turn is a degenerate case
+ * of the same bug: nothing distinguishes "the last id is about to be
+ * deleted" from "no id will ever be deleted" if you check before deleting.
+ * Deciding once, from the final state, has no such window.
+ */
+import {
+  isAssistantMessage,
+  isToolResultMessage,
+  isUserMessage,
+  type AssistantMessage,
+  type Message,
+  type ToolResultMessage,
+} from '@openaidy/runtime';
+
+export type ProviderHistoryRepair = {
+  messages: Message[];
+  diagnostics: {
+    /** Tool results whose id no assistant turn declared. Dropped. */
+    orphanToolResults: number;
+    /**
+     * Assistant turns whose `toolCalls` were stripped because one or more
+     * declared ids never got a matching result.
+     */
+    strippedToolCallTurns: number;
+    /** User messages deferred from inside a tool turn to right after it. */
+    deferredUserMessages: number;
+  };
+};
+
+/** A message this module never needs to look inside; passed through as-is. */
+type OtherMessage = Exclude<Message, AssistantMessage | ToolResultMessage>;
+
+type PendingGroup = {
+  assistant: AssistantMessage;
+  /** Declared tool_call ids not yet matched by a result. */
+  pendingIds: Set<string>;
+  /** Results matched so far, in arrival order. */
+  matchedTools: ToolResultMessage[];
+};
+
+/**
+ * Reconstruct a provider-ready history from a possibly-malformed one.
+ *
+ * Pure function — same input produces the same output, the input array and
+ * its messages are never mutated, and relative order is preserved except for
+ * the deferral described above.
+ */
+export function repairProviderHistory(
+  messages: readonly Message[],
+): ProviderHistoryRepair {
+  const result: Message[] = [];
+  const deferredUsers: Message[] = [];
+  let pending: PendingGroup | undefined;
+
+  let orphanToolResults = 0;
+  let strippedToolCallTurns = 0;
+  let deferredUserMessages = 0;
+
+  const hasDeclaredToolCalls = (
+    msg: AssistantMessage,
+  ): msg is AssistantMessage & { toolCalls: readonly { id: string }[] } =>
+    (msg.toolCalls?.length ?? 0) > 0;
+
+  /**
+   * Settle the pending group, if any: emit it complete (unchanged) when
+   * every declared id was matched, or with `toolCalls` stripped — and its
+   * matched results dropped, since they would otherwise cite ids the
+   * stripped assistant no longer declares — when it was not.
+   */
+  function closePendingGroup(): void {
+    if (!pending) return;
+    if (pending.pendingIds.size === 0) {
+      result.push(pending.assistant, ...pending.matchedTools);
+    } else {
+      result.push(stripToolCalls(pending.assistant));
+      strippedToolCallTurns++;
+      orphanToolResults += pending.matchedTools.length;
+    }
+    pending = undefined;
+  }
+
+  function flushDeferredUsers(): void {
+    if (deferredUsers.length === 0) return;
+    result.push(...deferredUsers);
+    deferredUsers.length = 0;
+  }
+
+  for (const msg of messages) {
+    if (isAssistantMessage(msg) && hasDeclaredToolCalls(msg)) {
+      // A new tool-calling turn begins; anything still pending from a prior
+      // turn is now provably abandoned (nothing else could have matched it).
+      closePendingGroup();
+      pending = {
+        assistant: msg,
+        pendingIds: new Set(msg.toolCalls.map((tc) => tc.id)),
+        matchedTools: [],
+      };
+      continue;
+    }
+
+    if (isToolResultMessage(msg)) {
+      if (pending?.pendingIds.has(msg.toolCallId)) {
+        pending.pendingIds.delete(msg.toolCallId);
+        pending.matchedTools.push(msg);
+        // All declared ids matched — the group can only get more complete
+        // from here, so settle now rather than waiting for the next message
+        // (which may never come, if this was the last turn in the array).
+        if (pending.pendingIds.size === 0) closePendingGroup();
+      } else {
+        // No open group declares this id — a genuinely unrelated or
+        // already-resolved result. The provider would reject it outright.
+        orphanToolResults++;
+      }
+      continue;
+    }
+
+    if (isUserMessage(msg) && pending) {
+      // Arrived mid-turn (a slow tool call still in flight). Hold it so the
+      // eventual tool_call/tool_result adjacency is unbroken; re-emit right
+      // after the group settles, preserving relative order among deferrals.
+      deferredUsers.push(msg);
+      deferredUserMessages++;
+      continue;
+    }
+
+    // System, plain-text assistant, or a user message with nothing pending:
+    // this message can't belong to an open group, so settle it first.
+    closePendingGroup();
+    flushDeferredUsers();
+    result.push(msg as OtherMessage);
+  }
+
+  closePendingGroup();
+  flushDeferredUsers();
+
+  return {
+    messages: result,
+    diagnostics: {
+      orphanToolResults,
+      strippedToolCallTurns,
+      deferredUserMessages,
+    },
+  };
+}
+
+/**
+ * Copy of an assistant message with `toolCalls` removed, so the provider
+ * sees a plain text turn instead of a dangling declaration. Every other
+ * field (`reasoningContent`, etc.) is preserved.
+ */
+function stripToolCalls(msg: AssistantMessage): AssistantMessage {
+  const { toolCalls: _toolCalls, ...rest } = msg;
+  return rest;
+}

--- a/apps/server/src/providers/invocation.ts
+++ b/apps/server/src/providers/invocation.ts
@@ -8,6 +8,31 @@ import {
 } from '@openaidy/runtime';
 import type { ProviderRegistryService } from './registry';
 import type { ProviderSelectionService } from './selection';
+import { repairProviderHistory } from './history-repair.js';
+import { createLogger } from '../lib/logger.js';
+
+const log = createLogger('provider-invocation');
+
+/**
+ * Repair tool-call/tool-result adjacency in the request history before it
+ * reaches the provider — see `history-repair.ts` for why a persisted
+ * transcript can develop this shape and what "repair" means here. Applied
+ * once, at this chokepoint, so every caller of `invoke`/`invokeStream`
+ * (session submissions, the agentic dispatch loop, the planning service,
+ * personality auto-fill, the provider test endpoint) is covered without
+ * each one having to remember to call it.
+ */
+function repairRequestHistory(request: ModelRequest): ModelRequest {
+  const { messages, diagnostics } = repairProviderHistory(request.messages);
+  if (
+    diagnostics.orphanToolResults > 0 ||
+    diagnostics.strippedToolCallTurns > 0 ||
+    diagnostics.deferredUserMessages > 0
+  ) {
+    log.warn('Repaired provider request history before sending', diagnostics);
+  }
+  return { ...request, messages };
+}
 
 /**
  * Invocation options
@@ -23,14 +48,14 @@ export type InvocationOptions = {
 
 /**
  * Model Invocation Service
- * 
+ *
  * Orchestrates provider invocation through the normalized interface.
  * Handles both streaming and non-streaming paths.
  */
 export class ModelInvocationService {
   constructor(
     private readonly registry: ProviderRegistryService,
-    private readonly selection: ProviderSelectionService
+    private readonly selection: ProviderSelectionService,
   ) {}
 
   /**
@@ -38,16 +63,20 @@ export class ModelInvocationService {
    */
   async invoke(
     request: ModelRequest,
-    options?: InvocationOptions
+    options?: InvocationOptions,
   ): Promise<ProviderResult<ModelResponse>> {
     // Determine provider ID from options or request metadata
-    const providerId = options?.providerId ?? (request.metadata?.providerId as string | undefined);
-    
+    const providerId =
+      options?.providerId ??
+      (request.metadata?.providerId as string | undefined);
+
     // Select provider and model
     const selectionResult = this.selection.select({
       ...(providerId !== undefined && { providerId }),
       modelId: options?.modelId ?? request.model,
-      capabilities: request.stream ? ['streaming', 'text_generation'] : ['text_generation'],
+      capabilities: request.stream
+        ? ['streaming', 'text_generation']
+        : ['text_generation'],
     });
 
     if (!selectionResult.ok) {
@@ -62,14 +91,14 @@ export class ModelInvocationService {
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${provider.descriptor.id}" does not support streaming`,
-          { providerId: provider.descriptor.id, modelId }
-        )
+          { providerId: provider.descriptor.id, modelId },
+        ),
       );
     }
 
-    // Build the actual request with resolved model
+    // Build the actual request with resolved model and repaired history
     const actualRequest: ModelRequest = {
-      ...request,
+      ...repairRequestHistory(request),
       model: modelId,
       metadata: {
         ...request.metadata,
@@ -91,8 +120,8 @@ export class ModelInvocationService {
             cause: error,
             providerId: provider.descriptor.id,
             modelId,
-          }
-        )
+          },
+        ),
       );
     }
   }
@@ -103,11 +132,13 @@ export class ModelInvocationService {
    */
   async *invokeStream(
     request: ModelRequest,
-    options?: InvocationOptions
+    options?: InvocationOptions,
   ): AsyncIterable<ProviderResult<ModelStreamEvent>> {
     // Determine provider ID from options or request metadata
-    const providerId = options?.providerId ?? (request.metadata?.providerId as string | undefined);
-    
+    const providerId =
+      options?.providerId ??
+      (request.metadata?.providerId as string | undefined);
+
     // Select provider and model
     const selectionResult = this.selection.select({
       ...(providerId !== undefined && { providerId }),
@@ -128,15 +159,15 @@ export class ModelInvocationService {
         createProviderError(
           'provider.capability_unsupported',
           `Provider "${provider.descriptor.id}" does not support streaming`,
-          { providerId: provider.descriptor.id, modelId }
-        )
+          { providerId: provider.descriptor.id, modelId },
+        ),
       );
       return;
     }
 
-    // Build the actual request with resolved model
+    // Build the actual request with resolved model and repaired history
     const actualRequest: ModelRequest = {
-      ...request,
+      ...repairRequestHistory(request),
       model: modelId,
       stream: true,
       metadata: {
@@ -158,8 +189,8 @@ export class ModelInvocationService {
             cause: error,
             providerId: provider.descriptor.id,
             modelId,
-          }
-        )
+          },
+        ),
       );
     }
   }
@@ -184,7 +215,7 @@ export class ModelInvocationService {
  */
 export function createModelInvocation(
   registry: ProviderRegistryService,
-  selection: ProviderSelectionService
+  selection: ProviderSelectionService,
 ): ModelInvocationService {
   return new ModelInvocationService(registry, selection);
 }


### PR DESCRIPTION
## Problem

MiniMax (and every OpenAI-compatible provider) rejects a request with a 400 if a `role: 'tool'` message's `tool_call_id` is not declared by an immediately-preceding `role: 'assistant'` message's `toolCalls`:

```
400 invalid params, tool result's tool id(call_725210a72edc4da4af984734) not found (2013)
```

A persisted transcript can develop exactly this shape — a user message arrives while a slow tool call is still in flight, or a tool result is never persisted (a crash, an aborted run). Once malformed, every future request built from that session's history hits the same 400: the session is permanently stuck until the bad rows are deleted by hand.

## Root cause, verified

I traced the actual failing session (`6IQhCK3tSugUMuQ6EtY-r`) end to end before writing any fix:

- The persisted DB rows are perfectly paired (every `tool` row's `tool_call_id` matches its preceding `assistant` row's `metadata.toolCalls`) — checked directly against the SQLite file.
- The repository's JSON round-trip (the custom `drizzleNodeSqlite` shim over `node:sqlite`) correctly parses `metadata` back into an object — checked by running the real repository code against a copy of the DB.
- Reconstructing `historyMessages` exactly as `SessionMessageService.submitMessageStreaming` does produces a structurally clean array — no orphans.

So the malformed request wasn't coming from persistence or reconstruction. It came from a **previously-attempted fix for this same issue** (`fix/provider-history-tool-call-adjacency`, since discarded) that was active on the server when the error was reported. Its `flushBufferedAssistant()` decided orphan-vs-complete by checking the pending-tool-id set **before** deleting the id that had just matched — so at the exact moment a multi-tool-call turn was about to resolve completely (or even a single-tool-call turn, resolving via its one and only id), the set still looked non-empty, and it stripped `toolCalls` from a perfectly healthy turn — turning its own tool results into fresh orphans. I reproduced this directly against the discarded implementation (both the single- and parallel-call cases) before writing the replacement.

## Fix

`apps/server/src/providers/history-repair.ts` — a pure function, `repairProviderHistory(messages)`, that groups each tool-calling assistant turn with its results and decides **exactly once**, from the group's final state, whether it's complete (emitted unchanged) or abandoned (`toolCalls` stripped, and any partial matches dropped too — keeping them would just relocate the orphan). Deciding once, from the final state, is what closes the exact window the discarded version got wrong.

Wired into `ModelInvocationService.invoke` / `invokeStream` — the single chokepoint every caller (session submissions, the agentic dispatch loop, the planning service, personality auto-fill, the provider test endpoint) already flows through, so no per-caller wiring is needed.

## Not MiniMax-specific

The invariant this repairs — a declared `tool_call` must precede its result — isn't a MiniMax quirk; it's the shared contract every provider adapter relies on. Confirmed directly: `openai-compatible/adapter.ts`, `anthropic/request-mapper.ts`, and `gemini/request-mapper.ts` all read the same canonical `toolCalls` / `toolCallId` fields off `Message`. Sitting one layer above all three, at the `ModelInvocationService` chokepoint, protects every provider family with zero per-vendor code.

Genuine per-vendor quirks (MiniMax's streaming markup, DeepSeek's tool-name sanitization) already have a Strategy-pattern extension point — `ProviderAdapterCodec`. This fix deliberately does not live there, since the problem it solves isn't vendor-specific to begin with; a future provider with a genuinely different adjacency rule would extend via its own adapter, not by modifying this file.

## Testing

- 15 unit tests in `history-repair.test.ts`: healthy histories (single call, parallel calls, 3+ parallel calls, several consecutive rounds, no tool calls at all) pass through byte-for-byte unchanged; genuinely broken histories (orphan result, unresolved turn, partial-parallel-resolution, a new tool-calling turn abandoning a previous one) are repaired correctly; mid-turn user messages are deferred, not dropped; purity (no mutation, deterministic); and a realistic multi-round reproduction of the exact reported shape.
- Two of those tests are direct regressions for the discarded implementation's bug (single-call and parallel-call, both fully resolved) — reproduced failing against that code before writing this one.
- `pnpm --filter @openaidy/server test`: 3422 passed. The one failure, `update/service.test.ts` "passes the version as a single argv element", reproduces identically on unmodified `main` on Windows and is unrelated.
- `tsc --noEmit` clean.
- **Verified locally against the live session that produced the original error** — same DB, same session, confirmed the run that previously failed now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)