### PR TITLE
feat(mcp): add Buffer to preinstalled MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,19 @@ The dev mode runs the API server and Vite UI separately with hot reload.
 
 ## How OpenAidy compares
 
-| Capability                              | OpenAidy | n8n   | CrewAI | AutoGen |
-| --------------------------------------- | :------: | :---: | :----: | :-----: |
-| **Self-hostable**                       |    ✅    |  ✅   |   ❌   |    ❌   |
-| **Built-in operator UI**                |    ✅    |  ✅   |   ❌   |    ❌   |
-| **Real-time token streaming**           |    ✅    |  🟡   |   ❌   |    ❌   |
-| **Persistent agent sessions**           |    ✅    |  🟡   |   ❌   |    ❌   |
-| **Cron + one-shot scheduler**           |    ✅    |  ✅   |   ❌   |    ❌   |
-| **First-class MCP support**             |    ✅    |  🟡   |   ❌   |    ✅   |
-| **Plugin SDK (tools, channels, UI)**    |    ✅    |  ✅   |   ❌   |    ❌   |
-| **Messaging channels (WhatsApp, etc.)** |    ✅    |  ✅   |   ❌   |    ❌   |
-| **Multi-agent orchestration**           |    ✅    |  🟡   |   ✅   |    ✅   |
-| **Provider-agnostic (OpenAI/Anthropic/Gemini/local)** | ✅ | ✅ | ✅ | ✅ |
-| **License**                             |   MIT    |  ⚖️   |  MIT   |   MIT   |
+| Capability                                            | OpenAidy | n8n | CrewAI | AutoGen |
+| ----------------------------------------------------- | :------: | :-: | :----: | :-----: |
+| **Self-hostable**                                     |    ✅    | ✅  |   ❌   |   ❌    |
+| **Built-in operator UI**                              |    ✅    | ✅  |   ❌   |   ❌    |
+| **Real-time token streaming**                         |    ✅    | 🟡  |   ❌   |   ❌    |
+| **Persistent agent sessions**                         |    ✅    | 🟡  |   ❌   |   ❌    |
+| **Cron + one-shot scheduler**                         |    ✅    | ✅  |   ❌   |   ❌    |
+| **First-class MCP support**                           |    ✅    | 🟡  |   ❌   |   ✅    |
+| **Plugin SDK (tools, channels, UI)**                  |    ✅    | ✅  |   ❌   |   ❌    |
+| **Messaging channels (WhatsApp, etc.)**               |    ✅    | ✅  |   ❌   |   ❌    |
+| **Multi-agent orchestration**                         |    ✅    | 🟡  |   ✅   |   ✅    |
+| **Provider-agnostic (OpenAI/Anthropic/Gemini/local)** |    ✅    | ✅  |   ✅   |   ✅    |
+| **License**                                           |   MIT    | ⚖️  |  MIT   |   MIT   |
 
 Legend: ✅ yes &nbsp;&nbsp; 🟡 partial &nbsp;&nbsp; ❌ no &nbsp;&nbsp; ⚖️ "Sustainable Use" (not OSI-open)
 
@@ -290,6 +290,7 @@ The following MCP servers ship preinstalled (reconciled into every install on st
 | Context7 Docs       | http      | optional                          | [free tier](https://context7.com/dashboard) works without a key; higher rate limits with `${CONTEXT7_API_KEY}` |
 | Brave Search        | stdio     | `${BRAVE_API_KEY}`                | [free tier](https://brave.com/search/api/) (~2000 req/month)                                                   |
 | Tavily Search       | stdio     | `${TAVILY_API_KEY}`               | [free tier](https://tavily.com/)                                                                               |
+| Buffer              | http      | `${BUFFER_API_KEY}`               | [Buffer](https://buffer.com) social media scheduling — per-account API key                                     |
 
 #### Setting API keys
 

--- a/apps/server/src/mcp/preinstall.test.ts
+++ b/apps/server/src/mcp/preinstall.test.ts
@@ -72,6 +72,14 @@ const tavily: McpServerConfig = {
   env: { TAVILY_API_KEY: '${TAVILY_API_KEY}' },
 };
 
+const buffer: McpServerConfig = {
+  id: 'buffer',
+  name: 'Buffer',
+  transport: 'http',
+  url: 'https://mcp.buffer.com/mcp',
+  headers: { Authorization: 'Bearer ${BUFFER_API_KEY}' },
+};
+
 /** The full preinstalled set shipped in `config/openaidy.template.json`. */
 const allPreinstalled: McpServerConfig[] = [
   github,
@@ -81,6 +89,7 @@ const allPreinstalled: McpServerConfig[] = [
   context7,
   braveSearch,
   tavily,
+  buffer,
 ];
 
 describe('reconcilePreinstalledMcpServers', () => {

--- a/config/openaidy.template.json
+++ b/config/openaidy.template.json
@@ -59,6 +59,15 @@
       "env": {
         "TAVILY_API_KEY": "${TAVILY_API_KEY}"
       }
+    },
+    {
+      "id": "buffer",
+      "name": "Buffer",
+      "transport": "http",
+      "url": "https://mcp.buffer.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${BUFFER_API_KEY}"
+      }
     }
   ],
   "providers": [],


### PR DESCRIPTION
## What

Adds Buffer (https://buffer.com) to the preinstalled MCP servers shipped in `config/openaidy.template.json`. Buffer is a social media management platform; their public MCP server is available at `https://mcp.buffer.com/mcp` and uses Bearer auth via a per-account API key.

## How existing installs get it

The preinstalled server reconciliation (`apps/server/src/mcp/preinstall.ts`, called from `apps/server/src/config/service.ts`) already handles this. On every startup it diffs the user's persisted MCP servers against the template and:

- Absent from config, absent from manifest → **ADD** (newly shipped server)
- Absent from config, present in manifest → leave it (user deleted; do not resurrect)
- Present, pristine (matches manifest hash) → UPDATE if template changed
- Present, user-modified → never clobber

`buffer` lands in the first row for every existing install: it is in the template, not in the user's config, not in the manifest. The reconciliation adds it to the user's `config.json` and records its hash in `.mcp-seed-manifest.json`. Zero user action; the next start picks it up.

The only thing the user has to do is set `BUFFER_API_KEY` in their environment. Until then, the server sits in "awaiting configuration" (no auto-connect) — same flow as `github`, `brave-search`, `tavily`.

## Why HTTP + Bearer auth (not npm — supply chain)

Buffer is a SaaS vendor with a hosted MCP endpoint, not an npm package. Same trust category as the existing `github` server (which also uses `transport: http` + `Authorization: Bearer ${...}`). The supply-chain bar for preinstalled servers (preference #70) prohibits low-trust npm MCP ports, not vendor-hosted endpoints.

## Auth

The template does **not** contain the user's API key. The `Authorization` header interpolates `${BUFFER_API_KEY}` from the user's environment (same pattern as `GITHUB_PERSONAL_ACCESS_TOKEN`, `BRAVE_API_KEY`, `TAVILY_API_KEY`). Users set their own key in their `.env` or shell.

## Tests

- 11/11 in `preinstall.test.ts` pass, including the three that exercise the upgrade path: `adds a new template server absent from config and manifest`, `adds only the new server when one is already configured`, and `seeds every preinstalled server into a fresh install with no manifest`.

## Files

| File | Change |
|------|--------|
| `config/openaidy.template.json` | Add `buffer` server entry (HTTP, Bearer auth via `BUFFER_API_KEY` env var) |
| `apps/server/src/mcp/preinstall.test.ts` | Add `buffer` fixture; include it in `allPreinstalled` so the upgrade and idempotency tests cover it |