### PR TITLE
fix(tasks): model subtask dependencies as a graph, fix context handoff

### DIFF
--- a/apps/server/src/lib/context-budget.test.ts
+++ b/apps/server/src/lib/context-budget.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { createContextBudget, truncateWithBudget } from './context-budget';
+
+describe('context-budget', () => {
+  it('returns text unchanged and decrements budget by its length when under both caps', () => {
+    const budget = createContextBudget(100);
+    const result = truncateWithBudget('short text', 50, budget);
+
+    expect(result).toBe('short text');
+    expect(budget.remaining).toBe(100 - 'short text'.length);
+  });
+
+  it('truncates to the per-item cap and decrements by the full returned length, including the marker', () => {
+    const budget = createContextBudget(1000);
+    const text = 'x'.repeat(50);
+
+    const result = truncateWithBudget(text, 10, budget);
+
+    expect(result).toBe('xxxxxxxxxx…[truncated 40 chars]');
+    // Regression: the marker itself must count against the budget,
+    // not just the sliced `cap` chars — otherwise every truncated item
+    // leaks a few dozen chars past the total cap.
+    expect(budget.remaining).toBe(1000 - result.length);
+  });
+
+  it('never lets a single item consume more than the remaining budget', () => {
+    const budget = createContextBudget(20);
+    const text = 'y'.repeat(100);
+
+    const result = truncateWithBudget(text, 50, budget);
+
+    expect(result.length).toBeLessThanOrEqual(
+      20 + '…[truncated 100 chars]'.length,
+    );
+    expect(budget.remaining).toBe(20 - result.length);
+  });
+});

--- a/apps/server/src/lib/context-budget.ts
+++ b/apps/server/src/lib/context-budget.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helpers for bounding how much text gets carried into a new
+ * LLM context (e.g. handing a completed subtask's result to a
+ * dependent subtask, or summarizing tool results for verification).
+ * Caps both the size of any single item and the running total, so a
+ * few large results can't unboundedly grow the next prompt.
+ */
+
+export type ContextBudget = { remaining: number };
+
+export function createContextBudget(totalCap: number): ContextBudget {
+  return { remaining: totalCap };
+}
+
+/**
+ * Truncate `text` to at most `perItemCap` chars, further capped by
+ * whatever remains of the shared `budget`. Decrements `budget` by the
+ * number of characters actually kept. Callers should check
+ * `budget.remaining > 0` before calling if they want to omit the item
+ * entirely once the budget is exhausted, rather than get an empty
+ * truncation marker.
+ */
+export function truncateWithBudget(
+  text: string,
+  perItemCap: number,
+  budget: ContextBudget,
+): string {
+  const cap = Math.max(0, Math.min(perItemCap, budget.remaining));
+  if (text.length <= cap) {
+    budget.remaining -= text.length;
+    return text;
+  }
+  const truncated =
+    text.slice(0, cap) + `…[truncated ${text.length - cap} chars]`;
+  budget.remaining -= truncated.length;
+  return truncated;
+}

--- a/apps/server/src/planning/agent-assignment.test.ts
+++ b/apps/server/src/planning/agent-assignment.test.ts
@@ -86,6 +86,7 @@ const makeSubtasksRepo = () => ({
     } as MockSubtask),
   ),
   deleteByTask: vi.fn().mockResolvedValue([]),
+  addEdges: vi.fn().mockResolvedValue(undefined),
 });
 
 const makeTaskAgentsRepo = () => ({

--- a/apps/server/src/planning/service.test.ts
+++ b/apps/server/src/planning/service.test.ts
@@ -79,6 +79,7 @@ const makeSubtasksRepo = () => ({
     orderIndex: 0,
   } as MockSubtask),
   deleteByTask: vi.fn().mockResolvedValue([]),
+  addEdges: vi.fn().mockResolvedValue(undefined),
 });
 
 describe('PlanningService', () => {
@@ -110,6 +111,42 @@ describe('PlanningService', () => {
         expect(result.subtasks).toHaveLength(2);
         expect(result.subtasks[0]!.title).toBe('Subtask 1');
       }
+    });
+
+    it('writes ALL declared dependencies as edges, not just the first (regression: previously only dependencies[0] was kept)', async () => {
+      mockProviders.invocation.invoke.mockResolvedValue({
+        ok: true,
+        value: {
+          content: JSON.stringify([
+            { title: 'A', description: 'First', dependencies: [] },
+            { title: 'B', description: 'Second', dependencies: [] },
+            {
+              title: 'Merge',
+              description: 'Combine A and B',
+              dependencies: [0, 1],
+            },
+          ]),
+        },
+      });
+      let created = 0;
+      mockSubtasksRepo.create.mockImplementation(async () => {
+        created += 1;
+        return {
+          id: `subtask-${created}`,
+          taskId: 'task-1',
+          title: `Subtask ${created}`,
+          description: 'x',
+          orderIndex: created - 1,
+        } as MockSubtask;
+      });
+
+      const result = await service.planTask('task-1');
+
+      expect(result.ok).toBe(true);
+      expect(mockSubtasksRepo.addEdges).toHaveBeenCalledWith('subtask-3', [
+        'subtask-1',
+        'subtask-2',
+      ]);
     });
 
     it('updates planning status to completed on success', async () => {

--- a/apps/server/src/planning/service.ts
+++ b/apps/server/src/planning/service.ts
@@ -13,6 +13,7 @@ import type {
 } from '@openaidy/db';
 import type { AgentRegistry } from '../agents';
 import { parseModelString } from '../agents/schema';
+import { createLogger } from '../lib/logger';
 import {
   PLANNING_AGENT_CONFIG,
   type PlanningOptions,
@@ -24,6 +25,8 @@ import {
   buildAgentContextPrompt,
 } from './prompts';
 import type { Task } from '@openaidy/db';
+
+const logger = createLogger('PlanningService');
 
 /**
  * Planning service options
@@ -398,22 +401,16 @@ export class PlanningService {
     taskId: string,
     planned: PlannedSubtask[],
   ): Promise<void> {
-    // Create subtasks in order, respecting dependencies
+    // Create subtasks in order, then wire up dependency edges once all
+    // subtasks exist (an edge can reference a subtask later in the list).
     const created = new Map<number, string>();
 
     for (let i = 0; i < planned.length; i++) {
       const subtask = planned[i];
       if (!subtask) continue;
 
-      // Get parent subtask ID from first dependency if exists
-      const parentSubtaskId =
-        subtask.dependencies.length > 0 && subtask.dependencies[0] !== undefined
-          ? created.get(subtask.dependencies[0])
-          : undefined;
-
       const createInput: {
         taskId: string;
-        parentSubtaskId?: string;
         title: string;
         description: string;
         orderIndex: number;
@@ -425,10 +422,6 @@ export class PlanningService {
         orderIndex: i,
       };
 
-      if (parentSubtaskId !== undefined) {
-        createInput.parentSubtaskId = parentSubtaskId;
-      }
-
       if (subtask.assignedAgentId) {
         createInput.assignedAgentId = subtask.assignedAgentId;
       }
@@ -436,6 +429,35 @@ export class PlanningService {
       const createdSubtask = await this.subtasksRepo.create(createInput);
 
       created.set(i, createdSubtask.id);
+    }
+
+    // Second pass: now that every subtask exists, resolve each planned
+    // subtask's full dependency list (not just the first one) into
+    // edges. Dependencies are plan-local indices into `planned`.
+    for (let i = 0; i < planned.length; i++) {
+      const subtask = planned[i];
+      if (!subtask || subtask.dependencies.length === 0) continue;
+
+      const subtaskId = created.get(i);
+      if (!subtaskId) continue;
+
+      const dependsOnIds: string[] = [];
+      for (const depIndex of subtask.dependencies) {
+        if (depIndex === i) continue; // ignore a self-referencing dependency
+        const depId = created.get(depIndex);
+        if (!depId) {
+          logger.warn(
+            'Planned subtask references a dependency index that was not created; skipping edge',
+            { taskId, subtaskIndex: i, dependencyIndex: depIndex },
+          );
+          continue;
+        }
+        dependsOnIds.push(depId);
+      }
+
+      if (dependsOnIds.length > 0) {
+        await this.subtasksRepo.addEdges(subtaskId, dependsOnIds);
+      }
     }
   }
 }

--- a/apps/server/src/prompts/build-system-prompt.ts
+++ b/apps/server/src/prompts/build-system-prompt.ts
@@ -244,6 +244,8 @@ Rules:
 - Do NOT offer a menu of options or ask "what would you like me to do?". Pick the best approach and execute it.
 - Do NOT end your response with a question or a proposal. End it with the finished work.
 
+Your final message is the ONLY thing downstream subtasks will ever see from this work — they do not see your intermediate steps or tool calls. Before finishing, explicitly restate every concrete fact a later subtask might need: IDs, URLs, file paths, names, numbers, and key decisions. Do not assume anything you did earlier in this conversation carries forward — if it's not in your final message, it is lost to the rest of the workflow.
+
 Your response will be automatically evaluated. Work is judged complete only if the actual deliverable is present in your response, not if you described what you could do.
 [/SUBTASK_REMINDER]`;
   }

--- a/apps/server/src/routes/subtasks.ts
+++ b/apps/server/src/routes/subtasks.ts
@@ -4,7 +4,7 @@ import type { TaskService } from '../tasks/service';
 
 // Validation schemas
 const createSubtaskSchema = z.object({
-  parentSubtaskId: z.string().optional(),
+  dependsOn: z.array(z.string()).optional(),
   title: z.string().min(1),
   description: z.string().min(1),
   orderIndex: z.number().int().min(0).optional(),
@@ -38,7 +38,7 @@ export type SubtaskRoutesOptions = {
 
 export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
   app,
-  options
+  options,
 ) => {
   const { taskService } = options;
 
@@ -53,7 +53,13 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
     const task = await taskService.getTask(taskId);
     if (!task) {
       reply.code(404);
-      return { ok: false, error: { code: 'task.not_found', message: `Task "${taskId}" not found` } };
+      return {
+        ok: false,
+        error: {
+          code: 'task.not_found',
+          message: `Task "${taskId}" not found`,
+        },
+      };
     }
 
     const items = await taskService.getSubtasks(taskId);
@@ -76,14 +82,15 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
         ok: false,
         error: {
           code: 'validation.invalid_request',
-          message: error instanceof Error ? error.message : 'Invalid request body',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
         },
       };
     }
 
     const createInput: {
       taskId: string;
-      parentSubtaskId?: string;
+      dependsOn?: string[];
       title: string;
       description: string;
       orderIndex?: number;
@@ -93,8 +100,8 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
       title: parsed.title,
       description: parsed.description,
     };
-    if (parsed.parentSubtaskId !== undefined) {
-      createInput.parentSubtaskId = parsed.parentSubtaskId;
+    if (parsed.dependsOn !== undefined) {
+      createInput.dependsOn = parsed.dependsOn;
     }
     if (parsed.orderIndex !== undefined) {
       createInput.orderIndex = parsed.orderIndex;
@@ -136,12 +143,17 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
         ok: false,
         error: {
           code: 'validation.invalid_request',
-          message: error instanceof Error ? error.message : 'Invalid request body',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
         },
       };
     }
 
-    const updateInput: { title?: string; description?: string; orderIndex?: number } = {};
+    const updateInput: {
+      title?: string;
+      description?: string;
+      orderIndex?: number;
+    } = {};
     if (parsed.title !== undefined) {
       updateInput.title = parsed.title;
     }
@@ -203,7 +215,8 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
         ok: false,
         error: {
           code: 'validation.invalid_request',
-          message: error instanceof Error ? error.message : 'Invalid request body',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
         },
       };
     }
@@ -238,7 +251,8 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
         ok: false,
         error: {
           code: 'validation.invalid_request',
-          message: error instanceof Error ? error.message : 'Invalid request body',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
         },
       };
     }
@@ -275,7 +289,8 @@ export const subtaskRoutes: FastifyPluginAsync<SubtaskRoutesOptions> = async (
         ok: false,
         error: {
           code: 'validation.invalid_request',
-          message: error instanceof Error ? error.message : 'Invalid request body',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
         },
       };
     }

--- a/apps/server/src/tasks/execution/subtask-graph.ts
+++ b/apps/server/src/tasks/execution/subtask-graph.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure helpers over the subtask dependency graph (subtask_edges).
+ * Shared between task execution and subtask operations so gating and
+ * context handoff always agree on the same dependency semantics.
+ */
+
+import type { Subtask } from '@openaidy/db';
+
+export type SubtaskDependencyEdge = {
+  subtaskId: string;
+  dependsOnSubtaskId: string;
+};
+
+/**
+ * A subtask is executable once every subtask it depends on has
+ * reached `completed`. A subtask with no incoming edges is always
+ * executable (subject to its own status already being `pending`,
+ * which callers check separately).
+ */
+export function isSubtaskExecutable(
+  subtask: Subtask,
+  allSubtasks: Subtask[],
+  edges: SubtaskDependencyEdge[],
+): boolean {
+  const dependsOnIds = edges
+    .filter((e) => e.subtaskId === subtask.id)
+    .map((e) => e.dependsOnSubtaskId);
+  if (dependsOnIds.length === 0) return true;
+
+  const byId = new Map(allSubtasks.map((s) => [s.id, s]));
+  return dependsOnIds.every((depId) => byId.get(depId)?.status === 'completed');
+}
+
+/**
+ * The subtasks `subtask` actually depends on, in the order the edges
+ * were declared. Used to scope context handoff to real dependencies
+ * instead of every completed subtask in the task.
+ */
+export function getDependencySubtasks(
+  subtask: Subtask,
+  allSubtasks: Subtask[],
+  edges: SubtaskDependencyEdge[],
+): Subtask[] {
+  const byId = new Map(allSubtasks.map((s) => [s.id, s]));
+  return edges
+    .filter((e) => e.subtaskId === subtask.id)
+    .map((e) => byId.get(e.dependsOnSubtaskId))
+    .filter((s): s is Subtask => Boolean(s));
+}

--- a/apps/server/src/tasks/execution/task-execution.ts
+++ b/apps/server/src/tasks/execution/task-execution.ts
@@ -17,10 +17,24 @@ import type {
 } from '@openaidy/shared-types';
 import { createLogger } from '../../lib/logger';
 import { stripThinking } from '../../lib/message.js';
+import {
+  createContextBudget,
+  truncateWithBudget,
+} from '../../lib/context-budget';
 import type { SessionMessageRecord, ServiceResult } from '../../types';
+import {
+  isSubtaskExecutable,
+  getDependencySubtasks,
+  type SubtaskDependencyEdge,
+} from './subtask-graph';
 
 const MAX_RETRIES = 5;
 const STUCK_TIMEOUT_MINUTES = 3;
+// Bounds on how much of a completed dependency's result is carried into
+// a dependent subtask's opening message, so a large upstream result
+// can't unboundedly grow the next subtask's context window.
+const DEP_CONTEXT_PER_ITEM_CHARS = 2000;
+const DEP_CONTEXT_TOTAL_CHARS = 8000;
 
 export class TaskExecution {
   private readonly logger: ReturnType<typeof createLogger>;
@@ -312,7 +326,16 @@ export class TaskExecution {
 
   async executeSubtask(
     subtaskId: string,
-    options: { sessionId?: string } = {},
+    options: {
+      sessionId?: string;
+      // Lets executeSubtasks() pass the task's subtasks/edges it already
+      // fetched for the batch, instead of this method re-fetching the
+      // same data per subtask.
+      preloadedGraph?: {
+        allSubtasks: Subtask[];
+        edges: SubtaskDependencyEdge[];
+      };
+    } = {},
   ): Promise<ServiceResult<{ sessionId: string }>> {
     if (!this.sessionService) {
       return {
@@ -349,17 +372,21 @@ export class TaskExecution {
       };
     }
 
-    if (subtask.parentSubtaskId) {
-      const parent = await this.subtasksRepo.findById(subtask.parentSubtaskId);
-      if (parent?.status !== 'completed') {
-        return {
-          ok: false,
-          error: {
-            code: 'subtask.dependency_not_met',
-            message: 'Parent subtask not completed',
-          },
-        };
-      }
+    const allSubtasks =
+      options.preloadedGraph?.allSubtasks ??
+      (await this.subtasksRepo.listByTask(subtask.taskId));
+    const edges =
+      options.preloadedGraph?.edges ??
+      (await this.subtasksRepo.listEdgesByTask(subtask.taskId));
+
+    if (!isSubtaskExecutable(subtask, allSubtasks, edges)) {
+      return {
+        ok: false,
+        error: {
+          code: 'subtask.dependency_not_met',
+          message: 'One or more dependencies not completed',
+        },
+      };
     }
 
     // Reuse the existing session if the caller (e.g. the recurring-task
@@ -387,20 +414,32 @@ export class TaskExecution {
     await this.subtasksRepo.update(subtaskId, { sessionId: session.id });
     await this.subtasksRepo.updateStatus(subtaskId, 'in_progress');
 
-    const allSubtasks = await this.subtasksRepo.listByTask(subtask.taskId);
-    const completedDeps = allSubtasks.filter(
-      (s) => s.status === 'completed' && s.result,
-    );
+    // Scope the handoff to this subtask's actual dependencies only
+    // (not every completed subtask in the task), and bound its size so
+    // a large upstream result can't unboundedly grow this session.
+    const completedDeps = getDependencySubtasks(
+      subtask,
+      allSubtasks,
+      edges,
+    ).filter((s) => s.status === 'completed' && s.result);
 
     let messageContent = subtask.description;
     if (completedDeps.length > 0) {
-      const contextParts = completedDeps.map(
-        (dep) => `## Result from "${dep.title}":\n${dep.result}`,
-      );
-      messageContent = `${subtask.description}\n\n---\n\n**Context from completed work:**\n\n${contextParts.join('\n\n')}`;
+      const depBudget = createContextBudget(DEP_CONTEXT_TOTAL_CHARS);
+      const contextParts: string[] = [];
+      for (const dep of completedDeps) {
+        if (depBudget.remaining <= 0) break;
+        const truncatedResult = truncateWithBudget(
+          dep.result!,
+          DEP_CONTEXT_PER_ITEM_CHARS,
+          depBudget,
+        );
+        contextParts.push(`## Result from "${dep.title}":\n${truncatedResult}`);
+      }
+      messageContent = `${subtask.description}\n\n---\n\n**Context from completed dependencies:**\n\n${contextParts.join('\n\n')}`;
       this.logger.info('Including context from completed dependencies', {
         subtaskId,
-        depCount: completedDeps.length,
+        depCount: contextParts.length,
       });
     }
 
@@ -439,21 +478,24 @@ export class TaskExecution {
     }
 
     const subtasks = await this.subtasksRepo.listByTask(taskId);
+    const edges = await this.subtasksRepo.listEdgesByTask(taskId);
     const executable = subtasks
       .filter((s) => s.status === 'pending')
-      .filter((subtask) => {
-        if (!subtask.parentSubtaskId) return true;
-        const parent = subtasks.find((s) => s.id === subtask.parentSubtaskId);
-        return parent?.status === 'completed';
-      });
+      .filter((subtask) => isSubtaskExecutable(subtask, subtasks, edges));
+
+    // Executable subtasks already have every dependency in a terminal
+    // `completed` state as of this snapshot, and a dependency's status
+    // and result never change once completed — so it's safe to reuse
+    // this same snapshot for every subtask in the batch instead of each
+    // executeSubtask() call re-fetching it.
+    const preloadedGraph = { allSubtasks: subtasks, edges };
 
     let startedCount = 0;
     for (const subtask of executable) {
-      const result = options.sessionId
-        ? await this.executeSubtask(subtask.id, {
-            sessionId: options.sessionId,
-          })
-        : await this.executeSubtask(subtask.id);
+      const result = await this.executeSubtask(subtask.id, {
+        ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+        preloadedGraph,
+      });
       if (result.ok) startedCount++;
     }
 
@@ -682,9 +724,9 @@ export class TaskExecution {
 
     const consultedSkills = new Set<string>();
     const toolCallsWithResults: string[] = [];
-    let totalResultsBytes = 0;
     const MAX_PER_RESULT = 1000;
     const MAX_TOTAL_RESULTS = 8192;
+    const resultsBudget = createContextBudget(MAX_TOTAL_RESULTS);
 
     if (sessionMessages && sessionMessages.length > 0) {
       for (const m of sessionMessages) {
@@ -698,18 +740,15 @@ export class TaskExecution {
             let entry = `- ${tc.name}(${tc.arguments})`;
             if (tc.id && toolResultByCallId.has(tc.id)) {
               const result = toolResultByCallId.get(tc.id)!;
-              if (totalResultsBytes < MAX_TOTAL_RESULTS) {
-                const remaining = MAX_TOTAL_RESULTS - totalResultsBytes;
-                const budget = Math.min(MAX_PER_RESULT, remaining);
-                const truncated =
-                  result.content.length > budget
-                    ? result.content.slice(0, budget) +
-                      `…[truncated ${result.content.length - budget} chars]`
-                    : result.content;
+              if (resultsBudget.remaining > 0) {
+                const truncated = truncateWithBudget(
+                  result.content,
+                  MAX_PER_RESULT,
+                  resultsBudget,
+                );
                 entry += `\n    → result${
                   result.isError ? ' (ERROR)' : ''
                 }: ${truncated}`;
-                totalResultsBytes += truncated.length;
               }
             }
             toolCallsWithResults.push(entry);

--- a/apps/server/src/tasks/execution/task-schedule-executor.test.ts
+++ b/apps/server/src/tasks/execution/task-schedule-executor.test.ts
@@ -56,10 +56,6 @@ const makeAgent = (overrides: Partial<TaskAgent> = {}): TaskAgent => ({
 const makeSubtask = (overrides: Partial<Subtask> = {}): Subtask => ({
   id: 'sub-1',
   taskId: 'task-1',
-  // The Drizzle schema declares parentSubtaskId as NOT NULL, so we use
-  // a placeholder string for root subtasks. (The repository's own create()
-  // writes null — pre-existing inconsistency in the codebase, not ours.)
-  parentSubtaskId: '',
   title: 'Subtask 1',
   description: 'Do thing 1',
   status: 'pending',

--- a/apps/server/src/tasks/operations/subtask-operations.ts
+++ b/apps/server/src/tasks/operations/subtask-operations.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentRegistry } from '../../agents';
 import { createLogger } from '../../lib/logger';
 import type { CreateSubtaskInput, ServiceResult } from '../../types';
+import { isSubtaskExecutable } from '../execution/subtask-graph';
 
 export class SubtaskOperations {
   constructor(
@@ -41,11 +42,25 @@ export class SubtaskOperations {
       }
     }
     const subtask = await this.subtasksRepo.create(input);
+    if (input.dependsOn && input.dependsOn.length > 0) {
+      await this.subtasksRepo.addEdges(subtask.id, input.dependsOn);
+    }
     return { ok: true, data: subtask };
   }
 
-  async getSubtasks(taskId: string): Promise<Subtask[]> {
-    return this.subtasksRepo.listByTask(taskId);
+  async getSubtasks(
+    taskId: string,
+  ): Promise<(Subtask & { dependsOnSubtaskIds: string[] })[]> {
+    const [subtasks, edges] = await Promise.all([
+      this.subtasksRepo.listByTask(taskId),
+      this.subtasksRepo.listEdgesByTask(taskId),
+    ]);
+    return subtasks.map((subtask) => ({
+      ...subtask,
+      dependsOnSubtaskIds: edges
+        .filter((e) => e.subtaskId === subtask.id)
+        .map((e) => e.dependsOnSubtaskId),
+    }));
   }
 
   async updateSubtask(
@@ -160,12 +175,10 @@ export class SubtaskOperations {
 
   async getNextExecutableSubtasks(taskId: string): Promise<Subtask[]> {
     const subtasks = await this.subtasksRepo.listByTask(taskId);
-    return subtasks.filter((subtask) => {
-      if (subtask.status !== 'pending') return false;
-      if (!subtask.parentSubtaskId) return true;
-      const parent = subtasks.find((s) => s.id === subtask.parentSubtaskId);
-      return parent?.status === 'completed';
-    });
+    const edges = await this.subtasksRepo.listEdgesByTask(taskId);
+    return subtasks
+      .filter((s) => s.status === 'pending')
+      .filter((subtask) => isSubtaskExecutable(subtask, subtasks, edges));
   }
 
   async getSubtaskBySessionId(

--- a/apps/server/src/tasks/service-session.test.ts
+++ b/apps/server/src/tasks/service-session.test.ts
@@ -47,6 +47,7 @@ describe('TaskService Session Integration', () => {
     update: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
     listByTask: ReturnType<typeof vi.fn>;
+    listEdgesByTask: ReturnType<typeof vi.fn>;
     getCountsByStatus: ReturnType<typeof vi.fn>;
     assignAgent: ReturnType<typeof vi.fn>;
     setResult: ReturnType<typeof vi.fn>;
@@ -99,6 +100,7 @@ describe('TaskService Session Integration', () => {
       update: vi.fn().mockResolvedValue({}),
       updateStatus: vi.fn().mockResolvedValue({}),
       listByTask: vi.fn().mockResolvedValue([]),
+      listEdgesByTask: vi.fn().mockResolvedValue([]),
       getCountsByStatus: vi.fn().mockResolvedValue({
         pending: 0,
         assigned: 0,

--- a/apps/server/src/tasks/service.ts
+++ b/apps/server/src/tasks/service.ts
@@ -181,7 +181,9 @@ export class TaskService {
     return this.subtaskOps.createSubtask(input);
   }
 
-  async getSubtasks(taskId: string): Promise<Subtask[]> {
+  async getSubtasks(
+    taskId: string,
+  ): Promise<(Subtask & { dependsOnSubtaskIds: string[] })[]> {
     return this.subtaskOps.getSubtasks(taskId);
   }
 

--- a/apps/server/src/tasks/subtask-execution.test.ts
+++ b/apps/server/src/tasks/subtask-execution.test.ts
@@ -18,6 +18,8 @@ type MockTasksRepo = {
 type MockSubtasksRepo = {
   findById: ReturnType<typeof vi.fn>;
   listByTask: ReturnType<typeof vi.fn>;
+  listEdgesByTask: ReturnType<typeof vi.fn>;
+  addEdges: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   updateStatus: ReturnType<typeof vi.fn>;
   assignAgent: ReturnType<typeof vi.fn>;
@@ -51,6 +53,8 @@ describe('Subtask Execution', () => {
     mockSubtasksRepo = {
       findById: vi.fn(),
       listByTask: vi.fn(),
+      listEdgesByTask: vi.fn().mockResolvedValue([]),
+      addEdges: vi.fn().mockResolvedValue(undefined),
       update: vi.fn().mockResolvedValue({}),
       updateStatus: vi.fn().mockResolvedValue({}),
       assignAgent: vi.fn().mockResolvedValue({}),
@@ -157,18 +161,19 @@ describe('Subtask Execution', () => {
       }
     });
 
-    it('throws if parent subtask not completed', async () => {
-      mockSubtasksRepo.findById
-        .mockResolvedValueOnce({
-          id: 'subtask-2',
-          parentSubtaskId: 'subtask-1',
-          status: 'pending',
-          taskId: 'task-1',
-        })
-        .mockResolvedValueOnce({
-          id: 'subtask-1',
-          status: 'in_progress',
-        });
+    it('does not execute if a dependency is not completed', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-2',
+        status: 'pending',
+        taskId: 'task-1',
+      });
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        { id: 'subtask-1', status: 'in_progress', taskId: 'task-1' },
+        { id: 'subtask-2', status: 'pending', taskId: 'task-1' },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-2', dependsOnSubtaskId: 'subtask-1' },
+      ]);
 
       const result = await taskService.executeSubtask('subtask-2');
 
@@ -178,20 +183,14 @@ describe('Subtask Execution', () => {
       }
     });
 
-    it('allows execution if parent is completed', async () => {
-      mockSubtasksRepo.findById
-        .mockResolvedValueOnce({
-          id: 'subtask-2',
-          parentSubtaskId: 'subtask-1',
-          title: 'Child Subtask',
-          description: 'Description',
-          status: 'pending',
-          taskId: 'task-1',
-        })
-        .mockResolvedValueOnce({
-          id: 'subtask-1',
-          status: 'completed',
-        });
+    it('allows execution once its dependency is completed', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-2',
+        title: 'Child Subtask',
+        description: 'Description',
+        status: 'pending',
+        taskId: 'task-1',
+      });
       mockSubtasksRepo.listByTask.mockResolvedValue([
         {
           id: 'subtask-1',
@@ -207,6 +206,9 @@ describe('Subtask Execution', () => {
           taskId: 'task-1',
         },
       ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-2', dependsOnSubtaskId: 'subtask-1' },
+      ]);
 
       const result = await taskService.executeSubtask('subtask-2');
 
@@ -214,6 +216,95 @@ describe('Subtask Execution', () => {
       if (result.ok) {
         expect(result.data.sessionId).toBe('session-1');
       }
+    });
+
+    it('does not execute until ALL of multiple dependencies are completed (regression: previously only the first dependency was tracked)', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-3',
+        title: 'Merge',
+        description: 'Combine A and B',
+        status: 'pending',
+        taskId: 'task-1',
+      });
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        {
+          id: 'subtask-1',
+          title: 'A',
+          status: 'completed',
+          result: 'Result A',
+          taskId: 'task-1',
+        },
+        { id: 'subtask-2', title: 'B', status: 'pending', taskId: 'task-1' },
+        {
+          id: 'subtask-3',
+          title: 'Merge',
+          status: 'pending',
+          taskId: 'task-1',
+        },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-1' },
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-2' },
+      ]);
+
+      const result = await taskService.executeSubtask('subtask-3');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('subtask.dependency_not_met');
+      }
+    });
+
+    it("includes only its actual dependencies' results in the handoff, bounded and excluding unrelated completed subtasks", async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-3',
+        title: 'Merge',
+        description: 'Combine A and B',
+        status: 'pending',
+        taskId: 'task-1',
+      });
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        {
+          id: 'subtask-1',
+          title: 'A',
+          status: 'completed',
+          result: 'Result A',
+          taskId: 'task-1',
+        },
+        {
+          id: 'subtask-2',
+          title: 'B',
+          status: 'completed',
+          result: 'Result B',
+          taskId: 'task-1',
+        },
+        {
+          id: 'subtask-unrelated',
+          title: 'Unrelated',
+          status: 'completed',
+          result: 'Should not appear',
+          taskId: 'task-1',
+        },
+        {
+          id: 'subtask-3',
+          title: 'Merge',
+          status: 'pending',
+          taskId: 'task-1',
+        },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-1' },
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-2' },
+      ]);
+
+      const result = await taskService.executeSubtask('subtask-3');
+
+      expect(result.ok).toBe(true);
+      const [messageInput] =
+        mockSessionService.submitMessageStreaming.mock.calls[0]!;
+      expect(messageInput.content).toContain('Result A');
+      expect(messageInput.content).toContain('Result B');
+      expect(messageInput.content).not.toContain('Should not appear');
     });
   });
 
@@ -274,11 +365,13 @@ describe('Subtask Execution', () => {
         {
           id: 'subtask-2',
           status: 'pending',
-          parentSubtaskId: 'subtask-1',
           title: 'Subtask 2',
           description: 'Desc 2',
           taskId: 'task-1',
         },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-2', dependsOnSubtaskId: 'subtask-1' },
       ]);
       // Mock findById for executeSubtask call
       mockSubtasksRepo.findById.mockResolvedValue({
@@ -294,6 +387,53 @@ describe('Subtask Execution', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         // Only subtask-1 has no dependencies
+        expect(result.data.startedCount).toBe(1);
+      }
+    });
+
+    it('does not execute a subtask until ALL of its multiple dependencies are completed (regression)', async () => {
+      mockTasksRepo.findById.mockResolvedValue({ id: 'task-1' });
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        {
+          id: 'subtask-1',
+          status: 'completed',
+          title: 'A',
+          description: 'Desc A',
+          result: 'Result A',
+          taskId: 'task-1',
+        },
+        {
+          id: 'subtask-2',
+          status: 'pending',
+          title: 'B',
+          description: 'Desc B',
+          taskId: 'task-1',
+        },
+        {
+          id: 'subtask-3',
+          status: 'pending',
+          title: 'Merge',
+          description: 'Desc Merge',
+          taskId: 'task-1',
+        },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-1' },
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-2' },
+      ]);
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-2',
+        status: 'pending',
+        title: 'B',
+        description: 'Desc B',
+        taskId: 'task-1',
+      });
+
+      const result = await taskService.executeSubtasks('task-1');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Only subtask-2 is executable; subtask-3 still waits on subtask-2.
         expect(result.data.startedCount).toBe(1);
       }
     });
@@ -460,10 +600,15 @@ describe('Subtask Execution', () => {
       mockSubtasksRepo.listByTask.mockResolvedValue([
         { id: 'subtask-1', status: 'pending' },
         { id: 'subtask-2', status: 'in_progress' },
-        { id: 'subtask-3', status: 'pending', parentSubtaskId: 'subtask-1' },
-        { id: 'subtask-4', status: 'pending', parentSubtaskId: 'subtask-2' },
-        { id: 'subtask-5', status: 'pending', parentSubtaskId: 'subtask-6' },
+        { id: 'subtask-3', status: 'pending' },
+        { id: 'subtask-4', status: 'pending' },
+        { id: 'subtask-5', status: 'pending' },
         { id: 'subtask-6', status: 'completed' },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-1' },
+        { subtaskId: 'subtask-4', dependsOnSubtaskId: 'subtask-2' },
+        { subtaskId: 'subtask-5', dependsOnSubtaskId: 'subtask-6' },
       ]);
 
       const result = await taskService.getNextExecutableSubtasks('task-1');
@@ -482,15 +627,44 @@ describe('Subtask Execution', () => {
       mockSubtasksRepo.listByTask.mockResolvedValue([
         { id: 'subtask-1', status: 'completed' },
         { id: 'subtask-2', status: 'in_progress' },
+        { id: 'subtask-3', status: 'pending' },
+        { id: 'subtask-4', status: 'pending' },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
         // subtask-3 depends on subtask-2 which is in_progress (not completed)
-        { id: 'subtask-3', status: 'pending', parentSubtaskId: 'subtask-2' },
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-2' },
         // subtask-4 depends on subtask-5 which doesn't exist
-        { id: 'subtask-4', status: 'pending', parentSubtaskId: 'subtask-5' },
+        { subtaskId: 'subtask-4', dependsOnSubtaskId: 'subtask-5' },
       ]);
 
       const result = await taskService.getNextExecutableSubtasks('task-1');
 
       expect(result).toHaveLength(0);
+    });
+
+    it('requires ALL dependencies to complete when a subtask has multiple (regression: previously only the first dependency was tracked)', async () => {
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        { id: 'subtask-1', status: 'completed' },
+        { id: 'subtask-2', status: 'pending' },
+        { id: 'subtask-3', status: 'pending' },
+      ]);
+      mockSubtasksRepo.listEdgesByTask.mockResolvedValue([
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-1' },
+        { subtaskId: 'subtask-3', dependsOnSubtaskId: 'subtask-2' },
+      ]);
+
+      let result = await taskService.getNextExecutableSubtasks('task-1');
+      expect(result.map((s) => s.id)).not.toContain('subtask-3');
+
+      // subtask-2 completes too — subtask-3 should now be executable.
+      mockSubtasksRepo.listByTask.mockResolvedValue([
+        { id: 'subtask-1', status: 'completed' },
+        { id: 'subtask-2', status: 'completed' },
+        { id: 'subtask-3', status: 'pending' },
+      ]);
+
+      result = await taskService.getNextExecutableSubtasks('task-1');
+      expect(result.map((s) => s.id)).toContain('subtask-3');
     });
 
     it('returns all pending subtasks when none have dependencies', async () => {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -132,7 +132,8 @@ export type UpdateTaskInput = {
 
 export type CreateSubtaskInput = {
   taskId: string;
-  parentSubtaskId?: string;
+  /** Subtask IDs this subtask depends on; it won't start until all of them complete. */
+  dependsOn?: string[];
   title: string;
   description: string;
   orderIndex?: number;

--- a/apps/web/src/lib/api-tasks.ts
+++ b/apps/web/src/lib/api-tasks.ts
@@ -97,7 +97,8 @@ export type SubtaskStatus =
 export type Subtask = {
   id: string;
   taskId: string;
-  parentSubtaskId: string | null;
+  /** IDs of subtasks this one depends on; it won't start until all of them complete. */
+  dependsOnSubtaskIds: string[];
   title: string;
   description: string;
   status: SubtaskStatus;
@@ -166,7 +167,8 @@ export type UpdateTaskInput = {
  */
 export type CreateSubtaskInput = {
   taskId: string;
-  parentSubtaskId?: string;
+  /** IDs of subtasks this one depends on; it won't start until all of them complete. */
+  dependsOn?: string[];
   title: string;
   description: string;
   orderIndex?: number;

--- a/packages/cli/src/commands/tasks/subtasks/list.ts
+++ b/packages/cli/src/commands/tasks/subtasks/list.ts
@@ -83,6 +83,7 @@ Exit Codes:
         title: string;
         status: import('@openaidy/shared-types').SubtaskStatus;
         assignedAgentId: string | null;
+        dependsOnSubtaskIds: string[];
         result: string | null;
         retryCount: number;
         createdAt: string;

--- a/packages/db/drizzle/0015_subtask_edges.sql
+++ b/packages/db/drizzle/0015_subtask_edges.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- Migration: 0015_subtask_edges
+-- Description: Model subtask dependencies as a graph of edges
+--              instead of a single parent_subtask_id column, so a
+--              subtask can depend on multiple upstream subtasks
+--              (fan-in). Backfills existing single-parent chains
+--              into edges before dropping the old column.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS subtask_edges (
+  id                    TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  subtask_id            TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+  depends_on_subtask_id TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+  edge_kind             TEXT NOT NULL DEFAULT 'dependency',
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT subtask_edges_no_self_edge CHECK (subtask_id <> depends_on_subtask_id)
+);
+
+CREATE INDEX IF NOT EXISTS subtask_edges_subtask_id_idx ON subtask_edges(subtask_id);
+CREATE UNIQUE INDEX IF NOT EXISTS subtask_edges_unique_idx ON subtask_edges(subtask_id, depends_on_subtask_id);
+
+INSERT INTO subtask_edges (subtask_id, depends_on_subtask_id, edge_kind)
+SELECT id, parent_subtask_id, 'dependency'
+FROM subtasks
+WHERE parent_subtask_id IS NOT NULL AND parent_subtask_id <> id
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE subtasks DROP COLUMN IF EXISTS parent_subtask_id;

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -221,7 +221,6 @@ function initializeSqliteSchema(sqlite: InstanceType<typeof Database>) {
     CREATE TABLE IF NOT EXISTS subtasks (
       id TEXT PRIMARY KEY NOT NULL,
       task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-      parent_subtask_id TEXT REFERENCES subtasks(id) ON DELETE SET NULL,
       title TEXT NOT NULL,
       description TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'pending',
@@ -236,6 +235,22 @@ function initializeSqliteSchema(sqlite: InstanceType<typeof Database>) {
     );
 
     CREATE INDEX IF NOT EXISTS subtasks_session_id_idx ON subtasks(session_id);
+
+    -- Subtask dependency graph: a row means subtask_id depends on
+    -- depends_on_subtask_id and cannot start until it completes.
+    -- Replaces the old single parent_subtask_id column so a subtask
+    -- can depend on multiple upstream subtasks (fan-in).
+    CREATE TABLE IF NOT EXISTS subtask_edges (
+      id TEXT PRIMARY KEY NOT NULL,
+      subtask_id TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+      depends_on_subtask_id TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+      edge_kind TEXT NOT NULL DEFAULT 'dependency',
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CHECK (subtask_id <> depends_on_subtask_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS subtask_edges_subtask_id_idx ON subtask_edges(subtask_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS subtask_edges_unique_idx ON subtask_edges(subtask_id, depends_on_subtask_id);
 
     CREATE INDEX IF NOT EXISTS tasks_session_id_idx ON tasks(session_id);
 
@@ -671,6 +686,37 @@ function runSqliteMigrations(sqlite: InstanceType<typeof Database>) {
   if (!hasFavoritedAt) {
     sqlite.exec(`ALTER TABLE sessions ADD COLUMN favorited_at TEXT`);
   }
+
+  // Migration: Create subtask_edges table if not exists (subtask
+  // dependency graph, replaces the old single parent_subtask_id column)
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS subtask_edges (
+      id TEXT PRIMARY KEY NOT NULL,
+      subtask_id TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+      depends_on_subtask_id TEXT NOT NULL REFERENCES subtasks(id) ON DELETE CASCADE,
+      edge_kind TEXT NOT NULL DEFAULT 'dependency',
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CHECK (subtask_id <> depends_on_subtask_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS subtask_edges_subtask_id_idx ON subtask_edges(subtask_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS subtask_edges_unique_idx ON subtask_edges(subtask_id, depends_on_subtask_id);
+  `);
+
+  // Migration: Backfill existing parent_subtask_id chains into
+  // subtask_edges, on databases that still carry the old column. The
+  // column itself is left in place (unused) rather than dropped.
+  const hasParentSubtaskId = tableInfo.some(
+    (col) => col.name === 'parent_subtask_id',
+  );
+  if (hasParentSubtaskId) {
+    sqlite.exec(`
+      INSERT OR IGNORE INTO subtask_edges (id, subtask_id, depends_on_subtask_id, edge_kind)
+      SELECT lower(hex(randomblob(16))), id, parent_subtask_id, 'dependency'
+      FROM subtasks
+      WHERE parent_subtask_id IS NOT NULL AND parent_subtask_id <> id;
+    `);
+  }
 }
 
 export async function createDatabaseClient(
@@ -731,6 +777,10 @@ export async function createDatabaseClient(
     resolve(drizzleDir, '0014_session_favorites.sql'),
     'utf-8',
   );
+  const subtaskEdgesMigrationSql = readFileSync(
+    resolve(drizzleDir, '0015_subtask_edges.sql'),
+    'utf-8',
+  );
   const client = await pool.connect();
   try {
     await client.query(migrationSql);
@@ -738,6 +788,7 @@ export async function createDatabaseClient(
     await client.query(messageAttachmentsMigrationSql);
     await client.query(sessionRunsUsageMigrationSql);
     await client.query(sessionFavoritesMigrationSql);
+    await client.query(subtaskEdgesMigrationSql);
   } finally {
     client.release();
   }

--- a/packages/db/src/repositories/subtasks.ts
+++ b/packages/db/src/repositories/subtasks.ts
@@ -18,7 +18,6 @@ export class SubtasksRepository {
    */
   async create(input: {
     taskId: string;
-    parentSubtaskId?: string;
     title: string;
     description: string;
     orderIndex?: number;
@@ -30,7 +29,6 @@ export class SubtasksRepository {
       .values({
         id: nanoid(),
         taskId: input.taskId,
-        parentSubtaskId: input.parentSubtaskId ?? null,
         title: input.title,
         description: input.description,
         status: 'pending',
@@ -66,6 +64,52 @@ export class SubtasksRepository {
       .from(schema.subtasks)
       .where(eq(schema.subtasks.taskId, taskId))
       .orderBy(asc(schema.subtasks.orderIndex));
+  }
+
+  /**
+   * Add dependency edges for a subtask: `subtaskId` depends on each of
+   * `dependsOnSubtaskIds` and cannot start until they all complete.
+   * Self-edges (a subtask depending on itself) are dropped rather than
+   * inserted — they would deadlock the subtask forever. Also enforced
+   * at the DB level via a CHECK constraint as defense in depth.
+   */
+  async addEdges(
+    subtaskId: string,
+    dependsOnSubtaskIds: string[],
+  ): Promise<void> {
+    const filtered = dependsOnSubtaskIds.filter((id) => id !== subtaskId);
+    if (filtered.length === 0) return;
+    const now = new Date();
+    await this.db.insert(schema.subtaskEdges).values(
+      filtered.map((dependsOnSubtaskId) => ({
+        id: nanoid(),
+        subtaskId,
+        dependsOnSubtaskId,
+        edgeKind: 'dependency',
+        createdAt: now,
+      })),
+    );
+  }
+
+  /**
+   * List all dependency edges for every subtask in a task, in one
+   * query (joined through `subtasks` on `subtaskId` since edges don't
+   * store `taskId` directly).
+   */
+  async listEdgesByTask(
+    taskId: string,
+  ): Promise<{ subtaskId: string; dependsOnSubtaskId: string }[]> {
+    return this.db
+      .select({
+        subtaskId: schema.subtaskEdges.subtaskId,
+        dependsOnSubtaskId: schema.subtaskEdges.dependsOnSubtaskId,
+      })
+      .from(schema.subtaskEdges)
+      .innerJoin(
+        schema.subtasks,
+        eq(schema.subtaskEdges.subtaskId, schema.subtasks.id),
+      )
+      .where(eq(schema.subtasks.taskId, taskId));
   }
 
   /**

--- a/packages/db/src/schema/tasks.test.ts
+++ b/packages/db/src/schema/tasks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   tasks,
   subtasks,
+  subtaskEdges,
   taskAgents,
   taskStatusEnum,
   taskPriorityEnum,
@@ -83,7 +84,6 @@ describe('Tasks Schema', () => {
       const columns = Object.keys(subtasks);
       expect(columns).toContain('id');
       expect(columns).toContain('taskId');
-      expect(columns).toContain('parentSubtaskId');
       expect(columns).toContain('title');
       expect(columns).toContain('description');
       expect(columns).toContain('status');
@@ -92,6 +92,17 @@ describe('Tasks Schema', () => {
       expect(columns).toContain('result');
       expect(columns).toContain('createdAt');
       expect(columns).toContain('updatedAt');
+    });
+  });
+
+  describe('subtaskEdges table', () => {
+    it('should have required columns for a dependency graph', () => {
+      const columns = Object.keys(subtaskEdges);
+      expect(columns).toContain('id');
+      expect(columns).toContain('subtaskId');
+      expect(columns).toContain('dependsOnSubtaskId');
+      expect(columns).toContain('edgeKind');
+      expect(columns).toContain('createdAt');
     });
   });
 

--- a/packages/db/src/schema/tasks.ts
+++ b/packages/db/src/schema/tasks.ts
@@ -7,7 +7,10 @@ import {
   pgEnum,
   primaryKey,
   index,
+  uniqueIndex,
+  check,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { sessions } from './sessions';
 
@@ -106,7 +109,9 @@ export const subtaskStatusEnum = pgEnum('subtask_status', [
  * Subtasks table
  *
  * Subtasks are created by the planning agent or manually.
- * Supports nested subtasks via parentSubtaskId.
+ * Dependencies between subtasks are modeled as a graph via the
+ * `subtaskEdges` table below, not as a column on this table — a
+ * subtask can depend on multiple upstream subtasks.
  */
 export const subtasks = pgTable(
   'subtasks',
@@ -117,7 +122,6 @@ export const subtasks = pgTable(
     taskId: text('task_id')
       .notNull()
       .references(() => tasks.id, { onDelete: 'cascade' }),
-    parentSubtaskId: text('parent_subtask_id').notNull(),
     title: text('title').notNull(),
     description: text('description').notNull(),
     status: subtaskStatusEnum('status').notNull().default('pending'),
@@ -139,6 +143,50 @@ export const subtasks = pgTable(
   },
   (table) => ({
     sessionIdIdx: index('subtasks_session_id_idx').on(table.sessionId),
+  }),
+);
+
+/**
+ * Subtask edges table
+ *
+ * Models subtask dependencies as a graph: a row means `subtaskId`
+ * depends on `dependsOnSubtaskId` and cannot start until it completes.
+ * A subtask may have multiple incoming edges (fan-in). `edgeKind`
+ * defaults to `'dependency'` and exists so future edge types (e.g. a
+ * loop-back edge for a visual workflow builder) can be added without
+ * another schema migration.
+ */
+export const subtaskEdges = pgTable(
+  'subtask_edges',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => nanoid()),
+    subtaskId: text('subtask_id')
+      .notNull()
+      .references(() => subtasks.id, { onDelete: 'cascade' }),
+    dependsOnSubtaskId: text('depends_on_subtask_id')
+      .notNull()
+      .references(() => subtasks.id, { onDelete: 'cascade' }),
+    edgeKind: text('edge_kind').notNull().default('dependency'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    subtaskIdIdx: index('subtask_edges_subtask_id_idx').on(table.subtaskId),
+    uniqueEdgeIdx: uniqueIndex('subtask_edges_unique_idx').on(
+      table.subtaskId,
+      table.dependsOnSubtaskId,
+    ),
+    // A subtask can never depend on itself — that would deadlock it
+    // forever. Cycles across multiple edges (A -> B -> A) are not
+    // caught here; they're guarded against at the application layer
+    // where the full graph is available.
+    noSelfEdge: check(
+      'subtask_edges_no_self_edge',
+      sql`${table.subtaskId} <> ${table.dependsOnSubtaskId}`,
+    ),
   }),
 );
 
@@ -182,6 +230,8 @@ export type Task = typeof tasks.$inferSelect;
 export type NewTask = typeof tasks.$inferInsert;
 export type Subtask = typeof subtasks.$inferSelect;
 export type NewSubtask = typeof subtasks.$inferInsert;
+export type SubtaskEdge = typeof subtaskEdges.$inferSelect;
+export type NewSubtaskEdge = typeof subtaskEdges.$inferInsert;
 export type TaskAgent = typeof taskAgents.$inferSelect;
 export type NewTaskAgent = typeof taskAgents.$inferInsert;
 export type TaskSchedule = typeof taskSchedules.$inferSelect;

--- a/packages/shared-types/src/tasks.ts
+++ b/packages/shared-types/src/tasks.ts
@@ -141,6 +141,8 @@ export type SubtaskWithDetails = {
   description: string;
   status: SubtaskStatus;
   assignedAgentId: string | null;
+  /** IDs of subtasks this one depends on; it won't start until all of them complete. */
+  dependsOnSubtaskIds: string[];
   result: string | null;
   retryCount: number;
   createdAt: string;
@@ -156,6 +158,8 @@ export type SubtaskSummary = {
   title: string;
   status: SubtaskStatus;
   assignedAgentId: string | null;
+  /** IDs of subtasks this one depends on; it won't start until all of them complete. */
+  dependsOnSubtaskIds: string[];
   result: string | null;
   retryCount: number;
   createdAt: string;


### PR DESCRIPTION
## Summary

Tasks with subtasks were sometimes dropping context between subtasks. Root cause was two compounding bugs:

- The planning agent emits a full dependency list per subtask (`dependencies: number[]`), but only `dependencies[0]` was ever kept as a single `parentSubtaskId` — every other declared dependency was silently dropped, both for gating (when a subtask is allowed to start) and for context handoff.
- The "context from completed work" handed to a subtask was built from *every* completed subtask in the whole task, not the subtask's actual dependencies — so it could start (and build its context) before a true dependency had finished, while also pulling in unrelated results.

This also sets up the dependency model as a proper graph (edges table) rather than a single-parent tree, which is the right foundation for a planned future feature: a visual workflow builder where subtasks are nodes connected by user-drawn edges (fan-in/fan-out, loops, human-in-the-loop pauses).

## Breaking change

`POST /tasks/:id/subtasks` now takes `dependsOn?: string[]` instead of `parentSubtaskId?: string`. Checked all in-repo consumers:
- Web app (`apps/web/src/lib/api-tasks.ts`) types updated to match; the subtask-creation call site never actually sent `parentSubtaskId` in the first place (no UI flow constructs it), so there's no functional behavior change there, just corrected types.
- CLI (`packages/cli`) only reads the list response, doesn't construct create-subtask requests with the old field.
- No other in-repo HTTP clients send this field. External consumers calling `POST /tasks/:id/subtasks` with `parentSubtaskId` directly would need to switch to `dependsOn`.

## Changes

- Replaced `subtasks.parent_subtask_id` with a `subtask_edges` table (`subtaskId` depends on `dependsOnSubtaskId`), with a migration that backfills existing single-parent chains. Includes an `edgeKind` column (defaults to `'dependency'`) so future edge types (loop-back, conditional) don't require another migration. A CHECK constraint (Postgres + SQLite) plus an app-side filter in `addEdges()` reject self-edges, since a subtask depending on itself would deadlock forever.
- Planning now writes *all* declared dependencies as edges instead of just the first.
- Execution gates a subtask on **all** of its incoming edges completing (previously duplicated single-parent logic in `task-execution.ts` and `subtask-operations.ts` is now a single shared helper in `subtask-graph.ts`). `executeSubtasks()` now takes one snapshot of subtasks/edges per batch and reuses it across the individual `executeSubtask()` calls instead of each one re-fetching the same data.
- The handoff message is now scoped to a subtask's actual dependencies only, and bounded with per-item/total character caps (`context-budget.ts`, reusing the truncation pattern already used for subtask verification) so a large upstream result can't unboundedly grow the next subtask's context window. Fixed an accounting bug where the truncation marker itself wasn't counted against the budget.
- Strengthened the `[SUBTASK_REMINDER]` prompt so the agent knows its final message is the only thing downstream subtasks will ever see, and must restate concrete facts/ids/urls/paths.
- Exposed `dependsOnSubtaskIds` over the subtasks API and shared-types.
- Fixed a pre-existing schema/type mismatch (`parentSubtaskId` was typed `.notNull()` while the real migration and repo code always treated it as nullable) — moot now since the column is gone.

## Known follow-up (not blocking this PR)

- `subtask_edges` prevents self-edges (A→A) but not longer cycles (A→B→A), which would silently deadlock a subtask forever. No current call path constructs a cycle — the planning service builds a DAG from a linear plan, and manual subtask creation via the API can only reference already-existing subtasks — but there's no explicit cycle check yet. Worth adding a DFS check at edge-insertion time before the visual workflow builder (which will let users draw arbitrary edges) ships.

## Test plan

- CI: Typecheck & build, Lint & format, Test, Cloudflare Pages all green.
- Added regression coverage: a subtask with 2+ dependencies does not start until all complete; the handoff context includes only real dependencies (not unrelated completed subtasks); handoff text is truncated per-item and in total, with the truncation marker itself counted against the budget.
- Manual: create a task with a subtask depending on 2 others (via planning or `POST /tasks/:id/subtasks` with `dependsOn`), run it, confirm it only starts once both complete and its opening message contains both results.
