### PR TITLE
fix(installer): resolve ripgrep fallback 404 by embedding release version

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -171,7 +171,15 @@ function Install-Ripgrep {
     # drop rg.exe into $InstallDir\bin. No package manager required.
     $arch = $env:PROCESSOR_ARCHITECTURE
     $rgArch = if ($arch -eq "ARM64") { "aarch64-pc-windows-msvc" } else { "x86_64-pc-windows-msvc" }
-    $url = "https://github.com/BurntSushi/ripgrep/releases/latest/download/ripgrep-$rgArch.zip"
+    try {
+        $tag = Invoke-RestMethod -Uri "https://api.github.com/repos/BurntSushi/ripgrep/releases/latest" -Headers @{ "User-Agent" = "OpenAidy/1.0" } -TimeoutSec 30
+        $version = $tag.tag_name
+        if (-not $version) { throw "tag_name missing from API response" }
+    } catch {
+        Log-Error "Could not determine the latest ripgrep version from the GitHub API: $_"
+        return $false
+    }
+    $url = "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-$rgArch.zip"
     $zipPath = New-TempFile
     $binDir = Join-Path $InstallDir "bin"
     $rgExe = Join-Path $binDir "rg.exe"

--- a/install.sh
+++ b/install.sh
@@ -282,7 +282,15 @@ install_ripgrep() {
         aarch64|arm64) arch="aarch64-unknown-linux-musl" ;;
         *)             log_error "Unsupported architecture for ripgrep fallback: $(uname -m)"; return 1 ;;
     esac
-    local url="https://github.com/BurntSushi/ripgrep/releases/latest/download/ripgrep-${arch}.tar.gz"
+    local version
+    if ! version=$(curl -fsSL --retry 3 --retry-connrefused \
+            "https://api.github.com/repos/BurntSushi/ripgrep/releases/latest" \
+            | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+            | head -1) || [ -z "$version" ]; then
+        log_error "Could not determine the latest ripgrep version from the GitHub API"
+        return 1
+    fi
+    local url="https://github.com/BurntSushi/ripgrep/releases/download/${version}/ripgrep-${version}-${arch}.tar.gz"
     local tmp_dir
     tmp_dir=$(mktemp -d)
     log_info "Downloading ripgrep static binary..."


### PR DESCRIPTION
## Summary

- `install.sh` and `install.ps1` both fell back to a versionless ripgrep asset URL on the GitHub releases latest endpoint. ripgrep only ships versioned asset names (e.g. `ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz`), so the versionless URL resolves to a 404 and the installer aborts with `Failed to install ripgrep` even when the binary is reachable.
- Resolve the latest tag via the GitHub Releases API (`/repos/BurntSushi/ripgrep/releases/latest`), then build the asset URL with that version embedded. Unauthenticated, one GET per install, no hardcoded version to bit-rot.
- Affects both the Linux/macOS shell installer and the Windows PowerShell installer.

## Reproduction

Before the fix, on any Linux box without a system `rg`:

```
$ curl -fsSL https://openaidy.com/install.sh | bash
...
[openaidy] Downloading ripgrep static binary...
curl: (22) The requested URL returned error: 404
[openaidy] ✗ Failed to install ripgrep
```

Direct probe against the buggy URL:

```
$ curl -sIL -o /dev/null -w %{http_code}\n \
    https://github.com/BurntSushi/ripgrep/releases/latest/download/ripgrep-x86_64-unknown-linux-musl.tar.gz
404
```

After the fix, the resolved URL returns 200 and the binary installs cleanly.

## Changes

| File | Change |
|------|--------|
| `install.sh` | In `install_ripgrep`, query `api.github.com/.../releases/latest`, parse `tag_name`, and build the asset URL with the version embedded. |
| `install.ps1` | In `Install-Ripgrep`, use `Invoke-RestMethod` against the same API endpoint to fetch `tag_name`, then build the asset URL with the version embedded. |

## Test Plan

- [x] Both scripts parse cleanly (`bash -n install.sh`, `[Parser]::ParseFile(install.ps1)`).
- [x] Resolved asset URLs return 200 against the live GitHub release:
  - `https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz` -> 200
  - `https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-pc-windows-msvc.zip` -> 200
- [ ] Manual install on a fresh Linux VM (out of scope here; relies on a CI agent).

## Workaround

While this is unreleased, Linux Mint / Ubuntu users can `sudo apt install ripgrep` before running the installer; macOS users with Homebrew get `rg` automatically from the existing branch.