### PR TITLE
chore(release): bump version to 0.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump version to `0.3.12`. No code changes — only the root `package.json` version field. Follows the same pattern as the previous `0.3.11` release.

## Changes since `v0.3.11`

- feat(mcp): add Buffer to preinstalled MCP servers (#492)
- fix(providers): repair tool-call/tool-result adjacency before invocation (#491)
- feat(agents): give agents context on the installed addons (#490)
- feat(skills): auto-activate newly created skills on the creating agent (#489)
- chore: remove accidental `=` file at repo root (#488)

## Out of scope for this release

Open PRs not yet merged into `main` (will ship in a later release if they're merged first):

- #493 fix(tasks): model subtask dependencies as a graph, fix context handoff
- #494 fix(installer): resolve ripgrep fallback 404 by embedding release version

## Post-merge

After the merge commit lands on `main`, tag the merge commit as `v0.3.12` to match the existing tag scheme.