### PR TITLE
fix(installer): provision git as a prerequisite; bump baileys off its git-URL dep

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,7 +24,7 @@
     "@openaidy/providers": "workspace:*",
     "@openaidy/runtime": "workspace:*",
     "@openaidy/shared-types": "workspace:*",
-    "@whiskeysockets/baileys": "7.0.0-rc10",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "adm-zip": "^0.6.0",
     "archiver": "^8.0.0",
     "croner": "^10.0.1",

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,8 @@
 # OpenAidy Installer for Windows
 # ============================================================================
 # Installs OpenAidy from the prebuilt npm package (@openaidy/app). No git
-# clone, no source build — just Node + ripgrep, then `npm install -g`.
+# clone, no source build — just Node + ripgrep + uv + git, then `npm install
+# -g`.
 #
 # Usage:
 #   iex (irm https://openaidy.com/install.ps1)
@@ -310,6 +311,81 @@ function Test-Uv {
 }
 
 # ============================================================================
+# git provisioning
+# ============================================================================
+# Defense-in-depth prerequisite. npm's @npmcli/git module spawns `git` to
+# resolve git+https / github: dependencies some packages still use (e.g.
+# historical @whiskeysockets/baileys releases pinned libsignal to
+# git+https://github.com/whiskeysockets/libsignal-node.git, which broke npm
+# install on bare boxes without git). Even after bumping such deps to registry
+# releases, a future transitive dep could reintroduce the same requirement —
+# so the installer provisions git instead of asking the user to.
+#
+# Scope: the git binary only. No git repo is cloned, no source is fetched —
+# this matches the installer's "prebuilt package" model.
+
+function Install-Git {
+    Log-Info "Installing git..."
+
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if ($winget) {
+        Log-Info "Installing git via winget..."
+        winget install --id Git.Git -e --silent --accept-package-agreements --accept-source-agreements 2>$null
+        if (Get-Command git -ErrorAction SilentlyContinue) {
+            Log-Success "git installed via winget"
+            return $true
+        }
+    }
+
+    $choco = Get-Command choco -ErrorAction SilentlyContinue
+    if ($choco) {
+        Log-Info "Installing git via Chocolatey..."
+        choco install git -y --no-progress 2>$null
+        if (Get-Command git -ErrorAction SilentlyContinue) {
+            Log-Success "git installed via Chocolatey"
+            return $true
+        }
+    }
+
+    $scoop = Get-Command scoop -ErrorAction SilentlyContinue
+    if ($scoop) {
+        Log-Info "Installing git via Scoop..."
+        scoop install git 2>$null
+        if (Get-Command git -ErrorAction SilentlyContinue) {
+            Log-Success "git installed via Scoop"
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-Git {
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        try {
+            $v = (& git --version) 2>$null
+            if ($v) {
+                Log-Success "git found"
+                return $true
+            }
+        } catch { }
+    }
+
+    Log-Warn "git not found — required by npm for any git-URL dependency"
+    if (-not (Install-Git)) {
+        Log-Error "git could not be installed automatically."
+        Log-Info "Install 'Git for Windows' from https://git-scm.com/download/win, or via your package manager:"
+        Log-Info "  winget install --id Git.Git -e --silent --accept-package-agreements --accept-source-agreements"
+        Log-Info "  choco install git -y"
+        Log-Info "  scoop install git"
+        Log-Info "Then re-run this installer."
+        return $false
+    }
+    Log-Success "git installed"
+    return $true
+}
+
+# ============================================================================
 # OpenAidy CLI (prebuilt npm package)
 # ============================================================================
 
@@ -454,6 +530,13 @@ if (-not (Test-Ripgrep)) {
 # uv / uvx + Python MCP server environments (non-fatal: only Python-based MCP
 # servers depend on it, the server itself boots fine without it).
 Test-Uv
+
+# git (defense-in-depth: npm needs git on PATH if any transitive dep uses a
+# git URL). Fail-loud if we can't install it — a soft-skip here would leave
+# the user with a half-installed setup that breaks on the very next step.
+if (-not (Test-Git)) {
+    exit 1
+}
 
 # OpenAidy CLI (prebuilt package)
 Install-OpenAidy

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@
 # OpenAidy Installer
 # ============================================================================
 # Installs OpenAidy on Linux, macOS, and WSL2 from the prebuilt npm package
-# (@openaidy/app). No git clone, no source build — just Node + ripgrep, then
-# `npm install -g @openaidy/app`.
+# (@openaidy/app). No git clone, no source build — just Node + ripgrep + uv +
+# git, then `npm install -g @openaidy/app`.
 #
 # Usage:
 #   curl -fsSL https://openaidy.com/install.sh | bash
@@ -389,6 +389,95 @@ check_uv() {
 }
 
 # ============================================================================
+# git Provisioning
+# ============================================================================
+# Required as a defense-in-depth prerequisite. npm's @npmcli/git module spawns
+# `git` to resolve git+https / github: dependencies that some packages still
+# use (e.g. historical @whiskeysockets/baileys releases pinned libsignal to
+# git+https://github.com/whiskeysockets/libsignal-node.git, which broke npm
+# install on bare boxes without git). Even after bumping such deps to registry
+# releases, a future transitive dep could reintroduce the same requirement —
+# so the installer provisions git instead of asking the user to.
+#
+# Scope: the git binary only. No git repo is cloned, no source is fetched —
+# this matches the installer's "prebuilt package" model.
+# ============================================================================
+
+install_git() {
+    log_info "Installing git..."
+
+    case "$OS" in
+        macos)
+            if command -v brew >/dev/null 2>&1; then
+                log_info "Installing git via Homebrew..."
+                brew install git >/dev/null 2>&1 || true
+                command -v git >/dev/null 2>&1 && return 0
+            fi
+            log_warn "Could not install git via Homebrew"
+            ;;
+        linux|linux-wsl)
+            local sudo_cmd=""
+            if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
+                command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
+            fi
+            case "$DISTRO" in
+                ubuntu|debian)
+                    log_info "Installing git via apt..."
+                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git >/dev/null 2>&1 || true
+                    ;;
+                fedora)
+                    log_info "Installing git via dnf..."
+                    $sudo_cmd dnf install -y git >/dev/null 2>&1 || true
+                    ;;
+                arch)
+                    log_info "Installing git via pacman..."
+                    $sudo_cmd pacman -S --noconfirm git >/dev/null 2>&1 || true
+                    ;;
+            esac
+            command -v git >/dev/null 2>&1 && return 0
+            log_warn "Could not install git via system package manager"
+            ;;
+    esac
+
+    return 1
+}
+
+check_git() {
+    log_info "Checking git..."
+
+    if command -v git >/dev/null 2>&1; then
+        local ver
+        ver=$(git --version 2>/dev/null | awk '{print $3}')
+        log_success "git ${ver:-} found"
+        return 0
+    fi
+
+    log_warn "git not found — required by npm for any git-URL dependency"
+    if install_git; then
+        local ver
+        ver=$(git --version 2>/dev/null | awk '{print $3}')
+        log_success "git ${ver:-} installed"
+        return 0
+    fi
+
+    log_error "git could not be installed automatically."
+    log_info "Install it manually, then re-run this installer:"
+    case "$OS" in
+        macos)       log_info "  macOS:   xcode-select --install   # or: brew install git" ;;
+        linux|linux-wsl)
+            case "$DISTRO" in
+                ubuntu|debian) log_info "  Debian/Ubuntu/Mint: sudo apt-get install -y git" ;;
+                fedora)        log_info "  Fedora:             sudo dnf install -y git" ;;
+                arch)          log_info "  Arch:               sudo pacman -S git" ;;
+                *)             log_info "  Use your distro's package manager to install the 'git' package" ;;
+            esac
+            ;;
+        *)           log_info "  Use your OS package manager to install 'git'" ;;
+    esac
+    return 1
+}
+
+# ============================================================================
 # OpenAidy CLI (prebuilt npm package)
 # ============================================================================
 
@@ -511,6 +600,7 @@ main() {
     check_node
     check_ripgrep
     check_uv
+    check_git
     install_openaidy
 
     # Ensure JWT secret + generate bootstrap-admin token (idempotent).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
       '@whiskeysockets/baileys':
-        specifier: 7.0.0-rc10
-        version: 7.0.0-rc10(sharp@0.34.5)
+        specifier: 7.0.0-rc14
+        version: 7.0.0-rc14(sharp@0.34.5)
       adm-zip:
         specifier: ^0.6.0
         version: 0.6.0
@@ -2633,13 +2633,9 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@whiskeysockets/baileys@7.0.0-rc10':
-    resolution: {integrity: sha512-tVHZRIE06HlQajHcLEsCa+gnH5z+dAXPjwHsGXDNY9/Y0iqbymQzHLvh4tMH/pi/ea/D617qCQhNkDT2B0tufg==}
+  '@whiskeysockets/baileys@7.0.0-rc14':
+    resolution: {integrity: sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ==}
     engines: {node: '>=20.0.0'}
-    deprecated: |-
-      This version is affected by a zero-day vulnerability that allows spoofing of messages, please update to
-        the latest versions (6.7.22^ or 7.0.0-rc12^)! For more information, check out the public advisory at
-        https://github.com/WhiskeySockets/Baileys/security/advisories/GHSA-qvv5-jq5g-4cgg
     peerDependencies:
       audio-decode: ^2.1.3
       jimp: ^1.6.1
@@ -3978,9 +3974,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
-    version: 6.0.0
+  libsignal@6.0.0:
+    resolution: {integrity: sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -5518,8 +5513,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  whatsapp-rust-bridge@0.5.3:
-    resolution: {integrity: sha512-Xb3GAgtWQQJ30oI4a4pjM4+YUeli9CMLTwTIewUrb+AJMFElIkiT5uo+j1Zhc+amiV0Jj+LfX76c/EEZirJbGA==}
+  whatsapp-rust-bridge@0.5.4:
+    resolution: {integrity: sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -7680,19 +7675,19 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@whiskeysockets/baileys@7.0.0-rc10(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc14(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
+      libsignal: 6.0.0
       lru-cache: 11.2.7
       music-metadata: 11.12.3
       p-queue: 9.2.0
       pino: 9.14.0
       protobufjs: 7.5.6
       sharp: 0.34.5
-      whatsapp-rust-bridge: 0.5.3
+      whatsapp-rust-bridge: 0.5.4
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -9120,7 +9115,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+  libsignal@6.0.0:
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 7.5.6
@@ -10810,7 +10805,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  whatsapp-rust-bridge@0.5.3: {}
+  whatsapp-rust-bridge@0.5.4: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Installs `git` automatically alongside Node, ripgrep, and uv, so a fresh Linux Mint / WSL / Windows box with no pre-installed system packages can install OpenAidy with one curl/iex command.

Two changes:

1. **Bump `@whiskeysockets/baileys` from `7.0.0-rc10` to `7.0.0-rc14`.** The published `@openaidy/app` package depended on `@whiskeysockets/baileys@7.0.0-rc10`, whose direct dep `libsignal: git+https://github.com/whiskeysockets/libsignal-node.git` forced npm to spawn `git` during install. On a host without git installed, `npm install -g @openaidy/app` failed with `npm error syscall spawn git ENOENT`. baileys rc11 onward switched libsignal to a registry release (`^6.0.0`), so rc14 removes the git-URL dep entirely. rc10 is also npm-deprecated for the message-spoofing zero-day tracked in advisory GHSA-qvv5-jq5g-4cgg, with the fix recommendation being `6.7.22+` or `7.0.0-rc12+`, so this bump is two-for-one: unblocks the installer AND patches the CVE.

2. **Provision git as a prerequisite in `install.sh` + `install.ps1`.** Same pattern as the existing ripgrep / uv checks: detect what's on PATH, fall back to the OS package manager (`apt` / `dnf` / `pacman` / `brew` on Unix; `winget` / `choco` / `scoop` on Windows), and fail loudly with platform-specific install hints if none of those succeed. Hard-exits on failure rather than soft-skipping — a soft skip would leave the user with a half-installed setup that crashes on the very next step. Defense-in-depth: even though rc14 doesn't need git, a future transitive dep could reintroduce the same requirement.

## Test plan

- [x] `pnpm install --frozen-lockfile` resolves cleanly; `pnpm-lock.yaml` has zero `git+` / `git@` / `github:` URLs anywhere in the dep tree (verified by grep).
- [x] `pnpm lint` — 12/12 successful.
- [x] `pnpm build` — 14/14 successful (includes typecheck).
- [x] `pnpm test` — 8/13 packages pass; the 5 failed packages are pre-existing Windows-only SQLite file-lock failures (`EBUSY: resource busy or locked, unlink '...openaidy-test-XXX.db'`), confirmed unrelated by `git stash` + re-run on the unmodified branch. Same set as the 3 noted in PR #496's test plan.
- [x] `install.sh` parses cleanly under bash syntax check (`bash -n`) and runs the `--help` branch end-to-end.
- [x] `install.ps1` parses cleanly under PowerShell's `[System.Management.Automation.Language.Parser]::ParseFile`.
- [x] `landing/public/install.sh` and `landing/public/install.ps1` are gitignored — they're dev artifacts only. The production installers come from the repo-root files served via Cloudflare Pages. Confirmed via `landing/.gitignore`.
- [ ] **Manual verification on a bare Linux Mint box** (the original failure environment) — needs a real apt-get run; not reproducible on this Windows dev host. Please test on the original box before merging.