### PR TITLE
fix(installer): detect Linux Mint and other Ubuntu/Debian derivatives via ID_LIKE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,15 +87,42 @@ detect_os() {
         fi
         if [ -f /etc/os-release ]; then
             DISTRO=$(. /etc/os-release; echo "$ID")
+            # Map the distro's ID onto the package-manager family it inherits.
+            # Enumerating every Ubuntu/Debian/RHEL/Arch derivative (Linux Mint,
+            # Pop!_OS, elementary, Zorin, Kali, Raspbian, Fedora, CentOS, RHEL,
+            # Rocky, Manjaro, Endeavour, …) is brittle — the list grows every
+            # year. /etc/os-release carries an ID_LIKE field precisely so the
+            # installer can ask "is this Debian-family?" without enumerating
+            # every derivative; fall back to ID for the well-known names and
+            # to ID_LIKE otherwise.
+            local id_like=""
+            id_like=$(. /etc/os-release; echo "$ID_LIKE")
+            case "$DISTRO" in
+                ubuntu|debian)            DISTRO_FAMILY="debian" ;;
+                fedora|centos|rhel|rocky|almalinux) DISTRO_FAMILY="rhel" ;;
+                arch)                     DISTRO_FAMILY="arch" ;;
+                *)
+                    case " $id_like " in
+                        *" ubuntu "*|*" debian "*) DISTRO_FAMILY="debian" ;;
+                        *" rhel "*|*" fedora "*)   DISTRO_FAMILY="rhel" ;;
+                        *" arch "*)               DISTRO_FAMILY="arch" ;;
+                        *)                        DISTRO_FAMILY="unknown" ;;
+                    esac
+                    ;;
+            esac
         elif [ -f /etc/redhat-release ]; then
             DISTRO="fedora"
+            DISTRO_FAMILY="rhel"
         elif [ -f /etc/debian_version ]; then
             DISTRO="debian"
+            DISTRO_FAMILY="debian"
         else
             DISTRO="unknown"
+            DISTRO_FAMILY="unknown"
         fi
     elif [ "$OS" = "macos" ]; then
         DISTRO="macos"
+        DISTRO_FAMILY="macos"
     fi
 }
 
@@ -254,12 +281,12 @@ install_ripgrep() {
             if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
                 command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
             fi
-            case "$DISTRO" in
-                ubuntu|debian)
+            case "$DISTRO_FAMILY" in
+                debian)
                     log_info "Installing ripgrep via apt..."
                     $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ripgrep >/dev/null 2>&1 || true
                     ;;
-                fedora)
+                rhel)
                     log_info "Installing ripgrep via dnf..."
                     $sudo_cmd dnf install -y ripgrep >/dev/null 2>&1 || true
                     ;;
@@ -420,12 +447,12 @@ install_git() {
             if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
                 command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
             fi
-            case "$DISTRO" in
-                ubuntu|debian)
+            case "$DISTRO_FAMILY" in
+                debian)
                     log_info "Installing git via apt..."
                     $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git >/dev/null 2>&1 || true
                     ;;
-                fedora)
+                rhel)
                     log_info "Installing git via dnf..."
                     $sudo_cmd dnf install -y git >/dev/null 2>&1 || true
                     ;;
@@ -465,11 +492,11 @@ check_git() {
     case "$OS" in
         macos)       log_info "  macOS:   xcode-select --install   # or: brew install git" ;;
         linux|linux-wsl)
-            case "$DISTRO" in
-                ubuntu|debian) log_info "  Debian/Ubuntu/Mint: sudo apt-get install -y git" ;;
-                fedora)        log_info "  Fedora:             sudo dnf install -y git" ;;
-                arch)          log_info "  Arch:               sudo pacman -S git" ;;
-                *)             log_info "  Use your distro's package manager to install the 'git' package" ;;
+            case "$DISTRO_FAMILY" in
+                debian) log_info "  Debian/Ubuntu/Mint: sudo apt-get install -y git" ;;
+                rhel)   log_info "  Fedora/RHEL/Rocky:  sudo dnf install -y git" ;;
+                arch)   log_info "  Arch/Manjaro:       sudo pacman -S git" ;;
+                *)      log_info "  Use your distro's package manager to install the 'git' package" ;;
             esac
             ;;
         *)           log_info "  Use your OS package manager to install 'git'" ;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Fixes the install failure reported after PR #497: the new `check_git` (and the existing `check_ripgrep`) routed on `$DISTRO`, which is set from `/etc/os-release`'s `ID` field — and Linux Mint's `ID` is `linuxmint`, not `ubuntu`. The `case $DISTRO in ubuntu|debian` branch never fired, so the installer fell through with the misleading "Use your distro's package manager" hint and exited 1 before npm install even ran.

Fix: derive a `DISTRO_FAMILY` (debian / rhel / arch / unknown) from `/etc/os-release` at detect_os time, preferring `ID` for the well-known names (ubuntu, debian, fedora, centos, rhel, rocky, almalinux, arch) and falling back to `ID_LIKE` for derivatives (linuxmint → ubuntu → debian; manjaro → arch; rocky → rhel; etc.). Switch the ripgrep and git case statements from `$DISTRO` to `$DISTRO_FAMILY`; the manual-install-hint case statement also uses `$DISTRO_FAMILY` so the printed hint matches what the installer actually tried to do.

`/etc/os-release` was designed for exactly this — `ID_LIKE` is the standard field for "I'm a derivative of family X" — so this works for Linux Mint today, Pop!_OS / elementary / Zorin / Kali / Raspbian tomorrow, and any new derivative distro that follows the spec, without me having to enumerate every distro by hand.

## Test plan

- [x] `bash -n install.sh` parses cleanly.
- [x] Mapped 15 distros against the new logic (linuxmint, ubuntu, debian, pop, elementary, kali, raspbian, fedora, rhel, rocky, arch, manjaro, endeavouros, alpine, unknown) — Linux Mint correctly resolves to `debian` (apt), Pop!_OS to `debian`, Manjaro to `arch`, Rocky to `rhel`. Alpine / unknown correctly resolve to `unknown` so the manual-install hint fires for truly-unsupported distros.
- [x] `install.sh --help` runs end-to-end.
- [ ] **Manual verification on a bare Linux Mint box** — needs a real `apt-get install -y git` run; the previous PR's test plan left this unchecked too. Please re-run the curl one-liner on the original failing box to confirm the apt branch now kicks in.