### PR TITLE
fix(tasks): include verification reason in subtask retry message

### DIFF
--- a/apps/server/src/tasks/execution/task-execution.ts
+++ b/apps/server/src/tasks/execution/task-execution.ts
@@ -870,10 +870,7 @@ export class TaskExecution {
       isComplete,
       verdict: rawVerdict ?? null,
       verificationSummaryLength: content.length,
-    });
-    this.logger.debug('Subtask verification raw response', {
-      subtaskId,
-      content,
+      verificationSummaryPreview: content.slice(0, 400),
     });
 
     if (isComplete) {
@@ -904,6 +901,7 @@ export class TaskExecution {
         this.logger.info('Verification says incomplete, triggering retry', {
           subtaskId,
           reasonLength: verdictReason.length,
+          reasonPreview: verdictReason.slice(0, 400),
         });
         await this.triggerSubtaskRetry(subtaskId, verdictReason);
       }

--- a/apps/server/src/tasks/execution/task-execution.ts
+++ b/apps/server/src/tasks/execution/task-execution.ts
@@ -35,6 +35,10 @@ const STUCK_TIMEOUT_MINUTES = 3;
 // can't unboundedly grow the next subtask's context window.
 const DEP_CONTEXT_PER_ITEM_CHARS = 2000;
 const DEP_CONTEXT_TOTAL_CHARS = 8000;
+// Bound on how much of a verifier's rejection reason gets echoed back into
+// the retry message, so a verbose verdict can't unboundedly grow the next
+// attempt's opening message.
+const RETRY_REASON_MAX_CHARS = 1500;
 
 export class TaskExecution {
   private readonly logger: ReturnType<typeof createLogger>;
@@ -504,6 +508,7 @@ export class TaskExecution {
 
   async triggerSubtaskRetry(
     subtaskId: string,
+    reason?: string,
   ): Promise<ServiceResult<{ sessionId: string }>> {
     if (!this.sessionService) {
       return {
@@ -542,12 +547,19 @@ export class TaskExecution {
       subtaskId,
       sessionId,
       agentId,
+      hasReason: Boolean(reason),
     });
+
+    // When a verification verdict supplied a reason, tell the agent
+    // specifically what was wrong or missing instead of the generic
+    // "try again" — without it, a retry just repeats the same mistake.
+    const content = reason
+      ? `Your previous attempt at this subtask was reviewed and marked incomplete. Here is specifically what was wrong or missing:\n\n${reason.slice(0, RETRY_REASON_MAX_CHARS)}\n\nAddress this directly, then deliver the actual output requested. Do not ask what to do — execute the task directly.`
+      : 'Please continue and complete this subtask. Focus on delivering the actual output requested. Do not ask what to do — execute the task directly.';
 
     const messageInput: SubmitMessageStreamingInput = {
       sessionId,
-      content:
-        'Please continue and complete this subtask. Focus on delivering the actual output requested. Do not ask what to do — execute the task directly.',
+      content,
       role: 'user',
       onStreamEvent: () => {},
     };
@@ -889,10 +901,17 @@ export class TaskExecution {
           verificationSessionId,
         );
       } else {
+        // Prefer the verifier's structured reason; if JSON parsing failed
+        // (or the model omitted it), fall back to its raw response text
+        // rather than telling the agent nothing about what was wrong.
+        const retryReason =
+          parsedVerdict.reason?.trim() ||
+          content.slice(0, RETRY_REASON_MAX_CHARS).trim();
         this.logger.info('Verification says incomplete, triggering retry', {
           subtaskId,
+          retryReason,
         });
-        await this.triggerSubtaskRetry(subtaskId);
+        await this.triggerSubtaskRetry(subtaskId, retryReason);
       }
     }
   }

--- a/apps/server/src/tasks/execution/task-execution.ts
+++ b/apps/server/src/tasks/execution/task-execution.ts
@@ -27,6 +27,10 @@ import {
   getDependencySubtasks,
   type SubtaskDependencyEdge,
 } from './subtask-graph';
+import {
+  parseVerificationVerdict,
+  buildRetryMessage,
+} from './verification-verdict';
 
 const MAX_RETRIES = 5;
 const STUCK_TIMEOUT_MINUTES = 3;
@@ -543,19 +547,22 @@ export class TaskExecution {
     }
 
     const agentId = (subtask as { assignedAgentId?: string }).assignedAgentId;
-    this.logger.info('Triggering retry for stuck subtask', {
-      subtaskId,
-      sessionId,
-      agentId,
-      hasReason: Boolean(reason),
-    });
+    this.logger.info(
+      reason
+        ? 'Triggering verification-driven subtask retry'
+        : 'Triggering stuck-subtask retry',
+      {
+        subtaskId,
+        sessionId,
+        agentId,
+        hasReason: Boolean(reason),
+      },
+    );
 
     // When a verification verdict supplied a reason, tell the agent
     // specifically what was wrong or missing instead of the generic
     // "try again" — without it, a retry just repeats the same mistake.
-    const content = reason
-      ? `Your previous attempt at this subtask was reviewed and marked incomplete. Here is specifically what was wrong or missing:\n\n${reason.slice(0, RETRY_REASON_MAX_CHARS)}\n\nAddress this directly, then deliver the actual output requested. Do not ask what to do — execute the task directly.`
-      : 'Please continue and complete this subtask. Focus on delivering the actual output requested. Do not ask what to do — execute the task directly.';
+    const content = buildRetryMessage(reason, RETRY_REASON_MAX_CHARS);
 
     const messageInput: SubmitMessageStreamingInput = {
       sessionId,
@@ -852,28 +859,21 @@ export class TaskExecution {
     const rawContent = (lastMsg as { content?: string })?.content ?? '';
     const content = stripThinking(rawContent);
 
-    let isComplete = false;
-    let parsedVerdict: { verdict?: string; reason?: string } = {};
-
-    try {
-      const jsonMatch = content.match(/\{[^}]+\}/);
-      if (jsonMatch) {
-        parsedVerdict = JSON.parse(jsonMatch[0]);
-        isComplete = parsedVerdict.verdict?.toUpperCase() === 'COMPLETED';
-      } else {
-        isComplete =
-          /\bCOMPLETED\b/i.test(content) && !/\bINCOMPLETE\b/i.test(content);
-      }
-    } catch (_e) {
-      isComplete =
-        /\bCOMPLETED\b/i.test(content) && !/\bINCOMPLETE\b/i.test(content);
-    }
+    const {
+      isComplete,
+      reason: verdictReason,
+      rawVerdict,
+    } = parseVerificationVerdict(content);
 
     this.logger.info('Subtask verification result received', {
       subtaskId,
       isComplete,
-      verdict: parsedVerdict,
-      verificationSummary: content,
+      verdict: rawVerdict ?? null,
+      verificationSummaryLength: content.length,
+    });
+    this.logger.debug('Subtask verification raw response', {
+      subtaskId,
+      content,
     });
 
     if (isComplete) {
@@ -893,7 +893,7 @@ export class TaskExecution {
       if (hasConcreteArtifacts(originalResult)) {
         this.logger.warn(
           'Verifier said INCOMPLETE but executor response contains concrete success artifacts; overriding to COMPLETED to avoid duplicate side effects',
-          { subtaskId, verdict: parsedVerdict },
+          { subtaskId, verdict: rawVerdict ?? null },
         );
         await this.completeSubtask(
           subtaskId,
@@ -901,17 +901,11 @@ export class TaskExecution {
           verificationSessionId,
         );
       } else {
-        // Prefer the verifier's structured reason; if JSON parsing failed
-        // (or the model omitted it), fall back to its raw response text
-        // rather than telling the agent nothing about what was wrong.
-        const retryReason =
-          parsedVerdict.reason?.trim() ||
-          content.slice(0, RETRY_REASON_MAX_CHARS).trim();
         this.logger.info('Verification says incomplete, triggering retry', {
           subtaskId,
-          retryReason,
+          reasonLength: verdictReason.length,
         });
-        await this.triggerSubtaskRetry(subtaskId, retryReason);
+        await this.triggerSubtaskRetry(subtaskId, verdictReason);
       }
     }
   }

--- a/apps/server/src/tasks/execution/verification-verdict.test.ts
+++ b/apps/server/src/tasks/execution/verification-verdict.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractJsonObject,
+  parseVerificationVerdict,
+  buildRetryMessage,
+} from './verification-verdict';
+
+describe('extractJsonObject', () => {
+  it('extracts a simple object', () => {
+    expect(extractJsonObject('noise {"a":1} noise')).toBe('{"a":1}');
+  });
+
+  it('extracts a nested object without truncating on the inner closing brace', () => {
+    const text = '{"verdict":"INCOMPLETE","reason":"missing {x} in output"}';
+    expect(extractJsonObject(text)).toBe(text);
+  });
+
+  it('does not end the match early on a brace inside a string literal', () => {
+    const text =
+      '{"verdict":"INCOMPLETE","reason":"code snippet: function f() { return 1; }"}';
+    expect(extractJsonObject(text)).toBe(text);
+  });
+
+  it('returns null when there is no opening brace', () => {
+    expect(extractJsonObject('just plain text, no json here')).toBeNull();
+  });
+
+  it('returns null when braces never balance', () => {
+    expect(extractJsonObject('{"a": 1')).toBeNull();
+  });
+});
+
+describe('parseVerificationVerdict', () => {
+  it('parses a COMPLETED verdict', () => {
+    const result = parseVerificationVerdict(
+      '{"verdict":"COMPLETED","reason":""}',
+    );
+    expect(result.isComplete).toBe(true);
+    expect(result.rawVerdict).toBe('COMPLETED');
+  });
+
+  it('parses an INCOMPLETE verdict and prefers the structured reason', () => {
+    const result = parseVerificationVerdict(
+      '{"verdict":"INCOMPLETE","reason":"the headline does not appear in the tool results"}',
+    );
+    expect(result.isComplete).toBe(false);
+    expect(result.reason).toBe(
+      'the headline does not appear in the tool results',
+    );
+  });
+
+  it('falls back to the raw content when reason is missing', () => {
+    const content = '{"verdict":"INCOMPLETE"}';
+    const result = parseVerificationVerdict(content);
+    expect(result.isComplete).toBe(false);
+    expect(result.reason).toBe(content);
+  });
+
+  it('falls back to the raw content when reason is a non-string (array) without throwing', () => {
+    const content =
+      '{"verdict":"INCOMPLETE","reason":["missing X","missing Y"]}';
+    expect(() => parseVerificationVerdict(content)).not.toThrow();
+    const result = parseVerificationVerdict(content);
+    expect(result.isComplete).toBe(false);
+    expect(result.reason).toBe(content);
+  });
+
+  it('falls back to the raw content when reason is a non-string (number) without throwing', () => {
+    const content = '{"verdict":"INCOMPLETE","reason":42}';
+    expect(() => parseVerificationVerdict(content)).not.toThrow();
+    expect(parseVerificationVerdict(content).reason).toBe(content);
+  });
+
+  it('falls back to the plain-text heuristic when JSON parsing throws', () => {
+    const content =
+      '{"verdict": invalid json here} but marked INCOMPLETE overall';
+    const result = parseVerificationVerdict(content);
+    expect(result.isComplete).toBe(false);
+    expect(result.reason).toBe(content.trim());
+    expect(result.rawVerdict).toBeUndefined();
+  });
+
+  it('falls back to the plain-text heuristic when there is no JSON at all', () => {
+    const result = parseVerificationVerdict('Looks good, marked as COMPLETED.');
+    expect(result.isComplete).toBe(true);
+  });
+
+  it('treats mixed COMPLETED/INCOMPLETE plain text as incomplete', () => {
+    const result = parseVerificationVerdict(
+      'Almost COMPLETED but actually INCOMPLETE due to a missing field.',
+    );
+    expect(result.isComplete).toBe(false);
+  });
+});
+
+describe('buildRetryMessage', () => {
+  it('returns the generic message when no reason is given', () => {
+    const message = buildRetryMessage(undefined, 1500);
+    expect(message).toBe(
+      'Please continue and complete this subtask. Focus on delivering the actual output requested. Do not ask what to do — execute the task directly.',
+    );
+  });
+
+  it('includes the reason verbatim when it is under the cap', () => {
+    const message = buildRetryMessage('missing the published URL', 1500);
+    expect(message).toContain('missing the published URL');
+    expect(message).toContain('marked incomplete');
+    expect(message).not.toContain('truncated');
+  });
+
+  // Extracts the reason text the template embeds between its fixed
+  // preamble and closing sentence, so counting stray 'x' characters that
+  // happen to appear in the surrounding fixed wording (e.g. "execute")
+  // can't produce a false pass.
+  function extractEmbeddedReason(message: string): string {
+    const match = message.match(
+      /missing:\n\n([\s\S]*?)\n\nAddress this directly/,
+    );
+    if (!match) throw new Error('reason section not found in message');
+    return match[1]!;
+  }
+
+  it('truncates a reason over the cap and appends a truncation marker', () => {
+    const longReason = 'x'.repeat(5000);
+    const message = buildRetryMessage(longReason, 1500);
+
+    const embedded = extractEmbeddedReason(message);
+    expect(embedded).toBe(
+      `${'x'.repeat(1500)}\n\n[…reason truncated at 1500 chars…]`,
+    );
+  });
+
+  it('does not truncate or mark a reason exactly at the cap', () => {
+    const reason = 'x'.repeat(1500);
+    const message = buildRetryMessage(reason, 1500);
+
+    const embedded = extractEmbeddedReason(message);
+    expect(embedded).toBe('x'.repeat(1500));
+    expect(message).not.toContain('truncated');
+  });
+
+  it('truncates and marks a reason one character over the cap', () => {
+    const reason = 'x'.repeat(1501);
+    const message = buildRetryMessage(reason, 1500);
+
+    const embedded = extractEmbeddedReason(message);
+    expect(embedded).toBe(
+      `${'x'.repeat(1500)}\n\n[…reason truncated at 1500 chars…]`,
+    );
+  });
+});

--- a/apps/server/src/tasks/execution/verification-verdict.ts
+++ b/apps/server/src/tasks/execution/verification-verdict.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure helpers for interpreting a verifier session's raw response and
+ * building the retry message an executor subtask sees afterward.
+ * Split out from task-execution.ts so the JSON-extraction and reason-
+ * selection logic can be unit tested directly, without driving
+ * TaskExecution's private handleVerificationResult through a full run
+ * event.
+ */
+
+const RETRY_EXECUTE_DIRECTIVE =
+  'Do not ask what to do — execute the task directly.';
+
+export type VerificationVerdict = {
+  isComplete: boolean;
+  /** Best-effort reason text to show the executor on retry, always present. */
+  reason: string;
+  /** The verifier's raw `verdict` field, when structured output parsed cleanly. */
+  rawVerdict?: string;
+};
+
+/**
+ * Extracts the first balanced `{...}` object from `text`, tracking string
+ * literals so a brace inside a quoted value (code, regex, JSON example in
+ * the verifier's `reason`) can't end the match early. Returns null if no
+ * balanced object is found.
+ */
+export function extractJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escapeNext) {
+        escapeNext = false;
+      } else if (ch === '\\') {
+        escapeNext = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Interprets a verifier's raw response text: whether the subtask is
+ * COMPLETED, and — when it isn't — the best available reason to hand back
+ * to the executor. Prefers the verifier's structured `reason` field; falls
+ * back to the raw response text when JSON parsing fails, no balanced object
+ * is found, or `reason` is missing/non-string (an LLM can legitimately emit
+ * `reason` as an array, a number, or omit it — this must never throw).
+ */
+export function parseVerificationVerdict(content: string): VerificationVerdict {
+  const jsonText = extractJsonObject(content);
+  if (jsonText) {
+    try {
+      const parsed = JSON.parse(jsonText) as {
+        verdict?: unknown;
+        reason?: unknown;
+      };
+      const isComplete =
+        typeof parsed.verdict === 'string' &&
+        parsed.verdict.toUpperCase() === 'COMPLETED';
+      const reason =
+        typeof parsed.reason === 'string' && parsed.reason.trim()
+          ? parsed.reason.trim()
+          : content.trim();
+      return typeof parsed.verdict === 'string'
+        ? { isComplete, reason, rawVerdict: parsed.verdict }
+        : { isComplete, reason };
+    } catch {
+      // Not valid JSON despite the balanced braces — fall through to the
+      // plain-text heuristic below.
+    }
+  }
+  const isComplete =
+    /\bCOMPLETED\b/i.test(content) && !/\bINCOMPLETE\b/i.test(content);
+  return { isComplete, reason: content.trim() };
+}
+
+/**
+ * Builds the message sent back to a subtask's session on retry. When
+ * `reason` is given (a verification verdict), the agent is told exactly
+ * what was wrong, truncated to `maxChars` with an explicit marker so it
+ * never mistakes a cut mid-sentence for the complete verdict. Without a
+ * reason (the stuck-subtask sweep, which isn't verification-driven), the
+ * message stays generic.
+ */
+export function buildRetryMessage(
+  reason: string | undefined,
+  maxChars: number,
+): string {
+  if (!reason) {
+    return `Please continue and complete this subtask. Focus on delivering the actual output requested. ${RETRY_EXECUTE_DIRECTIVE}`;
+  }
+  const wasTruncated = reason.length > maxChars;
+  const reasonText = wasTruncated
+    ? `${reason.slice(0, maxChars)}\n\n[…reason truncated at ${maxChars} chars…]`
+    : reason;
+  return `Your previous attempt at this subtask was reviewed and marked incomplete. Here is specifically what was wrong or missing:\n\n${reasonText}\n\nAddress this directly, then deliver the actual output requested. ${RETRY_EXECUTE_DIRECTIVE}`;
+}

--- a/apps/server/src/tasks/service.ts
+++ b/apps/server/src/tasks/service.ts
@@ -278,8 +278,9 @@ export class TaskService {
 
   async triggerSubtaskRetry(
     subtaskId: string,
+    reason?: string,
   ): Promise<ServiceResult<{ sessionId: string }>> {
-    return this.execution.triggerSubtaskRetry(subtaskId);
+    return this.execution.triggerSubtaskRetry(subtaskId, reason);
   }
 
   async completeSubtask(

--- a/apps/server/src/tasks/subtask-execution.test.ts
+++ b/apps/server/src/tasks/subtask-execution.test.ts
@@ -731,7 +731,17 @@ describe('Subtask Execution', () => {
 
       const [messageInput] =
         mockSessionService.submitMessageStreaming.mock.calls[0]!;
-      expect(messageInput.content.length).toBeLessThan(longReason.length);
+      // Pin the exact bound (not just "shorter than input") so shrinking the
+      // cap, or dropping the slice entirely, fails this test. Extract the
+      // embedded reason rather than counting 'x' across the whole message,
+      // since the fixed wording around it ("execute") also contains an x.
+      const match = messageInput.content.match(
+        /missing:\n\n([\s\S]*?)\n\nAddress this directly/,
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe(
+        `${'x'.repeat(1500)}\n\n[…reason truncated at 1500 chars…]`,
+      );
     });
   });
 });

--- a/apps/server/src/tasks/subtask-execution.test.ts
+++ b/apps/server/src/tasks/subtask-execution.test.ts
@@ -679,4 +679,59 @@ describe('Subtask Execution', () => {
       expect(result).toHaveLength(3);
     });
   });
+
+  describe('triggerSubtaskRetry', () => {
+    it('sends the generic retry message when no reason is given', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-1',
+        sessionId: 'session-1',
+        assignedAgentId: 'agent-1',
+      });
+
+      const result = await taskService.triggerSubtaskRetry('subtask-1');
+
+      expect(result.ok).toBe(true);
+      const [messageInput] =
+        mockSessionService.submitMessageStreaming.mock.calls[0]!;
+      expect(messageInput.content).toBe(
+        'Please continue and complete this subtask. Focus on delivering the actual output requested. Do not ask what to do — execute the task directly.',
+      );
+    });
+
+    it('includes the verification reason in the retry message when given', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-1',
+        sessionId: 'session-1',
+        assignedAgentId: 'agent-1',
+      });
+
+      const result = await taskService.triggerSubtaskRetry(
+        'subtask-1',
+        'The headline claimed in the response does not appear anywhere in the actual tool results.',
+      );
+
+      expect(result.ok).toBe(true);
+      const [messageInput] =
+        mockSessionService.submitMessageStreaming.mock.calls[0]!;
+      expect(messageInput.content).toContain(
+        'The headline claimed in the response does not appear anywhere in the actual tool results.',
+      );
+      expect(messageInput.content).toContain('marked incomplete');
+    });
+
+    it('truncates an excessively long reason instead of forwarding it verbatim', async () => {
+      mockSubtasksRepo.findById.mockResolvedValue({
+        id: 'subtask-1',
+        sessionId: 'session-1',
+        assignedAgentId: 'agent-1',
+      });
+      const longReason = 'x'.repeat(5000);
+
+      await taskService.triggerSubtaskRetry('subtask-1', longReason);
+
+      const [messageInput] =
+        mockSessionService.submitMessageStreaming.mock.calls[0]!;
+      expect(messageInput.content.length).toBeLessThan(longReason.length);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When the verifier marks a subtask `INCOMPLETE`, the retry message sent back to the subtask's session was a generic "please continue and complete this subtask" — the verifier's actual `reason` (e.g. "the headline you cited doesn't appear anywhere in the tool results") never reached the agent, so a retry had a good chance of repeating the exact same mistake.

`handleVerificationResult` now threads the verdict's `reason` (falling back to the verifier's raw response text if JSON parsing failed) through to `triggerSubtaskRetry`, which folds it into the retry message:

> "Your previous attempt at this subtask was reviewed and marked incomplete. Here is specifically what was wrong or missing:
>
> \<reason\>
>
> Address this directly, then deliver the actual output requested. Do not ask what to do — execute the task directly."

Capped at 1500 chars so a verbose verdict can't blow up the next attempt's context window. The stuck-subtask auto-retry path (`checkStuckSubtasks`) isn't verification-driven and has no reason to pass, so it keeps sending the original generic message — unchanged.

## Test plan

- [x] New unit tests: generic message when no reason given (regression), reason included when given, long reason truncated
- [x] `pnpm -r build` (typecheck) clean
- [x] `pnpm --filter @openaidy/server test` — same 3 pre-existing Windows-only failures noted in prior PRs, unrelated to this change; everything else green

🤖 Generated with [Claude Code](https://claude.com/claude-code)