### PR TITLE
feat(agent): add structured visual identity (emoji + accentColor + optional avatar asset)

### DIFF
--- a/apps/server/src/agents/registry.test.ts
+++ b/apps/server/src/agents/registry.test.ts
@@ -809,6 +809,160 @@ describe('AgentRegistry', () => {
       expect(registry.size).toBe(0);
     });
   });
+
+  describe('createAgent with identity', () => {
+    it('persists the identity field in memory and to disk', () => {
+      const configPath = path.join(tempDir, 'openaidy.json');
+      fs.writeFileSync(configPath, JSON.stringify({ version: 1, agents: [] }));
+
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([]);
+
+      const summary = registry.createAgent({
+        id: 'fox-agent',
+        name: 'Fox Agent',
+        systemPrompt: 'You are a fox.',
+        model: 'openai/gpt-4o-mini',
+        identity: { emoji: '🦊', accentColor: '#7C3AED' },
+      });
+
+      expect(summary.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+      expect(registry.getAgent('fox-agent')?.identity).toEqual({
+        emoji: '🦊',
+        accentColor: '#7C3AED',
+      });
+
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<{ id: string; identity?: unknown }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'fox-agent');
+      expect(agent?.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+    });
+
+    it('creates an agent without identity when not provided', () => {
+      const registry = new AgentRegistry();
+      registry.replaceAll([]);
+
+      const summary = registry.createAgent({
+        id: 'plain-agent',
+        name: 'Plain Agent',
+        systemPrompt: 'You are plain.',
+        model: 'openai/gpt-4o-mini',
+      });
+
+      expect(summary.identity).toBeUndefined();
+    });
+  });
+
+  describe('updateAgentIdentity', () => {
+    let configPath: string;
+
+    beforeEach(() => {
+      configPath = path.join(tempDir, 'openaidy.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          agents: [
+            {
+              id: 'agent1',
+              name: 'Agent One',
+              enabled: true,
+              systemPrompt: 'Prompt',
+              model: 'openai/gpt-4',
+              identity: { emoji: '🐢', accentColor: '#111111' },
+            },
+          ],
+        }),
+      );
+    });
+
+    it('updates identity in memory and returns updated summary', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          version: 1,
+          identity: { emoji: '🐢', accentColor: '#111111' },
+        },
+      ]);
+
+      const result = registry.updateAgentIdentity('agent1', {
+        emoji: '🦊',
+        accentColor: '#7C3AED',
+      });
+
+      expect(result?.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+      expect(registry.getAgent('agent1')?.identity).toEqual({
+        emoji: '🦊',
+        accentColor: '#7C3AED',
+      });
+    });
+
+    it('persists identity to the config file on disk', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          version: 1,
+        },
+      ]);
+
+      registry.updateAgentIdentity('agent1', {
+        emoji: '🦊',
+        accentColor: '#7C3AED',
+      });
+
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<{ id: string; identity?: unknown }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'agent1');
+      expect(agent?.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+    });
+
+    it('removes the identity key from memory and disk when passed null', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([
+        {
+          id: 'agent1',
+          name: 'Agent One',
+          enabled: true,
+          systemPrompt: 'Prompt',
+          model: 'openai/gpt-4',
+          version: 1,
+          identity: { emoji: '🐢', accentColor: '#111111' },
+        },
+      ]);
+
+      registry.updateAgentIdentity('agent1', null);
+
+      expect(registry.getAgent('agent1')?.identity).toBeUndefined();
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<{ id: string; identity?: unknown }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'agent1');
+      expect(agent).not.toHaveProperty('identity');
+    });
+
+    it('returns undefined for an unknown agent id', () => {
+      const registry = new AgentRegistry({ configPath });
+      registry.replaceAll([]);
+
+      const result = registry.updateAgentIdentity('ghost', {
+        emoji: '🦊',
+        accentColor: '#7C3AED',
+      });
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 describe('createAgentRegistry', () => {

--- a/apps/server/src/agents/registry.ts
+++ b/apps/server/src/agents/registry.ts
@@ -405,10 +405,10 @@ export class AgentRegistry {
     this.agents.set(agentId, updated);
     this.persistConfig((agents) => {
       const idx = agents.findIndex((a) => a['id'] === agentId);
-      if (idx !== -1) {
-        if (identity) agents[idx]!['identity'] = identity;
-        else delete agents[idx]!['identity'];
-      }
+      const entry = idx !== -1 ? agents[idx] : undefined;
+      if (!entry) return;
+      if (identity) entry['identity'] = identity;
+      else delete entry['identity'];
     });
     return toAgentSummary(updated);
   }

--- a/apps/server/src/agents/registry.ts
+++ b/apps/server/src/agents/registry.ts
@@ -10,6 +10,7 @@ import {
   toAgentSummary,
 } from './schema';
 import type { CreateAgentInput } from '../types';
+import type { AgentIdentity } from '@openaidy/shared-types';
 
 /**
  * Agent registry options
@@ -384,6 +385,35 @@ export class AgentRegistry {
   }
 
   /**
+   * Update (or clear) the structured visual identity for an agent.
+   * Patches both the in-memory registry and the main openaidy.json config file on disk.
+   * Passing `null` removes the `identity` key. Returns the updated AgentSummary
+   * or undefined if the agent was not found.
+   */
+  updateAgentIdentity(
+    agentId: string,
+    identity: AgentIdentity | null,
+  ): AgentSummary | undefined {
+    this.ensureLoaded();
+    const agent = this.agents.get(agentId);
+    if (!agent) return undefined;
+
+    const updated: Agent = {
+      ...agent,
+      identity: identity ?? undefined,
+    };
+    this.agents.set(agentId, updated);
+    this.persistConfig((agents) => {
+      const idx = agents.findIndex((a) => a['id'] === agentId);
+      if (idx !== -1) {
+        if (identity) agents[idx]!['identity'] = identity;
+        else delete agents[idx]!['identity'];
+      }
+    });
+    return toAgentSummary(updated);
+  }
+
+  /**
    * Create a new agent from user-provided input.
    * All structural defaults (version, enabled, workspace scaffold, tags) are applied here
    * so callers never duplicate this logic. Persists to openaidy.json and registers in memory.
@@ -409,6 +439,7 @@ export class AgentRegistry {
       skills:
         input.skills && input.skills.length > 0 ? input.skills : undefined,
       version: 1,
+      identity: input.identity,
       workspace: {
         enabled: true,
         defaultPermissions: {

--- a/apps/server/src/agents/schema.test.ts
+++ b/apps/server/src/agents/schema.test.ts
@@ -10,6 +10,7 @@ import {
   WorkspaceConfigSchema,
   getAgentWorkspace,
   McpServerRefSchema,
+  IdentitySchema,
 } from './schema';
 
 describe('AgentSchema', () => {
@@ -543,5 +544,127 @@ describe('AgentSchema builtin tools (tools field)', () => {
     });
     const summary = toAgentSummary(agent);
     expect(summary.tools).toEqual(['workspace_read', 'workspace_write']);
+  });
+});
+
+describe('IdentitySchema', () => {
+  it('accepts a valid emoji + accentColor payload', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: '#7C3AED',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.emoji).toBe('🦊');
+      expect(result.data.accentColor).toBe('#7C3AED');
+      expect(result.data.avatar).toBeUndefined();
+    }
+  });
+
+  it('accepts a valid image avatar', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: '#7C3AED',
+      avatar: { kind: 'image', url: 'https://example.com/fox.png', alt: 'Fox' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid model3d avatar', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: '#7C3AED',
+      avatar: {
+        kind: 'model3d',
+        url: 'https://example.com/fox.glb',
+        format: 'glb',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a bad hex accentColor', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: 'purple',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a short hex accentColor', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: '#fff',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an emoji longer than 8 characters', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊🦊🦊🦊🦊',
+      accentColor: '#7C3AED',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an avatar with an unknown kind', () => {
+    const result = IdentitySchema.safeParse({
+      emoji: '🦊',
+      accentColor: '#7C3AED',
+      avatar: { kind: 'video', url: 'https://example.com/fox.mp4' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('AgentSchema with identity', () => {
+  it('parses an agent with identity', () => {
+    const agent = AgentSchema.parse({
+      id: 'identity-agent',
+      name: 'Identity Agent',
+      enabled: true,
+      systemPrompt: 'You are a test assistant.',
+      model: 'openai/gpt-4o-mini',
+      identity: { emoji: '🦊', accentColor: '#7C3AED' },
+    });
+    expect(agent.identity?.emoji).toBe('🦊');
+    expect(agent.identity?.accentColor).toBe('#7C3AED');
+  });
+
+  it('parses an agent without identity (backward compatible)', () => {
+    const agent = AgentSchema.parse({
+      id: 'no-identity-agent',
+      name: 'No Identity Agent',
+      enabled: true,
+      systemPrompt: 'You are a test assistant.',
+      model: 'openai/gpt-4o-mini',
+    });
+    expect(agent.identity).toBeUndefined();
+  });
+
+  it('toAgentSummary propagates identity', () => {
+    const agent = AgentSchema.parse({
+      id: 'identity-agent',
+      name: 'Identity Agent',
+      enabled: true,
+      systemPrompt: 'You are a test assistant.',
+      model: 'openai/gpt-4o-mini',
+      identity: { emoji: '🦊', accentColor: '#7C3AED' },
+    });
+    const summary = toAgentSummary(agent);
+    expect(summary.identity?.emoji).toBe('🦊');
+    expect(summary.identity?.accentColor).toBe('#7C3AED');
+  });
+
+  it('toAgentSummary produces identity: undefined when absent', () => {
+    const agent = AgentSchema.parse({
+      id: 'no-identity-agent',
+      name: 'No Identity Agent',
+      enabled: true,
+      systemPrompt: 'You are a test assistant.',
+      model: 'openai/gpt-4o-mini',
+    });
+    const summary = toAgentSummary(agent);
+    expect(summary.identity).toBeUndefined();
   });
 });

--- a/apps/server/src/agents/schema.ts
+++ b/apps/server/src/agents/schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import type { AgentIdentity, McpServerRef } from '@openaidy/shared-types';
+import {
+  AGENT_IDENTITY_HEX_COLOR_PATTERN,
+  type AgentIdentity,
+  type McpServerRef,
+} from '@openaidy/shared-types';
 
 /**
  * Workspace permissions schema
@@ -78,7 +82,7 @@ export type { McpServerRef };
  */
 const HexColorSchema = z
   .string()
-  .regex(/^#[0-9a-fA-F]{6}$/)
+  .regex(AGENT_IDENTITY_HEX_COLOR_PATTERN)
   .transform((v) => v as `#${string}`);
 
 /**

--- a/apps/server/src/agents/schema.ts
+++ b/apps/server/src/agents/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { McpServerRef } from '@openaidy/shared-types';
+import type { AgentIdentity, McpServerRef } from '@openaidy/shared-types';
 
 /**
  * Workspace permissions schema
@@ -73,6 +73,46 @@ export const McpServerRefSchema = z.object({
 export type { McpServerRef };
 
 /**
+ * Hex color schema (6-digit, e.g. "#7C3AED")
+ * Transformed to the `#${string}` brand so it lines up with AgentIdentity.
+ */
+const HexColorSchema = z
+  .string()
+  .regex(/^#[0-9a-fA-F]{6}$/)
+  .transform((v) => v as `#${string}`);
+
+/**
+ * Identity avatar asset schema
+ *
+ * Discriminated union so consumers branch on `kind` instead of inspecting
+ * URLs or content-type. See AgentIdentityAsset in @openaidy/shared-types.
+ */
+export const IdentityAssetSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('image'),
+    url: z.string().url(),
+    alt: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('model3d'),
+    url: z.string().url(),
+    format: z.enum(['gltf', 'glb']),
+  }),
+]);
+
+/**
+ * Identity schema
+ *
+ * Structured visual identity for an agent: emoji + accent color, with an
+ * optional avatar asset override. See AgentIdentity in @openaidy/shared-types.
+ */
+export const IdentitySchema = z.object({
+  emoji: z.string().min(1).max(8),
+  accentColor: HexColorSchema,
+  avatar: IdentityAssetSchema.optional(),
+});
+
+/**
  * Agent definition schema
  *
  * Defines an agent with its configuration and metadata.
@@ -116,6 +156,9 @@ export const AgentSchema = z.object({
     .optional(),
   // Workspace configuration (optional)
   workspace: WorkspaceConfigSchema.optional(),
+
+  // Structured visual identity (emoji + accent color + optional avatar).
+  identity: IdentitySchema.optional(),
 });
 
 /**
@@ -137,6 +180,7 @@ export type AgentSummary = {
   mcpServers: McpServerRef[] | undefined;
   model: string | undefined; // Format: "providerId/modelId"; undefined = inherit config default
   workspace?: WorkspaceConfig | undefined;
+  identity?: AgentIdentity | undefined;
 };
 
 /**
@@ -205,6 +249,7 @@ export function toAgentSummary(agent: Agent): AgentSummary {
     mcpServers: agent.mcpServers,
     model: agent.model,
     workspace: agent.workspace,
+    identity: agent.identity,
   };
 }
 

--- a/apps/server/src/routes/agents.test.ts
+++ b/apps/server/src/routes/agents.test.ts
@@ -371,6 +371,71 @@ describe('Agent Routes', () => {
     });
   });
 
+  describe('PATCH /agents/:agentId/identity', () => {
+    it('should update identity for an agent and return updated summary', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/default/identity',
+        payload: { identity: { emoji: '🦊', accentColor: '#7C3AED' } },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.id).toBe('default');
+      expect(body.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+    });
+
+    it('should clear identity when passed null', async () => {
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/default/identity',
+        payload: { identity: { emoji: '🦊', accentColor: '#7C3AED' } },
+      });
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/default/identity',
+        payload: { identity: null },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.identity).toBeUndefined();
+    });
+
+    it('should return 400 when accentColor is not a valid hex color', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/default/identity',
+        payload: { identity: { emoji: '🦊', accentColor: 'purple' } },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when identity is missing from the body', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/default/identity',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 for a non-existent agent', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/agents/ghost/identity',
+        payload: { identity: { emoji: '🦊', accentColor: '#7C3AED' } },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json();
+      expect(body.error).toBe('Agent not found');
+    });
+  });
+
   describe('DELETE /agents/:agentId', () => {
     it('returns 200 and the deleted agent summary', async () => {
       const response = await app.inject({

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -2,10 +2,15 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { AgentRegistry } from '../agents/registry';
 import type { AuthMiddleware } from '../websocket/middleware/auth';
 import type { CreateAgentInput } from '../types';
-import type { McpServerRef, PersonalityFileId } from '@openaidy/shared-types';
+import type {
+  AgentIdentity,
+  McpServerRef,
+  PersonalityFileId,
+} from '@openaidy/shared-types';
 import type { AgentPersonalityService } from '../agents/personality-service';
 import { PERSONALITY_FILES } from '../agents/personality-service';
 import { AGENT_PERSONALITY_PRESETS } from '@openaidy/shared-types';
+import { IdentitySchema } from '../agents/schema';
 import { requireAuth } from '../middleware/require-auth';
 
 /**
@@ -287,6 +292,42 @@ export const agentRoutes: FastifyPluginAsync<AgentRoutesOptions> = async (
       reply.code(404);
       return { error: 'Agent not found', agentId };
     }
+
+    return result;
+  });
+
+  /**
+   * PATCH /agents/:agentId/identity
+   * Update or clear the structured visual identity for an agent.
+   * Body: { identity: AgentIdentity | null }
+   */
+  app.patch('/agents/:agentId/identity', async (request, reply) => {
+    const { agentId } = request.params as { agentId: string };
+    const body = request.body as { identity?: unknown };
+
+    if (!agentRegistry.hasAgent(agentId)) {
+      reply.code(404);
+      return { error: 'Agent not found', agentId };
+    }
+
+    if (body?.identity === null) {
+      const result = agentRegistry.updateAgentIdentity(agentId, null);
+      return result;
+    }
+
+    const parsed = IdentitySchema.safeParse(body?.identity);
+    if (!parsed.success) {
+      reply.code(400);
+      return {
+        error:
+          'Invalid request: identity must be a valid identity object or null',
+      };
+    }
+
+    const result = agentRegistry.updateAgentIdentity(
+      agentId,
+      parsed.data as AgentIdentity,
+    );
 
     return result;
   });

--- a/apps/web/src/components/AgentPicker.test.tsx
+++ b/apps/web/src/components/AgentPicker.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { AgentPicker } from './AgentPicker';
+import type { Agent } from '../lib/api';
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'fox-agent',
+    name: 'Fox Agent',
+    enabled: true,
+    systemPrompt: 'You are a fox.',
+    model: 'openai/gpt-4o-mini',
+    defaults: {},
+    ...overrides,
+  };
+}
+
+describe('AgentPicker', () => {
+  it('shows a neutral dot (bot icon) fallback when no agent has identity', () => {
+    const agents = [makeAgent()];
+    const { container } = render(() => (
+      <AgentPicker agents={agents} onSelect={vi.fn()} />
+    ));
+    expect(container.querySelector('svg')).toBeTruthy();
+    expect(container.textContent).not.toContain('🦊');
+  });
+
+  it('renders the selected agent emoji in the trigger chip', () => {
+    const agents = [
+      makeAgent({ identity: { emoji: '🦊', accentColor: '#7C3AED' } }),
+    ];
+    const { container } = render(() => (
+      <AgentPicker
+        agents={agents}
+        selectedAgentId="fox-agent"
+        onSelect={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain('🦊');
+  });
+
+  it('renders emoji and accent-color left border on dropdown rows', () => {
+    const agents = [
+      makeAgent({ identity: { emoji: '🦊', accentColor: '#7C3AED' } }),
+    ];
+    const { getByLabelText, getByText, container } = render(() => (
+      <AgentPicker agents={agents} onSelect={vi.fn()} />
+    ));
+
+    fireEvent.click(getByLabelText('Select agent'));
+
+    expect(container.textContent).toContain('🦊');
+    const row = getByText('Fox Agent').closest('button');
+    // jsdom normalizes hex colors to rgb() in the serialized style attribute.
+    expect(row?.getAttribute('style')).toContain('border-left');
+    expect(row?.getAttribute('style')).toContain('rgb(124, 58, 237)');
+  });
+
+  it('falls back gracefully for agents without identity in the dropdown', () => {
+    const agents = [makeAgent({ id: 'plain-agent', name: 'Plain Agent' })];
+    const { getByLabelText, getByText } = render(() => (
+      <AgentPicker agents={agents} onSelect={vi.fn()} />
+    ));
+
+    fireEvent.click(getByLabelText('Select agent'));
+
+    const row = getByText('Plain Agent').closest('button');
+    expect(row?.getAttribute('style')).toBeFalsy();
+  });
+
+  it('calls onSelect with the agent id when a row is clicked', () => {
+    const onSelect = vi.fn();
+    const agents = [
+      makeAgent({ identity: { emoji: '🦊', accentColor: '#7C3AED' } }),
+    ];
+    const { getByLabelText, getByText } = render(() => (
+      <AgentPicker agents={agents} onSelect={onSelect} />
+    ));
+
+    fireEvent.click(getByLabelText('Select agent'));
+    fireEvent.click(getByText('Fox Agent'));
+
+    expect(onSelect).toHaveBeenCalledWith('fox-agent');
+  });
+});

--- a/apps/web/src/components/AgentPicker.tsx
+++ b/apps/web/src/components/AgentPicker.tsx
@@ -31,6 +31,16 @@ export function AgentPicker(props: AgentPickerProps) {
     props.agents.find((a) => a.id === props.selectedAgentId);
   const selectedLabel = () => selectedAgent()?.name ?? 'Default agent';
 
+  // Chip icon for the trigger button: agent's emoji when set, otherwise the
+  // neutral bot icon fallback.
+  const AgentIcon = (p: { agent?: Agent; class: string }) => (
+    <Show when={p.agent?.identity?.emoji} fallback={<Bot class={p.class} />}>
+      <span class="leading-none" aria-hidden="true">
+        {p.agent?.identity?.emoji}
+      </span>
+    </Show>
+  );
+
   // Option list shared by the desktop dropdown and the mobile bottom sheet.
   const OptionList = () => (
     <>
@@ -54,13 +64,23 @@ export function AgentPicker(props: AgentPickerProps) {
           <button
             type="button"
             onClick={() => handleSelect(agent.id)}
+            style={
+              agent.identity?.accentColor
+                ? { 'border-left': `2px solid ${agent.identity.accentColor}` }
+                : undefined
+            }
             class={`w-full px-3 py-3 md:py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 ${
+              agent.identity?.accentColor ? '' : 'border-l-2 border-transparent'
+            } ${
               props.selectedAgentId === agent.id
                 ? 'bg-blue-50 dark:bg-blue-900/30'
                 : ''
             }`}
           >
-            <Bot class="w-4 h-4 text-text-tertiary flex-shrink-0" />
+            <AgentIcon
+              agent={agent}
+              class="w-4 h-4 text-text-tertiary flex-shrink-0"
+            />
             <div class="flex-1 min-w-0">
               <div class="font-medium text-text-primary truncate">
                 {agent.name}
@@ -100,7 +120,10 @@ export function AgentPicker(props: AgentPickerProps) {
             aria-label="Select agent"
             class="flex items-center gap-2 px-3 h-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed min-w-[140px]"
           >
-            <Bot class="w-4 h-4 text-text-tertiary" />
+            <AgentIcon
+              agent={selectedAgent()}
+              class="w-4 h-4 text-text-tertiary"
+            />
             <span class="flex-1 text-left text-sm text-text-secondary truncate">
               {selectedLabel()}
             </span>
@@ -116,7 +139,7 @@ export function AgentPicker(props: AgentPickerProps) {
           title={selectedLabel()}
           class="flex items-center justify-center w-8 h-8 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-text-tertiary hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <Bot class="w-4 h-4" />
+          <AgentIcon agent={selectedAgent()} class="w-4 h-4" />
         </button>
       </Show>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -17,6 +17,8 @@ export type {
   AgentWorkspace,
   AgentWorkspaceConfig,
   Agent,
+  AgentIdentity,
+  AgentIdentityAsset,
   SessionRun,
   BuiltinToolInfo,
   SkillSource,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -57,6 +57,9 @@ export type {
   // shared-types so the registry, the route, and this client agree on one
   // shape; re-exported here so existing './types' imports keep working.
   SkillLoadError,
+  // Structured agent visual identity — single source of truth.
+  AgentIdentity,
+  AgentIdentityAsset,
 } from '@openaidy/shared-types';
 
 import type {
@@ -64,6 +67,7 @@ import type {
   RunStatus as SharedRunStatus,
   SessionRun as SharedSessionRun,
   SessionMessageAttachment,
+  AgentIdentity,
 } from '@openaidy/shared-types';
 
 // Attachment metadata on a session message. Declared in shared-types
@@ -124,7 +128,7 @@ export type Agent = {
     maxTokens?: number;
   };
   workspace?: AgentWorkspaceConfig;
-  identity?: import('@openaidy/shared-types').AgentIdentity;
+  identity?: AgentIdentity;
 };
 
 /**

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -124,6 +124,7 @@ export type Agent = {
     maxTokens?: number;
   };
   workspace?: AgentWorkspaceConfig;
+  identity?: import('@openaidy/shared-types').AgentIdentity;
 };
 
 /**

--- a/packages/cli/src/commands/agents/create.test.ts
+++ b/packages/cli/src/commands/agents/create.test.ts
@@ -431,4 +431,66 @@ describe('agents create', () => {
       expect(agent.identity).toEqual({ emoji: '🐢', accentColor: '#123abc' });
     });
   });
+
+  describe('flag value validation', () => {
+    it('rejects --emoji with no value instead of falling through to the prompt', async () => {
+      const result = await agentsCreateHandler([
+        '--name',
+        'No Value Agent',
+        '--emoji',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--emoji requires a value');
+      // Must fail before ever touching the interactive prompts.
+      expect(mockClack.text).not.toHaveBeenCalled();
+    });
+
+    it('rejects --color with no value instead of falling through to the prompt', async () => {
+      const result = await agentsCreateHandler([
+        '--name',
+        'No Value Agent',
+        '--color',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--color requires a value');
+      expect(mockClack.text).not.toHaveBeenCalled();
+    });
+
+    it('rejects --emoji immediately followed by another flag', async () => {
+      const result = await agentsCreateHandler([
+        '--name',
+        'No Value Agent',
+        '--emoji',
+        '--no-identity',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--emoji requires a value');
+    });
+
+    it('rejects --name with no value', async () => {
+      const result = await agentsCreateHandler(['--name']);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--name requires a value');
+    });
+
+    it('rejects --description with no value', async () => {
+      const result = await agentsCreateHandler([
+        '--name',
+        'No Value Agent',
+        '--description',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--description requires a value');
+    });
+
+    it('rejects --id with no value', async () => {
+      const result = await agentsCreateHandler([
+        '--name',
+        'No Value Agent',
+        '--id',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('--id requires a value');
+    });
+  });
 });

--- a/packages/cli/src/commands/agents/create.test.ts
+++ b/packages/cli/src/commands/agents/create.test.ts
@@ -151,12 +151,16 @@ describe('agents create', () => {
     beforeEach(() => setupClack());
 
     it('creates agent and exits 0', async () => {
-      const result = await agentsCreateHandler(['--name', 'My New Agent']);
+      const result = await agentsCreateHandler([
+        '--name',
+        'My New Agent',
+        '--no-identity',
+      ]);
       expect(result.exitCode).toBe(0);
     });
 
     it('writes openaidy.json with the new agent appended', async () => {
-      await agentsCreateHandler(['--name', 'My New Agent']);
+      await agentsCreateHandler(['--name', 'My New Agent', '--no-identity']);
       expect(mockWriteFile).toHaveBeenCalledOnce();
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string }>;
@@ -168,7 +172,7 @@ describe('agents create', () => {
     });
 
     it('creates workspace directory', async () => {
-      await agentsCreateHandler(['--name', 'My New Agent']);
+      await agentsCreateHandler(['--name', 'My New Agent', '--no-identity']);
       const mkdirCalls = mockMkdir.mock.calls.map((c) => c[0] as string);
       expect(mkdirCalls.some((path) => path.includes('my-new-agent'))).toBe(
         true,
@@ -176,7 +180,7 @@ describe('agents create', () => {
     });
 
     it('uses default model when none selected', async () => {
-      await agentsCreateHandler(['--name', 'My New Agent']);
+      await agentsCreateHandler(['--name', 'My New Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; model: string }>;
       };
@@ -185,7 +189,7 @@ describe('agents create', () => {
     });
 
     it('includes workspace property in created agent', async () => {
-      await agentsCreateHandler(['--name', 'My New Agent']);
+      await agentsCreateHandler(['--name', 'My New Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{
           id: string;
@@ -198,7 +202,7 @@ describe('agents create', () => {
     });
 
     it('calls p.outro with agent ID', async () => {
-      await agentsCreateHandler(['--name', 'My New Agent']);
+      await agentsCreateHandler(['--name', 'My New Agent', '--no-identity']);
       const outroArg = mockClack.outro.mock.calls[0]?.[0] as string;
       expect(outroArg).toContain('my-new-agent');
     });
@@ -208,7 +212,7 @@ describe('agents create', () => {
     it('copies model from selected agent', async () => {
       const defaultAgent = EXISTING_CONFIG.agents[0]!;
       setupClack({ model: defaultAgent });
-      await agentsCreateHandler(['--name', 'Cloned Agent']);
+      await agentsCreateHandler(['--name', 'Cloned Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; model: string }>;
       };
@@ -219,7 +223,7 @@ describe('agents create', () => {
     it('copies model from Code Assistant', async () => {
       const codeAgent = EXISTING_CONFIG.agents[1]!;
       setupClack({ model: codeAgent });
-      await agentsCreateHandler(['--name', 'Cloned Two']);
+      await agentsCreateHandler(['--name', 'Cloned Two', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; model: string }>;
       };
@@ -231,7 +235,7 @@ describe('agents create', () => {
   describe('skills assignment', () => {
     it('assigns selected skills', async () => {
       setupClack({ skills: ['example-skill', 'step-by-step'] });
-      await agentsCreateHandler(['--name', 'Skilled Agent']);
+      await agentsCreateHandler(['--name', 'Skilled Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; skills?: string[] }>;
       };
@@ -242,14 +246,14 @@ describe('agents create', () => {
 
     it('shows skills in p.outro when assigned', async () => {
       setupClack({ skills: ['example-skill', 'step-by-step'] });
-      await agentsCreateHandler(['--name', 'Skilled Agent']);
+      await agentsCreateHandler(['--name', 'Skilled Agent', '--no-identity']);
       const outroArg = mockClack.outro.mock.calls[0]?.[0] as string;
       expect(outroArg).toContain('Skills:');
     });
 
     it('assigns no skills when empty array returned', async () => {
       setupClack({ skills: [] });
-      await agentsCreateHandler(['--name', 'No Skills Agent']);
+      await agentsCreateHandler(['--name', 'No Skills Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; skills?: string[] }>;
       };
@@ -259,7 +263,7 @@ describe('agents create', () => {
 
     it('assigns only the skills the user selected', async () => {
       setupClack({ skills: ['step-by-step'] });
-      await agentsCreateHandler(['--name', 'Selective Agent']);
+      await agentsCreateHandler(['--name', 'Selective Agent', '--no-identity']);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; skills?: string[] }>;
       };
@@ -271,7 +275,13 @@ describe('agents create', () => {
   describe('--id and --description flags', () => {
     it('uses --id to override the derived slug', async () => {
       setupClack();
-      await agentsCreateHandler(['--name', 'My Agent', '--id', 'custom-id']);
+      await agentsCreateHandler([
+        '--name',
+        'My Agent',
+        '--id',
+        'custom-id',
+        '--no-identity',
+      ]);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string }>;
       };
@@ -290,12 +300,135 @@ describe('agents create', () => {
         'Desc Agent',
         '--description',
         'My desc',
+        '--no-identity',
       ]);
       const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
         agents: Array<{ id: string; description: string }>;
       };
       const agent = written.agents.find((a) => a.id === 'desc-agent')!;
       expect(agent.description).toBe('My desc');
+    });
+  });
+
+  describe('identity prompts', () => {
+    it('skips identity prompts entirely with --no-identity', async () => {
+      setupClack();
+      await agentsCreateHandler([
+        '--name',
+        'No Identity Agent',
+        '--no-identity',
+      ]);
+      const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
+        agents: Array<{ id: string; identity?: unknown }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'no-identity-agent')!;
+      expect(agent.identity).toBeUndefined();
+      // Only description + system prompt text calls — no emoji prompt.
+      expect(mockClack.text).toHaveBeenCalledTimes(2);
+    });
+
+    it('persists identity via --emoji and --color flags without prompting', async () => {
+      setupClack();
+      await agentsCreateHandler([
+        '--name',
+        'Flag Identity Agent',
+        '--emoji',
+        '🦊',
+        '--color',
+        '#7C3AED',
+      ]);
+      const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
+        agents: Array<{
+          id: string;
+          identity?: { emoji: string; accentColor: string };
+        }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'flag-identity-agent')!;
+      expect(agent.identity).toEqual({ emoji: '🦊', accentColor: '#7C3AED' });
+      // Only description + system prompt text calls — no emoji/color prompts.
+      expect(mockClack.text).toHaveBeenCalledTimes(2);
+      // Only the model select — no accent color select.
+      expect(mockClack.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an invalid --color hex value', async () => {
+      mockClack.isCancel.mockReturnValue(false);
+      mockClack.text.mockResolvedValueOnce(''); // description prompt only
+      const result = await agentsCreateHandler([
+        '--name',
+        'Bad Color Agent',
+        '--emoji',
+        '🦊',
+        '--color',
+        '#zzz',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain('Invalid accent color');
+    });
+
+    it('rejects a short --color hex code', async () => {
+      mockClack.isCancel.mockReturnValue(false);
+      mockClack.text.mockResolvedValueOnce(''); // description prompt only
+      const result = await agentsCreateHandler([
+        '--name',
+        'Short Color Agent',
+        '--emoji',
+        '🦊',
+        '--color',
+        '#fff',
+      ]);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('prompts for emoji and accent color when no flags are given', async () => {
+      mockClack.isCancel.mockReturnValue(false);
+      mockClack.text
+        .mockResolvedValueOnce('') // description
+        .mockResolvedValueOnce('🐢') // emoji prompt
+        .mockResolvedValueOnce(''); // system prompt
+      mockClack.select
+        .mockResolvedValueOnce('#16A34A') // accent color palette pick
+        .mockResolvedValueOnce(null); // model select
+      mockClack.multiselect.mockResolvedValueOnce([]);
+      mockClack.spinner.mockReturnValue({ start: vi.fn(), stop: vi.fn() });
+
+      await agentsCreateHandler(['--name', 'Prompted Identity Agent']);
+
+      const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
+        agents: Array<{
+          id: string;
+          identity?: { emoji: string; accentColor: string };
+        }>;
+      };
+      const agent = written.agents.find(
+        (a) => a.id === 'prompted-identity-agent',
+      )!;
+      expect(agent.identity).toEqual({ emoji: '🐢', accentColor: '#16A34A' });
+    });
+
+    it('prompts for a custom hex color when "Custom…" is selected', async () => {
+      mockClack.isCancel.mockReturnValue(false);
+      mockClack.text
+        .mockResolvedValueOnce('') // description
+        .mockResolvedValueOnce('🐢') // emoji prompt
+        .mockResolvedValueOnce('#123abc') // custom color prompt
+        .mockResolvedValueOnce(''); // system prompt
+      mockClack.select
+        .mockResolvedValueOnce('custom') // accent color palette pick -> custom
+        .mockResolvedValueOnce(null); // model select
+      mockClack.multiselect.mockResolvedValueOnce([]);
+      mockClack.spinner.mockReturnValue({ start: vi.fn(), stop: vi.fn() });
+
+      await agentsCreateHandler(['--name', 'Custom Color Agent']);
+
+      const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string) as {
+        agents: Array<{
+          id: string;
+          identity?: { emoji: string; accentColor: string };
+        }>;
+      };
+      const agent = written.agents.find((a) => a.id === 'custom-color-agent')!;
+      expect(agent.identity).toEqual({ emoji: '🐢', accentColor: '#123abc' });
     });
   });
 });

--- a/packages/cli/src/commands/agents/create.ts
+++ b/packages/cli/src/commands/agents/create.ts
@@ -15,7 +15,19 @@ import type {
   OpenAidyConfig,
   SkillSummary,
   CreateAgentInput,
+  AgentIdentity,
 } from '../../types.js';
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+const ACCENT_COLOR_PALETTE: Array<{ label: string; value: string }> = [
+  { label: 'Violet', value: '#7C3AED' },
+  { label: 'Blue', value: '#2563EB' },
+  { label: 'Green', value: '#16A34A' },
+  { label: 'Amber', value: '#D97706' },
+  { label: 'Rose', value: '#E11D48' },
+  { label: 'Slate', value: '#475569' },
+];
 
 function resolveConfigPath(): string {
   return resolve(process.env.APP_CONFIG_PATH ?? '.openaidy/openaidy.json');
@@ -83,11 +95,16 @@ Options:
   --name <name>          Agent display name (skips prompt)
   --id <id>              Agent ID slug (derived from name if omitted)
   --description <desc>   Short description (skips prompt)
+  --emoji <emoji>        Identity emoji (skips identity prompts)
+  --color <hex>          Identity accent color, e.g. #7C3AED (skips identity prompts)
+  --no-identity          Skip the identity (emoji + accent color) prompts entirely
 
 Examples:
   pnpm openaidy agents create
   pnpm openaidy agents create "Research Assistant"
   pnpm openaidy agents create --name "Research Assistant" --description "Helps with research"
+  pnpm openaidy agents create --name "Research Assistant" --emoji "🔬" --color "#2563EB"
+  pnpm openaidy agents create --name "Research Assistant" --no-identity
 
 Exit Codes:
   0  Agent created successfully
@@ -100,15 +117,21 @@ Exit Codes:
   const workspaceBaseDir = resolveWorkspaceBaseDir();
   const configPath = resolveConfigPath();
 
-  // Parse --name / --description / --id from args
+  // Parse --name / --description / --id / --emoji / --color / --no-identity from args
   let nameArg: string | undefined;
   let idArg: string | undefined;
   let descArg: string | undefined;
+  let emojiArg: string | undefined;
+  let colorArg: string | undefined;
+  let noIdentity = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--name') nameArg = args[++i];
     else if (args[i] === '--id') idArg = args[++i];
     else if (args[i] === '--description' || args[i] === '--desc')
       descArg = args[++i];
+    else if (args[i] === '--emoji') emojiArg = args[++i];
+    else if (args[i] === '--color') colorArg = args[++i];
+    else if (args[i] === '--no-identity') noIdentity = true;
     else if (!args[i]!.startsWith('-') && !nameArg) nameArg = args[i];
   }
 
@@ -161,6 +184,80 @@ Exit Codes:
     return { exitCode: 1, error: 'Cancelled.' };
   }
   const description = ((descResult as string | undefined) ?? '').trim();
+
+  // Identity: emoji + accent color (skippable via --no-identity, or preset via --emoji/--color)
+  let identity: AgentIdentity | undefined;
+  if (!noIdentity) {
+    let emoji: string | undefined = emojiArg?.trim();
+    if (emoji !== undefined && (!emoji || emoji.length > 8)) {
+      p.cancel('Emoji must be 1-8 characters.');
+      return { exitCode: 1, error: 'Emoji must be 1-8 characters.' };
+    }
+    if (emoji === undefined) {
+      const emojiResult = await p.text({
+        message: 'Identity emoji',
+        placeholder: '🦊',
+        validate: (v) => {
+          const trimmed = (v ?? '').trim();
+          if (!trimmed) return 'Emoji is required.';
+          if (trimmed.length > 8) return 'Emoji must be at most 8 characters.';
+          return undefined;
+        },
+      });
+      if (p.isCancel(emojiResult)) {
+        p.cancel('Cancelled.');
+        return { exitCode: 1, error: 'Cancelled.' };
+      }
+      emoji = (emojiResult as string).trim();
+    }
+
+    let accentColor: string | undefined = colorArg?.trim();
+    if (accentColor !== undefined && !HEX_COLOR_RE.test(accentColor)) {
+      p.cancel(
+        `Invalid accent color "${accentColor}". Expected a 6-digit hex color like #7C3AED.`,
+      );
+      return {
+        exitCode: 1,
+        error: `Invalid accent color "${accentColor}".`,
+      };
+    }
+    if (accentColor === undefined) {
+      const colorResult = await p.select<string>({
+        message: 'Identity accent color',
+        options: [
+          ...ACCENT_COLOR_PALETTE.map((c) => ({
+            value: c.value,
+            label: c.label,
+            hint: c.value,
+          })),
+          { value: 'custom', label: 'Custom…' },
+        ],
+      });
+      if (p.isCancel(colorResult)) {
+        p.cancel('Cancelled.');
+        return { exitCode: 1, error: 'Cancelled.' };
+      }
+      if (colorResult === 'custom') {
+        const customColorResult = await p.text({
+          message: 'Custom accent color (hex)',
+          placeholder: '#7C3AED',
+          validate: (v) =>
+            !HEX_COLOR_RE.test((v ?? '').trim())
+              ? 'Must be a 6-digit hex color, e.g. #7C3AED.'
+              : undefined,
+        });
+        if (p.isCancel(customColorResult)) {
+          p.cancel('Cancelled.');
+          return { exitCode: 1, error: 'Cancelled.' };
+        }
+        accentColor = (customColorResult as string).trim();
+      } else {
+        accentColor = colorResult;
+      }
+    }
+
+    identity = { emoji, accentColor: accentColor as `#${string}` };
+  }
 
   // Prompt: system prompt
   const systemPromptResult = await p.text({
@@ -232,6 +329,7 @@ Exit Codes:
     description: description || undefined,
     tags: [],
     skills: assignedSkills.length > 0 ? assignedSkills : undefined,
+    identity,
   };
 
   // Construct the full AgentConfig for openaidy.json (mirrors what registry.createAgent() produces)

--- a/packages/cli/src/commands/agents/create.ts
+++ b/packages/cli/src/commands/agents/create.ts
@@ -9,6 +9,7 @@
 import * as p from '@clack/prompts';
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { isAgentIdentityHexColor } from '@openaidy/shared-types';
 import type {
   CommandResult,
   AgentConfig,
@@ -17,8 +18,6 @@ import type {
   CreateAgentInput,
   AgentIdentity,
 } from '../../types.js';
-
-const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
 const ACCENT_COLOR_PALETTE: Array<{ label: string; value: string }> = [
   { label: 'Violet', value: '#7C3AED' },
@@ -117,22 +116,50 @@ Exit Codes:
   const workspaceBaseDir = resolveWorkspaceBaseDir();
   const configPath = resolveConfigPath();
 
-  // Parse --name / --description / --id / --emoji / --color / --no-identity from args
+  // Parse --name / --description / --id / --emoji / --color / --no-identity from args.
+  // A value-taking flag with no following value (or one immediately followed
+  // by another flag) is a usage error — it must not silently fall through to
+  // an interactive prompt, which would hang a non-interactive (CI) invocation.
+  const VALUE_FLAGS = new Set([
+    '--name',
+    '--id',
+    '--description',
+    '--desc',
+    '--emoji',
+    '--color',
+  ]);
+  const isFlagValue = (token: string | undefined): token is string =>
+    token !== undefined && !token.startsWith('-');
+
   let nameArg: string | undefined;
   let idArg: string | undefined;
   let descArg: string | undefined;
   let emojiArg: string | undefined;
   let colorArg: string | undefined;
   let noIdentity = false;
+
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--name') nameArg = args[++i];
-    else if (args[i] === '--id') idArg = args[++i];
-    else if (args[i] === '--description' || args[i] === '--desc')
-      descArg = args[++i];
-    else if (args[i] === '--emoji') emojiArg = args[++i];
-    else if (args[i] === '--color') colorArg = args[++i];
-    else if (args[i] === '--no-identity') noIdentity = true;
-    else if (!args[i]!.startsWith('-') && !nameArg) nameArg = args[i];
+    const arg = args[i];
+    if (arg === undefined) break;
+
+    if (VALUE_FLAGS.has(arg)) {
+      const value = args[i + 1];
+      if (!isFlagValue(value)) {
+        const message = `${arg} requires a value.`;
+        p.cancel(message);
+        return { exitCode: 1, error: message };
+      }
+      if (arg === '--name') nameArg = value;
+      else if (arg === '--id') idArg = value;
+      else if (arg === '--description' || arg === '--desc') descArg = value;
+      else if (arg === '--emoji') emojiArg = value;
+      else if (arg === '--color') colorArg = value;
+      i++;
+      continue;
+    }
+
+    if (arg === '--no-identity') noIdentity = true;
+    else if (!arg.startsWith('-') && !nameArg) nameArg = arg;
   }
 
   p.intro('Create Agent');
@@ -212,7 +239,7 @@ Exit Codes:
     }
 
     let accentColor: string | undefined = colorArg?.trim();
-    if (accentColor !== undefined && !HEX_COLOR_RE.test(accentColor)) {
+    if (accentColor !== undefined && !isAgentIdentityHexColor(accentColor)) {
       p.cancel(
         `Invalid accent color "${accentColor}". Expected a 6-digit hex color like #7C3AED.`,
       );
@@ -242,7 +269,7 @@ Exit Codes:
           message: 'Custom accent color (hex)',
           placeholder: '#7C3AED',
           validate: (v) =>
-            !HEX_COLOR_RE.test((v ?? '').trim())
+            !isAgentIdentityHexColor((v ?? '').trim())
               ? 'Must be a 6-digit hex color, e.g. #7C3AED.'
               : undefined,
         });

--- a/packages/cli/src/commands/agents/list.test.ts
+++ b/packages/cli/src/commands/agents/list.test.ts
@@ -175,4 +175,63 @@ describe('agents list', () => {
       expect(noteOutput()).toContain('No Model Agent');
     });
   });
+
+  describe('identity rendering', () => {
+    it('prepends the emoji when identity is present', async () => {
+      const config = {
+        version: 1,
+        agents: [
+          {
+            id: 'fox-agent',
+            name: 'Fox Agent',
+            enabled: true,
+            model: 'openai/gpt-4o-mini',
+            identity: { emoji: '🦊', accentColor: '#7C3AED' },
+          },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(config));
+      await agentsListHandler([]);
+      expect(noteOutput()).toContain('🦊  Fox Agent');
+    });
+
+    it('renders an ANSI truecolor swatch for the accent color', async () => {
+      const config = {
+        version: 1,
+        agents: [
+          {
+            id: 'fox-agent',
+            name: 'Fox Agent',
+            enabled: true,
+            model: 'openai/gpt-4o-mini',
+            identity: { emoji: '🦊', accentColor: '#7C3AED' },
+          },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(config));
+      await agentsListHandler([]);
+      // #7C3AED -> r=124 g=58 b=237
+      expect(noteOutput()).toContain('\x1b[48;2;124;58;237m');
+      expect(noteOutput()).toContain('\x1b[0m');
+    });
+
+    it('shows no emoji prefix or swatch when identity is absent', async () => {
+      const config = {
+        version: 1,
+        agents: [
+          {
+            id: 'plain-agent',
+            name: 'Plain Agent',
+            enabled: true,
+            model: 'openai/gpt-4o-mini',
+          },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(config));
+      await agentsListHandler([]);
+      expect(noteOutput()).not.toContain('\x1b[48;2;');
+      const firstLine = noteOutput().split('\n')[0];
+      expect(firstLine).toBe('Plain Agent');
+    });
+  });
 });

--- a/packages/cli/src/commands/agents/list.ts
+++ b/packages/cli/src/commands/agents/list.ts
@@ -14,6 +14,8 @@ import type {
   OpenAidyConfig,
 } from '../../types.js';
 
+const ESC = '\x1b';
+
 function resolveConfigPath(): string {
   return resolve(process.env.APP_CONFIG_PATH ?? '.openaidy/openaidy.json');
 }
@@ -28,9 +30,21 @@ async function readAgentConfigs(): Promise<AgentConfig[]> {
   }
 }
 
+/** Render a hex accent color (e.g. "#7C3AED") as a truecolor ANSI background swatch. */
+function colorSwatch(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `${ESC}[48;2;${r};${g};${b}m  ${ESC}[0m`;
+}
+
 function formatAgent(a: AgentConfig): string {
+  const emojiPrefix = a.identity?.emoji ? `${a.identity.emoji}  ` : '';
+  const swatch = a.identity?.accentColor
+    ? `  ${colorSwatch(a.identity.accentColor)}`
+    : '';
   const lines: string[] = [
-    `${a.name}${a.enabled === false ? ' [disabled]' : ''}`,
+    `${emojiPrefix}${a.name}${a.enabled === false ? ' [disabled]' : ''}${swatch}`,
   ];
   lines.push(`ID:     ${a.id}`);
   if (a.description) lines.push(`Desc:   ${a.description}`);

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,6 +4,8 @@
  * Shared type definitions for the OpenAidy CLI.
  */
 
+import type { AgentIdentity } from '@openaidy/shared-types';
+
 /**
  * Output format mode
  */
@@ -107,13 +109,14 @@ export type AgentConfig = {
     workspaces: Array<{ path: string; permissions: WorkspacePermissions }>;
   };
   version?: number;
+  identity?: AgentIdentity;
 };
 
 export type OpenAidyConfig = {
   agents?: AgentConfig[];
 };
 
-export type { CreateAgentInput } from '@openaidy/shared-types';
+export type { CreateAgentInput, AgentIdentity } from '@openaidy/shared-types';
 
 export type SkillSummary = {
   id: string;

--- a/packages/shared-types/src/agents.ts
+++ b/packages/shared-types/src/agents.ts
@@ -23,6 +23,26 @@ export type McpServerRef = {
 };
 
 /**
+ * A renderable visual asset for an agent's identity, layered on top of the
+ * emoji fallback. Discriminated by `kind` so consumers (web, CLI, future
+ * addons) branch on the union instead of inspecting URLs or content-type.
+ */
+export type AgentIdentityAsset =
+  | { kind: 'image'; url: string; alt?: string | undefined }
+  | { kind: 'model3d'; url: string; format: 'gltf' | 'glb' };
+
+/**
+ * Structured visual identity for an agent: emoji + accent color, with an
+ * optional avatar asset override. Optional everywhere it's consumed so
+ * existing agents without an `identity` block continue to load unchanged.
+ */
+export type AgentIdentity = {
+  emoji: string;
+  accentColor: `#${string}`;
+  avatar?: AgentIdentityAsset | undefined;
+};
+
+/**
  * Minimal user-provided fields for creating a new agent.
  * Structural defaults (version, enabled, workspace scaffold) are applied
  * by the server's AgentRegistry.createAgent().
@@ -41,4 +61,5 @@ export type CreateAgentInput = {
    * the new agent. Ignored by agent config storage itself.
    */
   personalityPresetId?: string;
+  identity?: AgentIdentity;
 };

--- a/packages/shared-types/src/agents.ts
+++ b/packages/shared-types/src/agents.ts
@@ -23,6 +23,20 @@ export type McpServerRef = {
 };
 
 /**
+ * Pattern for a 6-digit hex color (e.g. "#7C3AED"). Single source of truth
+ * for identity accent-color validation — consumed by the server's Zod
+ * schema and the CLI's flag/prompt validation so both agree on one rule.
+ */
+export const AGENT_IDENTITY_HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Type guard for a 6-digit hex color string.
+ */
+export function isAgentIdentityHexColor(value: string): value is `#${string}` {
+  return AGENT_IDENTITY_HEX_COLOR_PATTERN.test(value);
+}
+
+/**
  * A renderable visual asset for an agent's identity, layered on top of the
  * emoji fallback. Discriminated by `kind` so consumers (web, CLI, future
  * addons) branch on the union instead of inspecting URLs or content-type.


### PR DESCRIPTION
## Summary

Adds a structured `identity` block (`emoji`, `accentColor`, optional discriminated `avatar` asset) to the agent schema so the web agent picker, `pnpm openaidy agents list`, and `agents create` can render a real visual identity instead of plain text. Fully backward compatible — existing agents without `identity` load and render unchanged.

- **shared-types**: new `AgentIdentity` / `AgentIdentityAsset` types, re-exported from the package root.
- **server**: `IdentitySchema` / `IdentityAssetSchema` wired into `AgentSchema`, `AgentSummary`, `toAgentSummary`; `registry.createAgent` forwards `identity`; new `registry.updateAgentIdentity()`; new `PATCH /agents/:agentId/identity` route (200 / 404 / 400, `identity: null` clears).
- **CLI**: `agents create` prompts for emoji + accent color (curated palette + custom hex, with `--emoji` / `--color` / `--no-identity` flags); `agents list` prepends the emoji and renders a truecolor ANSI swatch for the accent color.
- **web**: `AgentPicker` shows the agent's emoji in the trigger chip and dropdown rows, with an accent-color left border on rows; falls back to the neutral bot icon when identity is absent.
- No Drizzle migration — agents remain file-backed (`config/agents/*.json` / `openaidy.json`).

Closes #502

## Test plan

- [x] `pnpm lint` — clean across all packages
- [x] `pnpm test` — all new/updated suites pass (schema, registry, routes, CLI create/list, `AgentPicker`); three pre-existing Windows-only failures in untouched files (CLI subprocess help output, a path-separator test, a spawn `shell` flag test) are unrelated to this change
- [x] `pnpm -r build` — clean, including typecheck
- [x] Manually verified `IdentitySchema` accepts valid emoji/hex/avatar payloads and rejects bad hex, oversized emoji, and unknown avatar `kind`
