### PR TITLE
feat(addons): expose tasks, pulses, and channels through the addon proxy

### DIFF
--- a/apps/server/src/addons/permission.ts
+++ b/apps/server/src/addons/permission.ts
@@ -24,6 +24,8 @@ export const PERMISSION_RESOURCES = [
   'workspace',
   'logs',
   'storage',
+  'channels',
+  'pulses',
 ] as const;
 
 /**

--- a/apps/server/src/addons/proxy-routes-channels.test.ts
+++ b/apps/server/src/addons/proxy-routes-channels.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Addon proxy routes — channel endpoints
+ *
+ * Tests the HTTP layer for:
+ *   GET  /api/addon-proxy/channels
+ *   GET  /api/addon-proxy/channels/:id/status
+ *   POST /api/addon-proxy/channels/:id/connect
+ *   POST /api/addon-proxy/channels/:id/disconnect
+ *
+ * Uses a minimal Fastify instance with the addonProxyRoutes plugin so we
+ * exercise the full request → auth → permission → service path without
+ * spinning up the entire application.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { addonProxyRoutes } from './proxy-routes';
+import { AddonService } from './service';
+import { ChannelRegistry } from '../channels/registry';
+import type { IChannel } from '../channels/interface';
+import type { Addon } from '@openaidy/db';
+
+const JWT_SECRET = 'test-secret-at-least-32-chars-long!!';
+
+function makeAddonService() {
+  return new AddonService({
+    repository: null as never,
+    validator: null as never,
+    jwtSecret: JWT_SECRET,
+    openAidyVersion: '0.0.0',
+  });
+}
+
+function makeEnabledAddon(addonId: string, permissions: string[]): Addon {
+  return {
+    id: 'db-row-id',
+    addonId,
+    name: 'Test Addon',
+    version: '1.0.0',
+    status: 'enabled',
+    permissions,
+    manifest: { permissions },
+    config: {},
+    installedAt: new Date(),
+    updatedAt: new Date(),
+    installedBy: 'admin',
+  } as unknown as Addon;
+}
+
+function makeChannel(id: string): IChannel {
+  return {
+    id,
+    type: 'whatsapp',
+    agentId: 'default',
+    getStatus: vi.fn().mockReturnValue('connected'),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    onStatusChange: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as IChannel;
+}
+
+function makeChannelRegistry(channels: IChannel[] = []): ChannelRegistry {
+  const registry = new ChannelRegistry();
+  for (const channel of channels) registry.register(channel);
+  return registry;
+}
+
+async function buildProxyApp(opts: {
+  addon: Addon | null;
+  channelRegistry?: ChannelRegistry;
+}): Promise<{ app: FastifyInstance; token: string }> {
+  const addonSvc = makeAddonService();
+
+  const permissions = (opts.addon?.permissions as string[]) ?? [];
+  const addonId = opts.addon?.addonId ?? 'test-addon';
+  const token = (
+    addonSvc as unknown as {
+      generateAccessToken: (id: string, perms: string[]) => string;
+    }
+  ).generateAccessToken(addonId, permissions);
+
+  vi.spyOn(addonSvc as never, 'getAddon' as never).mockResolvedValue(
+    opts.addon as never,
+  );
+  vi.spyOn(addonSvc as never, 'recordUsage' as never).mockResolvedValue(
+    undefined as never,
+  );
+
+  const app = Fastify({ logger: false });
+  await app.register(
+    async (api: FastifyInstance) => {
+      await api.register(addonProxyRoutes, {
+        addonService: addonSvc,
+        authMiddleware: null as never,
+        internalApiBaseUrl: '',
+        ...(opts.channelRegistry
+          ? { channelRegistry: opts.channelRegistry }
+          : {}),
+      });
+    },
+    { prefix: '/api' },
+  );
+
+  return { app, token };
+}
+
+describe('GET /api/addon-proxy/channels', () => {
+  it('returns 403 when addon lacks channels.list permission', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.read']),
+      channelRegistry: makeChannelRegistry([makeChannel('wa-1')]),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/channels',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('PERMISSION_DENIED');
+  });
+
+  it('returns empty items when no channelRegistry is wired', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.list']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/channels',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ items: [] });
+  });
+
+  it('lists channels with their status', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.list']),
+      channelRegistry: makeChannelRegistry([makeChannel('wa-1')]),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/channels',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toEqual([
+      { id: 'wa-1', type: 'whatsapp', status: 'connected', agentId: 'default' },
+    ]);
+  });
+});
+
+describe('GET /api/addon-proxy/channels/:id/status', () => {
+  it('returns 404 when the channel is not found', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.read']),
+      channelRegistry: makeChannelRegistry(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/channels/missing/status',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('CHANNEL_NOT_FOUND');
+  });
+
+  it('returns the channel status', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.read']),
+      channelRegistry: makeChannelRegistry([makeChannel('wa-1')]),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/channels/wa-1/status',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      id: 'wa-1',
+      type: 'whatsapp',
+      status: 'connected',
+      agentId: 'default',
+    });
+  });
+});
+
+describe('POST /api/addon-proxy/channels/:id/connect', () => {
+  it('returns 403 when addon lacks channels.manage permission', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.list']),
+      channelRegistry: makeChannelRegistry([makeChannel('wa-1')]),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/channels/wa-1/connect',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('calls connect() on the channel', async () => {
+    const channel = makeChannel('wa-1');
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.manage']),
+      channelRegistry: makeChannelRegistry([channel]),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/channels/wa-1/connect',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(channel.connect).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/addon-proxy/channels/:id/disconnect', () => {
+  it('calls disconnect() on the channel', async () => {
+    const channel = makeChannel('wa-1');
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.manage']),
+      channelRegistry: makeChannelRegistry([channel]),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/channels/wa-1/disconnect',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(channel.disconnect).toHaveBeenCalled();
+  });
+
+  it('returns 404 when the channel is not found', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['channels.manage']),
+      channelRegistry: makeChannelRegistry(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/channels/missing/disconnect',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/server/src/addons/proxy-routes-pulses.test.ts
+++ b/apps/server/src/addons/proxy-routes-pulses.test.ts
@@ -280,6 +280,54 @@ describe('POST /api/addon-proxy/pulses', () => {
   });
 });
 
+describe('PATCH /api/addon-proxy/pulses/:id', () => {
+  it('returns 404 PULSE_NOT_FOUND when the pulse does not exist', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.write']),
+      jobsRepo: makeJobsRepo(null),
+    });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/addon-proxy/pulses/missing',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: 'Renamed' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('PULSE_NOT_FOUND');
+  });
+
+  it('returns 400 INVALID_SCHEDULE for a malformed cron expression, not a 404', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.write']),
+    });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/addon-proxy/pulses/pulse-1',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { schedule: { cron: { expression: 'not-a-valid-cron' } } },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('INVALID_SCHEDULE');
+  });
+
+  it('updates a pulse', async () => {
+    const jobsRepo = makeJobsRepo();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.write']),
+      jobsRepo,
+    });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/addon-proxy/pulses/pulse-1',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: 'Renamed Pulse' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().pulse.id).toBe('pulse-1');
+    expect(jobsRepo.update).toHaveBeenCalled();
+  });
+});
+
 describe('DELETE /api/addon-proxy/pulses/:id', () => {
   it('deletes a pulse', async () => {
     const jobsRepo = makeJobsRepo();

--- a/apps/server/src/addons/proxy-routes-pulses.test.ts
+++ b/apps/server/src/addons/proxy-routes-pulses.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Addon proxy routes — pulse endpoints
+ *
+ * Tests the HTTP layer for:
+ *   GET    /api/addon-proxy/pulses
+ *   GET    /api/addon-proxy/pulses/:id
+ *   POST   /api/addon-proxy/pulses
+ *   PATCH  /api/addon-proxy/pulses/:id
+ *   DELETE /api/addon-proxy/pulses/:id
+ *   POST   /api/addon-proxy/pulses/:id/trigger
+ *   GET    /api/addon-proxy/pulses/:id/history
+ *
+ * Uses a minimal Fastify instance with the addonProxyRoutes plugin, a mocked
+ * PulseService is not injected directly — instead we wire in-memory
+ * jobsRepo/jobRunsRepo/sessionsRepo stubs, exactly like the real PulseService
+ * is constructed inside proxy-routes.ts, so this exercises the same
+ * construction path as production.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { addonProxyRoutes } from './proxy-routes';
+import { AddonService } from './service';
+import type {
+  Addon,
+  JobsStore,
+  JobRunsStore,
+  SessionsStore,
+} from '@openaidy/db';
+
+const JWT_SECRET = 'test-secret-at-least-32-chars-long!!';
+
+function makeAddonService() {
+  return new AddonService({
+    repository: null as never,
+    validator: null as never,
+    jwtSecret: JWT_SECRET,
+    openAidyVersion: '0.0.0',
+  });
+}
+
+function makeEnabledAddon(addonId: string, permissions: string[]): Addon {
+  return {
+    id: 'db-row-id',
+    addonId,
+    name: 'Test Addon',
+    version: '1.0.0',
+    status: 'enabled',
+    permissions,
+    manifest: { permissions },
+    config: {},
+    installedAt: new Date(),
+    updatedAt: new Date(),
+    installedBy: 'admin',
+  } as unknown as Addon;
+}
+
+const PULSE_JOB = {
+  id: 'pulse-1',
+  type: 'cron' as const,
+  schedule: null,
+  cronExpression: '0 * * * *',
+  targetType: 'isolated' as const,
+  targetSessionId: null,
+  payload: { message: 'Do the thing', agentId: undefined },
+  status: 'active' as const,
+  nextRunAt: new Date('2026-01-01T00:00:00Z'),
+  lastRunAt: null,
+  retryCount: 0,
+  maxRetries: 3,
+  backoffMs: 1000,
+  metadata: { kind: 'pulse', name: 'My Pulse', prompt: 'Do the thing' },
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+function makeJobsRepo(job: typeof PULSE_JOB | null = PULSE_JOB): JobsStore {
+  return {
+    findById: vi.fn().mockResolvedValue(job),
+    create: vi.fn().mockResolvedValue(job),
+    update: vi.fn().mockResolvedValue(job),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue(job ? [job] : []),
+    claimNextDueJob: vi.fn(),
+    countByStatus: vi.fn(),
+    listActive: vi.fn(),
+  } as unknown as JobsStore;
+}
+
+function makeJobRunsRepo(): JobRunsStore {
+  return {
+    findById: vi.fn().mockResolvedValue({
+      id: 'run-1',
+      jobId: 'pulse-1',
+      status: 'succeeded',
+      attemptNumber: 0,
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      errorCode: null,
+      errorMessage: null,
+      resultData: null,
+      createdAt: new Date(),
+    }),
+    create: vi.fn().mockResolvedValue({
+      id: 'run-1',
+      jobId: 'pulse-1',
+      status: 'queued',
+      attemptNumber: 0,
+      startedAt: null,
+      finishedAt: null,
+      errorCode: null,
+      errorMessage: null,
+      resultData: null,
+      createdAt: new Date(),
+    }),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    listByJob: vi.fn().mockResolvedValue([]),
+    getLatestByJob: vi.fn(),
+    countByJobAndStatus: vi.fn(),
+    listByStatus: vi.fn(),
+    deleteByJob: vi.fn(),
+  } as unknown as JobRunsStore;
+}
+
+function makeSessionsRepo(): SessionsStore {
+  return {
+    findById: vi.fn().mockResolvedValue(null),
+  } as unknown as SessionsStore;
+}
+
+async function buildProxyApp(opts: {
+  addon: Addon | null;
+  withPulseDeps?: boolean;
+  jobsRepo?: JobsStore;
+}): Promise<{ app: FastifyInstance; token: string; jobsRepo: JobsStore }> {
+  const addonSvc = makeAddonService();
+
+  const permissions = (opts.addon?.permissions as string[]) ?? [];
+  const addonId = opts.addon?.addonId ?? 'test-addon';
+  const token = (
+    addonSvc as unknown as {
+      generateAccessToken: (id: string, perms: string[]) => string;
+    }
+  ).generateAccessToken(addonId, permissions);
+
+  vi.spyOn(addonSvc as never, 'getAddon' as never).mockResolvedValue(
+    opts.addon as never,
+  );
+  vi.spyOn(addonSvc as never, 'recordUsage' as never).mockResolvedValue(
+    undefined as never,
+  );
+
+  const jobsRepo = opts.jobsRepo ?? makeJobsRepo();
+  const jobRunsRepo = makeJobRunsRepo();
+  const sessionsRepo = makeSessionsRepo();
+
+  const app = Fastify({ logger: false });
+  await app.register(
+    async (api: FastifyInstance) => {
+      await api.register(addonProxyRoutes, {
+        addonService: addonSvc,
+        authMiddleware: null as never,
+        internalApiBaseUrl: '',
+        ...(opts.withPulseDeps !== false
+          ? { jobsRepo, jobRunsRepo, sessionsRepo }
+          : {}),
+      });
+    },
+    { prefix: '/api' },
+  );
+
+  return { app, token, jobsRepo };
+}
+
+describe('GET /api/addon-proxy/pulses', () => {
+  it('returns 403 when addon lacks pulses.list permission', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.read']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('PERMISSION_DENIED');
+  });
+
+  it('returns an empty page when pulse deps are not wired', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.list']),
+      withPulseDeps: false,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ pulses: [], total: 0, limit: 50, offset: 0 });
+  });
+
+  it('lists pulses', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.list']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().pulses).toHaveLength(1);
+    expect(res.json().pulses[0].id).toBe('pulse-1');
+  });
+});
+
+describe('GET /api/addon-proxy/pulses/:id', () => {
+  it('returns 404 when the pulse is not found', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.read']),
+      jobsRepo: makeJobsRepo(null),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses/missing',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('PULSE_NOT_FOUND');
+  });
+
+  it('returns the pulse', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.read']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses/pulse-1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().pulse.id).toBe('pulse-1');
+  });
+});
+
+describe('POST /api/addon-proxy/pulses', () => {
+  it('returns 400 for an invalid body', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.write']),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/pulses',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: 'My Pulse' }, // missing prompt/schedule
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('creates a pulse', async () => {
+    const jobsRepo = makeJobsRepo();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.write']),
+      jobsRepo,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/pulses',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        name: 'My Pulse',
+        prompt: 'Do the thing',
+        schedule: { every: '1h' },
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(jobsRepo.create).toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/addon-proxy/pulses/:id', () => {
+  it('deletes a pulse', async () => {
+    const jobsRepo = makeJobsRepo();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.delete']),
+      jobsRepo,
+    });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/addon-proxy/pulses/pulse-1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(jobsRepo.delete).toHaveBeenCalledWith('pulse-1');
+  });
+
+  it('returns 404 when the pulse does not exist', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.delete']),
+      jobsRepo: makeJobsRepo(null),
+    });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/addon-proxy/pulses/missing',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /api/addon-proxy/pulses/:id/trigger', () => {
+  it('returns 503 when session service is not wired', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.invoke']),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/pulses/pulse-1/trigger',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    // No sessionService was wired in buildProxyApp for this suite.
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('GET /api/addon-proxy/pulses/:id/history', () => {
+  it('returns run history', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['pulses.read']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/pulses/pulse-1/history',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ runs: [], total: 0, limit: 50, offset: 0 });
+  });
+});

--- a/apps/server/src/addons/proxy-routes-tasks.test.ts
+++ b/apps/server/src/addons/proxy-routes-tasks.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Addon proxy routes — task endpoints
+ *
+ * Tests the HTTP layer for:
+ *   GET   /api/addon-proxy/tasks
+ *   GET   /api/addon-proxy/tasks/:id
+ *   POST  /api/addon-proxy/tasks
+ *   PATCH /api/addon-proxy/tasks/:id/status
+ *   GET   /api/addon-proxy/tasks/:id/subtasks
+ *   POST  /api/addon-proxy/tasks/:id/execute
+ *
+ * Uses a minimal Fastify instance with the addonProxyRoutes plugin so we
+ * exercise the full request → auth → permission → service path without
+ * spinning up the entire application.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { addonProxyRoutes } from './proxy-routes';
+import { AddonService } from './service';
+import type { TaskService } from '../tasks/service';
+import type { Addon } from '@openaidy/db';
+
+const JWT_SECRET = 'test-secret-at-least-32-chars-long!!';
+
+function makeAddonService() {
+  return new AddonService({
+    repository: null as never,
+    validator: null as never,
+    jwtSecret: JWT_SECRET,
+    openAidyVersion: '0.0.0',
+  });
+}
+
+function makeEnabledAddon(addonId: string, permissions: string[]): Addon {
+  return {
+    id: 'db-row-id',
+    addonId,
+    name: 'Test Addon',
+    version: '1.0.0',
+    status: 'enabled',
+    permissions,
+    manifest: { permissions },
+    config: {},
+    installedAt: new Date(),
+    updatedAt: new Date(),
+    installedBy: 'admin',
+  } as unknown as Addon;
+}
+
+function makeTaskService(): TaskService {
+  return {
+    listTasks: vi.fn().mockResolvedValue([{ id: 't1', title: 'Task One' }]),
+    getTaskWithDetails: vi.fn().mockResolvedValue({
+      id: 't1',
+      title: 'Task One',
+      subtasks: [],
+      progress: { total: 0, completed: 0, inProgress: 0, failed: 0 },
+    }),
+    createTask: vi.fn().mockResolvedValue({
+      ok: true,
+      data: { id: 't1', title: 'New Task', description: 'A new task' },
+    }),
+    updateTaskStatus: vi.fn().mockResolvedValue({
+      ok: true,
+      data: { id: 't1', status: 'in_progress' },
+    }),
+    getSubtasks: vi
+      .fn()
+      .mockResolvedValue([{ id: 's1', title: 'Subtask One' }]),
+    executeTask: vi
+      .fn()
+      .mockResolvedValue({ ok: true, data: { sessionId: 'sess-1' } }),
+  } as unknown as TaskService;
+}
+
+async function buildProxyApp(opts: {
+  addon: Addon | null;
+  taskService?: TaskService;
+}): Promise<{ app: FastifyInstance; token: string }> {
+  const addonSvc = makeAddonService();
+
+  const permissions = (opts.addon?.permissions as string[]) ?? [];
+  const addonId = opts.addon?.addonId ?? 'test-addon';
+  const token = (
+    addonSvc as unknown as {
+      generateAccessToken: (id: string, perms: string[]) => string;
+    }
+  ).generateAccessToken(addonId, permissions);
+
+  vi.spyOn(addonSvc as never, 'getAddon' as never).mockResolvedValue(
+    opts.addon as never,
+  );
+  vi.spyOn(addonSvc as never, 'recordUsage' as never).mockResolvedValue(
+    undefined as never,
+  );
+
+  const app = Fastify({ logger: false });
+  await app.register(
+    async (api: FastifyInstance) => {
+      await api.register(addonProxyRoutes, {
+        addonService: addonSvc,
+        authMiddleware: null as never,
+        internalApiBaseUrl: '',
+        ...(opts.taskService ? { taskService: opts.taskService } : {}),
+      });
+    },
+    { prefix: '/api' },
+  );
+
+  return { app, token };
+}
+
+describe('GET /api/addon-proxy/tasks', () => {
+  it('returns 403 when addon lacks tasks.list permission', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.read']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('PERMISSION_DENIED');
+  });
+
+  it('returns empty items when no taskService is wired', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.list']),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ items: [] });
+  });
+
+  it('lists tasks from the taskService', async () => {
+    const taskService = makeTaskService();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.list']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks?status=todo',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toHaveLength(1);
+    expect(taskService.listTasks).toHaveBeenCalledWith('todo');
+  });
+});
+
+describe('GET /api/addon-proxy/tasks/:id', () => {
+  it('returns 404 when the task is not found', async () => {
+    const taskService = makeTaskService();
+    (
+      taskService.getTaskWithDetails as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.read']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks/missing',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('TASK_NOT_FOUND');
+  });
+
+  it('returns the task with details', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.read']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks/t1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().task.id).toBe('t1');
+  });
+});
+
+describe('POST /api/addon-proxy/tasks', () => {
+  it('returns 400 when description is missing', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/tasks',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('INVALID_REQUEST');
+  });
+
+  it('derives a title from the description when none is given', async () => {
+    const taskService = makeTaskService();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/tasks',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { description: 'Do the thing' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(taskService.createTask).toHaveBeenCalledWith({
+      title: 'Do the thing',
+      description: 'Do the thing',
+    });
+  });
+
+  it('creates a task with an explicit title and priority', async () => {
+    const taskService = makeTaskService();
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/tasks',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        title: 'My Task',
+        description: 'Do the thing',
+        priority: 'urgent',
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(taskService.createTask).toHaveBeenCalledWith({
+      title: 'My Task',
+      description: 'Do the thing',
+      priority: 'urgent',
+    });
+  });
+});
+
+describe('PATCH /api/addon-proxy/tasks/:id/status', () => {
+  it('returns 404 when the task is not found', async () => {
+    const taskService = makeTaskService();
+    (
+      taskService.updateTaskStatus as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      ok: false,
+      error: { code: 'task.not_found', message: 'Task not found' },
+    });
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/addon-proxy/tasks/missing/status',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { status: 'done' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('updates the task status', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/addon-proxy/tasks/t1/status',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { status: 'in_progress' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().task.status).toBe('in_progress');
+  });
+});
+
+describe('GET /api/addon-proxy/tasks/:id/subtasks', () => {
+  it('returns 403 when addon lacks tasks.read permission', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.write']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks/t1/subtasks',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('lists subtasks', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.read']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/addon-proxy/tasks/t1/subtasks',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toHaveLength(1);
+  });
+});
+
+describe('POST /api/addon-proxy/tasks/:id/execute', () => {
+  it('returns 503 when session service is not configured', async () => {
+    const taskService = makeTaskService();
+    (taskService.executeTask as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      error: {
+        code: 'session.not_configured',
+        message: 'Session service is not configured',
+      },
+    });
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.invoke']),
+      taskService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/tasks/t1/execute',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('executes the task and returns a sessionId', async () => {
+    const { app, token } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['tasks.invoke']),
+      taskService: makeTaskService(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/tasks/t1/execute',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().sessionId).toBe('sess-1');
+  });
+});

--- a/apps/server/src/addons/proxy-routes.ts
+++ b/apps/server/src/addons/proxy-routes.ts
@@ -1,9 +1,21 @@
 import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import type { Addon, TaskPriority } from '@openaidy/db';
 import type { AddonProxyRoutesOptions, InvokeAgentBody } from './types';
 import { createAddonProxyService } from '../addons/proxy';
 import { AddonProxyAgentService } from './proxy-agent-service';
 import { AddonStorageError } from './storage/engine';
 import type { StorageParams } from './storage/engine';
+import { PulseService } from '../pulses/service.js';
+import { triggerPulseNow } from '../scheduler';
+import {
+  createPulseSchema,
+  updatePulseSchema,
+  listPulsesSchema,
+  listRunsSchema,
+  toScheduleInput,
+} from '../pulses/schemas.js';
+import { toStatusResponse } from '../channels/status.js';
 
 // Extend FastifyRequest to include addon context
 declare module 'fastify' {
@@ -317,12 +329,10 @@ export const addonProxyRoutes: FastifyPluginAsync<
     permission: 'storage.read' | 'storage.write',
   ): Promise<{ migrations: string[] } | null> => {
     if (!opts.storageEngine) {
-      reply
-        .code(503)
-        .send({
-          error: 'SERVICE_UNAVAILABLE',
-          message: 'Storage not available',
-        });
+      reply.code(503).send({
+        error: 'SERVICE_UNAVAILABLE',
+        message: 'Storage not available',
+      });
       return null;
     }
     const addon = await opts.addonService.getAddon(request.addonId!);
@@ -494,6 +504,651 @@ export const addonProxyRoutes: FastifyPluginAsync<
           limit,
         ),
       }));
+    },
+  );
+
+  // ==========================================================================
+  // Shared helper for the routes below (tasks/pulses/channels) — resolve the
+  // addon and check one permission, sending the 404/403 response itself on
+  // failure. Mirrors `forStorage` above but permission-generic.
+  // ==========================================================================
+  const getAuthorizedAddon = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    permission: string,
+  ): Promise<Addon | null> => {
+    const addon = await opts.addonService.getAddon(request.addonId!);
+    if (!addon) {
+      reply
+        .code(404)
+        .send({ error: 'ADDON_NOT_FOUND', message: 'Addon not found' });
+      return null;
+    }
+    const authResult = proxyService.authorize(addon, permission);
+    if (!authResult.authorized) {
+      reply
+        .code(403)
+        .send({ error: 'PERMISSION_DENIED', message: authResult.error });
+      return null;
+    }
+    return addon;
+  };
+
+  // ==========================================================================
+  // Tasks — /addon-proxy/tasks/*
+  // ==========================================================================
+  //
+  // Deliberately narrower than the web-facing /api/tasks surface: no agent
+  // assignment, no scheduling, no subtask CRUD/execution-history — just
+  // enough for an addon to create, read, and drive a task to completion.
+
+  const TASK_STATUSES = [
+    'backlog',
+    'todo',
+    'in_progress',
+    'review',
+    'done',
+    'cancelled',
+  ] as const;
+
+  const createAddonTaskSchema = z.object({
+    title: z.string().min(1).optional(),
+    description: z.string().min(1),
+    priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
+  });
+
+  const updateTaskStatusBodySchema = z.object({
+    status: z.enum(TASK_STATUSES),
+  });
+
+  // GET /api/addon-proxy/tasks
+  app.get<{ Querystring: { status?: string } }>(
+    '/addon-proxy/tasks',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.list');
+      if (!addon) return;
+      if (!opts.taskService) return reply.send({ items: [] });
+
+      await proxyService.recordUsage(request.addonId!, '/tasks');
+      const status = request.query.status as
+        | (typeof TASK_STATUSES)[number]
+        | undefined;
+      const items = await opts.taskService.listTasks(status);
+      return reply.send({ items });
+    },
+  );
+
+  // GET /api/addon-proxy/tasks/:id
+  app.get<{ Params: { id: string } }>(
+    '/addon-proxy/tasks/:id',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.read');
+      if (!addon) return;
+      if (!opts.taskService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Tasks not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/tasks/:id');
+      const task = await opts.taskService.getTaskWithDetails(request.params.id);
+      if (!task) {
+        return reply
+          .code(404)
+          .send({ error: 'TASK_NOT_FOUND', message: 'Task not found' });
+      }
+      return reply.send({ task });
+    },
+  );
+
+  // POST /api/addon-proxy/tasks
+  app.post<{
+    Body: { title?: string; description: string; priority?: string };
+  }>(
+    '/addon-proxy/tasks',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.write');
+      if (!addon) return;
+      if (!opts.taskService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Tasks not available',
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = createAddonTaskSchema.parse(request.body);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/tasks');
+      const derivedTitle =
+        parsed.title ??
+        (parsed.description.length > 60
+          ? `${parsed.description.slice(0, 60).trimEnd()}…`
+          : parsed.description);
+
+      const createInput: {
+        title: string;
+        description: string;
+        priority?: TaskPriority;
+      } = {
+        title: derivedTitle,
+        description: parsed.description,
+      };
+      if (parsed.priority !== undefined) {
+        createInput.priority = parsed.priority as TaskPriority;
+      }
+
+      const result = await opts.taskService.createTask(createInput);
+      if (!result.ok) {
+        return reply
+          .code(500)
+          .send({ error: result.error.code, message: result.error.message });
+      }
+      return reply.code(201).send({ task: result.data });
+    },
+  );
+
+  // PATCH /api/addon-proxy/tasks/:id/status
+  app.patch<{ Params: { id: string }; Body: { status: string } }>(
+    '/addon-proxy/tasks/:id/status',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.write');
+      if (!addon) return;
+      if (!opts.taskService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Tasks not available',
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = updateTaskStatusBodySchema.parse(request.body);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/tasks/:id/status');
+      const result = await opts.taskService.updateTaskStatus(
+        request.params.id,
+        parsed.status,
+      );
+      if (!result.ok) {
+        const status = result.error.code === 'task.not_found' ? 404 : 500;
+        return reply
+          .code(status)
+          .send({ error: result.error.code, message: result.error.message });
+      }
+      return reply.send({ task: result.data });
+    },
+  );
+
+  // GET /api/addon-proxy/tasks/:id/subtasks
+  app.get<{ Params: { id: string } }>(
+    '/addon-proxy/tasks/:id/subtasks',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.read');
+      if (!addon) return;
+      if (!opts.taskService) return reply.send({ items: [] });
+
+      await proxyService.recordUsage(request.addonId!, '/tasks/:id/subtasks');
+      const items = await opts.taskService.getSubtasks(request.params.id);
+      return reply.send({ items });
+    },
+  );
+
+  // POST /api/addon-proxy/tasks/:id/execute
+  app.post<{ Params: { id: string } }>(
+    '/addon-proxy/tasks/:id/execute',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'tasks.invoke');
+      if (!addon) return;
+      if (!opts.taskService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Tasks not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/tasks/:id/execute');
+      const result = await opts.taskService.executeTask(request.params.id);
+      if (!result.ok) {
+        const status =
+          result.error.code === 'task.not_found'
+            ? 404
+            : result.error.code === 'session.not_configured'
+              ? 503
+              : 500;
+        return reply
+          .code(status)
+          .send({ error: result.error.code, message: result.error.message });
+      }
+      return reply.send({ sessionId: result.data.sessionId });
+    },
+  );
+
+  // ==========================================================================
+  // Pulses — /addon-proxy/pulses/*
+  // ==========================================================================
+  //
+  // Full CRUD + trigger + history, mirroring `routes/pulses.ts` almost 1:1
+  // (pulses are inherently an automation primitive addons should be able to
+  // fully drive) — just gated behind addon permissions instead of user auth.
+
+  const pulseService =
+    opts.jobsRepo && opts.jobRunsRepo && opts.sessionsRepo
+      ? new PulseService(opts.jobsRepo, opts.jobRunsRepo, opts.sessionsRepo)
+      : undefined;
+
+  // GET /api/addon-proxy/pulses
+  app.get<{ Querystring: Record<string, string | undefined> }>(
+    '/addon-proxy/pulses',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.list');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.send({ pulses: [], total: 0, limit: 50, offset: 0 });
+      }
+
+      let parsed;
+      try {
+        parsed = listPulsesSchema.parse(request.query);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid query parameters',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses');
+      const listInput: import('@openaidy/shared-types').ListPulsesFilters = {
+        limit: parsed.limit,
+        offset: parsed.offset,
+      };
+      if (parsed.status !== undefined) listInput.status = parsed.status;
+      const result = await pulseService.listPulses(listInput);
+      return reply.send({
+        pulses: result.items,
+        total: result.total,
+        limit: result.limit,
+        offset: result.offset,
+      });
+    },
+  );
+
+  // GET /api/addon-proxy/pulses/:id
+  app.get<{ Params: { id: string } }>(
+    '/addon-proxy/pulses/:id',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.read');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses/:id');
+      try {
+        const pulse = await pulseService.getPulse(request.params.id);
+        return reply.send({ pulse });
+      } catch {
+        return reply
+          .code(404)
+          .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+      }
+    },
+  );
+
+  // POST /api/addon-proxy/pulses
+  app.post<{ Body: unknown }>(
+    '/addon-proxy/pulses',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.write');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = createPulseSchema.parse(request.body);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses');
+      try {
+        const input: import('@openaidy/shared-types').CreatePulseInput = {
+          name: parsed.name,
+          prompt: parsed.prompt,
+          schedule: toScheduleInput(parsed.schedule),
+        };
+        if (parsed.agentId != null) input.agentId = parsed.agentId;
+        if (parsed.sessionId != null) input.sessionId = parsed.sessionId;
+        const pulse = await pulseService.createPulse(input);
+        return reply.code(201).send({ pulse });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('not found')) {
+          return reply
+            .code(404)
+            .send({ error: 'SESSION_NOT_FOUND', message: msg });
+        }
+        return reply
+          .code(400)
+          .send({ error: 'INVALID_SCHEDULE', message: msg });
+      }
+    },
+  );
+
+  // PATCH /api/addon-proxy/pulses/:id
+  app.patch<{ Params: { id: string }; Body: unknown }>(
+    '/addon-proxy/pulses/:id',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.write');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = updatePulseSchema.parse(request.body);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses/:id');
+      try {
+        const input: import('@openaidy/shared-types').UpdatePulseInput = {};
+        if (parsed.name !== undefined) input.name = parsed.name;
+        if (parsed.prompt !== undefined) input.prompt = parsed.prompt;
+        if (parsed.schedule !== undefined) {
+          input.schedule = toScheduleInput(parsed.schedule);
+        }
+        if (parsed.status !== undefined) input.status = parsed.status;
+        if (parsed.agentId !== undefined) input.agentId = parsed.agentId;
+        if (parsed.sessionId !== undefined) input.sessionId = parsed.sessionId;
+        const pulse = await pulseService.updatePulse(request.params.id, input);
+        return reply.send({ pulse });
+      } catch {
+        return reply
+          .code(404)
+          .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+      }
+    },
+  );
+
+  // DELETE /api/addon-proxy/pulses/:id
+  app.delete<{ Params: { id: string } }>(
+    '/addon-proxy/pulses/:id',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.delete');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses/:id');
+      try {
+        await pulseService.deletePulse(request.params.id);
+        return reply.code(204).send();
+      } catch {
+        return reply
+          .code(404)
+          .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+      }
+    },
+  );
+
+  // POST /api/addon-proxy/pulses/:id/trigger
+  app.post<{ Params: { id: string } }>(
+    '/addon-proxy/pulses/:id/trigger',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.invoke');
+      if (!addon) return;
+      if (
+        !pulseService ||
+        !opts.jobsRepo ||
+        !opts.jobRunsRepo ||
+        !opts.sessionsRepo ||
+        !opts.sessionService
+      ) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses/:id/trigger');
+      try {
+        const run = await pulseService.triggerPulse(
+          request.params.id,
+          (jobId) =>
+            triggerPulseNow(jobId, {
+              jobsRepo: opts.jobsRepo!,
+              jobRunsRepo: opts.jobRunsRepo!,
+              sessionsStore: opts.sessionsRepo!,
+              sessionMessageService: opts.sessionService!,
+              logger: app.log,
+            }),
+        );
+        const updatedRun = await opts.jobRunsRepo.findById(run.id);
+        return reply.send({ run: updatedRun ?? run });
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Job not found') {
+          return reply
+            .code(404)
+            .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+        }
+        return reply.code(500).send({
+          error: 'PULSE_TRIGGER_FAILED',
+          message: error instanceof Error ? error.message : 'Trigger failed',
+        });
+      }
+    },
+  );
+
+  // GET /api/addon-proxy/pulses/:id/history
+  app.get<{
+    Params: { id: string };
+    Querystring: { limit?: string; offset?: string };
+  }>(
+    '/addon-proxy/pulses/:id/history',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'pulses.read');
+      if (!addon) return;
+      if (!pulseService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Pulses not available',
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = listRunsSchema.parse(request.query);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid query parameters',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/pulses/:id/history');
+      try {
+        const result = await pulseService.getPulseHistory(request.params.id, {
+          limit: parsed.limit,
+          offset: parsed.offset,
+        });
+        return reply.send({
+          runs: result.items,
+          total: result.total,
+          limit: result.limit,
+          offset: result.offset,
+        });
+      } catch {
+        return reply
+          .code(404)
+          .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+      }
+    },
+  );
+
+  // ==========================================================================
+  // Channels — /addon-proxy/channels/* (read-only + connect/disconnect)
+  // ==========================================================================
+  //
+  // No outbound "send a message" capability exists anywhere in the codebase
+  // yet — channels are purely reactive. Mirrors `routes/channels.ts` exactly.
+
+  // GET /api/addon-proxy/channels
+  app.get(
+    '/addon-proxy/channels',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'channels.list');
+      if (!addon) return;
+      if (!opts.channelRegistry) return reply.send({ items: [] });
+
+      await proxyService.recordUsage(request.addonId!, '/channels');
+      const items = opts.channelRegistry.getAll().map(toStatusResponse);
+      return reply.send({ items });
+    },
+  );
+
+  // GET /api/addon-proxy/channels/:id/status
+  app.get<{ Params: { id: string } }>(
+    '/addon-proxy/channels/:id/status',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'channels.read');
+      if (!addon) return;
+      if (!opts.channelRegistry) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Channels not available',
+        });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/channels/:id/status');
+      const channel = opts.channelRegistry.get(request.params.id);
+      if (!channel) {
+        return reply
+          .code(404)
+          .send({ error: 'CHANNEL_NOT_FOUND', message: 'Channel not found' });
+      }
+      return reply.send(toStatusResponse(channel));
+    },
+  );
+
+  // POST /api/addon-proxy/channels/:id/connect
+  app.post<{ Params: { id: string } }>(
+    '/addon-proxy/channels/:id/connect',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'channels.manage');
+      if (!addon) return;
+      if (!opts.channelRegistry) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Channels not available',
+        });
+      }
+
+      const channel = opts.channelRegistry.get(request.params.id);
+      if (!channel) {
+        return reply
+          .code(404)
+          .send({ error: 'CHANNEL_NOT_FOUND', message: 'Channel not found' });
+      }
+
+      await proxyService.recordUsage(request.addonId!, '/channels/:id/connect');
+      // Fire-and-forget — connect() is async and may take time (QR flow).
+      channel.connect().catch((err) => {
+        app.log.error(
+          { err, channelId: request.params.id },
+          'addon channel connect error',
+        );
+      });
+      return reply.code(204).send();
+    },
+  );
+
+  // POST /api/addon-proxy/channels/:id/disconnect
+  app.post<{ Params: { id: string } }>(
+    '/addon-proxy/channels/:id/disconnect',
+    { preHandler: validateAddonToken },
+    async (request, reply) => {
+      const addon = await getAuthorizedAddon(request, reply, 'channels.manage');
+      if (!addon) return;
+      if (!opts.channelRegistry) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Channels not available',
+        });
+      }
+
+      const channel = opts.channelRegistry.get(request.params.id);
+      if (!channel) {
+        return reply
+          .code(404)
+          .send({ error: 'CHANNEL_NOT_FOUND', message: 'Channel not found' });
+      }
+
+      await proxyService.recordUsage(
+        request.addonId!,
+        '/channels/:id/disconnect',
+      );
+      await channel.disconnect();
+      return reply.code(204).send();
     },
   );
 

--- a/apps/server/src/addons/proxy-routes.ts
+++ b/apps/server/src/addons/proxy-routes.ts
@@ -911,10 +911,21 @@ export const addonProxyRoutes: FastifyPluginAsync<
         if (parsed.sessionId !== undefined) input.sessionId = parsed.sessionId;
         const pulse = await pulseService.updatePulse(request.params.id, input);
         return reply.send({ pulse });
-      } catch {
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg === 'Pulse not found') {
+          return reply
+            .code(404)
+            .send({ error: 'PULSE_NOT_FOUND', message: msg });
+        }
+        if (msg.includes('not found')) {
+          return reply
+            .code(404)
+            .send({ error: 'SESSION_NOT_FOUND', message: msg });
+        }
         return reply
-          .code(404)
-          .send({ error: 'PULSE_NOT_FOUND', message: 'Pulse not found' });
+          .code(400)
+          .send({ error: 'INVALID_SCHEDULE', message: msg });
       }
     },
   );
@@ -952,12 +963,13 @@ export const addonProxyRoutes: FastifyPluginAsync<
     async (request, reply) => {
       const addon = await getAuthorizedAddon(request, reply, 'pulses.invoke');
       if (!addon) return;
+      const { jobsRepo, jobRunsRepo, sessionsRepo, sessionService } = opts;
       if (
         !pulseService ||
-        !opts.jobsRepo ||
-        !opts.jobRunsRepo ||
-        !opts.sessionsRepo ||
-        !opts.sessionService
+        !jobsRepo ||
+        !jobRunsRepo ||
+        !sessionsRepo ||
+        !sessionService
       ) {
         return reply.code(503).send({
           error: 'SERVICE_UNAVAILABLE',
@@ -971,14 +983,14 @@ export const addonProxyRoutes: FastifyPluginAsync<
           request.params.id,
           (jobId) =>
             triggerPulseNow(jobId, {
-              jobsRepo: opts.jobsRepo!,
-              jobRunsRepo: opts.jobRunsRepo!,
-              sessionsStore: opts.sessionsRepo!,
-              sessionMessageService: opts.sessionService!,
+              jobsRepo,
+              jobRunsRepo,
+              sessionsStore: sessionsRepo,
+              sessionMessageService: sessionService,
               logger: app.log,
             }),
         );
-        const updatedRun = await opts.jobRunsRepo.findById(run.id);
+        const updatedRun = await jobRunsRepo.findById(run.id);
         return reply.send({ run: updatedRun ?? run });
       } catch (error) {
         if (error instanceof Error && error.message === 'Job not found') {

--- a/apps/server/src/addons/types.ts
+++ b/apps/server/src/addons/types.ts
@@ -5,9 +5,12 @@
  */
 
 import type { AddonManifest } from '@openaidy/shared-types';
+import type { JobsStore, JobRunsStore, SessionsStore } from '@openaidy/db';
 import type { AuthMiddleware } from '../websocket/middleware/auth';
 import type { SessionMessageService } from '../sessions/service';
 import type { AgentRegistry } from '../agents/registry';
+import type { TaskService } from '../tasks/service';
+import type { ChannelRegistry } from '../channels/registry';
 
 // Forward declaration to avoid circular dependency
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,6 +26,12 @@ export interface AddonProxyRoutesOptions {
   sessionService?: SessionMessageService;
   agentRegistry?: AgentRegistry;
   storageEngine?: import('./storage/engine').AddonStorageEngine;
+  taskService?: TaskService;
+  channelRegistry?: ChannelRegistry;
+  /** Pulses need their own PulseService, constructed lazily from these three. */
+  jobsRepo?: JobsStore;
+  jobRunsRepo?: JobRunsStore;
+  sessionsRepo?: SessionsStore;
 }
 
 /**

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -883,6 +883,15 @@ export async function buildApp() {
           sessionService,
           agentRegistry,
           storageEngine: addonStorageEngine,
+          ...(taskService ? { taskService } : {}),
+          channelRegistry: services.channels,
+          ...(dbAdapter
+            ? {
+                jobsRepo: dbAdapter.repositories.jobs,
+                jobRunsRepo: dbAdapter.repositories.jobRuns,
+                sessionsRepo: dbAdapter.repositories.sessions,
+              }
+            : {}),
         });
       }
     },

--- a/apps/server/src/channels/status.ts
+++ b/apps/server/src/channels/status.ts
@@ -1,0 +1,18 @@
+/**
+ * Channel status projection
+ *
+ * Shared between the web-facing `/api/channels` routes and the addon-proxy
+ * `/api/addon-proxy/channels` routes, so both report the exact same shape.
+ */
+
+import type { IChannel } from './interface.js';
+import type { ChannelStatusResponse } from '@openaidy/shared-types';
+
+export function toStatusResponse(channel: IChannel): ChannelStatusResponse {
+  return {
+    id: channel.id,
+    type: channel.type,
+    status: channel.getStatus(),
+    agentId: channel.agentId,
+  };
+}

--- a/apps/server/src/pulses/schemas.ts
+++ b/apps/server/src/pulses/schemas.ts
@@ -1,0 +1,82 @@
+/**
+ * Pulse request schemas
+ *
+ * Shared between the web-facing `/api/pulses` routes and the addon-proxy
+ * `/api/addon-proxy/pulses` routes, so schedule validation has one source of
+ * truth regardless of caller.
+ */
+
+import { z } from 'zod';
+
+export const pulseScheduleSchema = z.union([
+  z.object({
+    every: z.enum(['15m', '30m', '1h', '6h', '12h', '1d', '1w']),
+  }),
+  z.object({
+    daily: z.object({
+      hour: z.number().int().min(0).max(23),
+      minute: z.number().int().min(0).max(59),
+    }),
+  }),
+  z.object({
+    cron: z.object({
+      expression: z.string(),
+      tz: z.string().optional(),
+    }),
+  }),
+  z.object({
+    at: z.string(),
+  }),
+]);
+
+export const createPulseSchema = z.object({
+  name: z.string().min(1),
+  prompt: z.string().min(1),
+  schedule: pulseScheduleSchema,
+  agentId: z.string().optional(),
+  sessionId: z.string().uuid().optional(),
+});
+
+export const updatePulseSchema = z.object({
+  name: z.string().min(1).optional(),
+  prompt: z.string().min(1).optional(),
+  schedule: pulseScheduleSchema.optional(),
+  status: z.enum(['active', 'paused']).optional(),
+  agentId: z.string().optional(),
+  sessionId: z.string().uuid().optional(),
+});
+
+export const listPulsesSchema = z.object({
+  status: z.enum(['active', 'paused', 'completed', 'failed']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const listRunsSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export function toScheduleInput(
+  schedule: z.infer<typeof pulseScheduleSchema>,
+): import('@openaidy/shared-types').ScheduleInput {
+  if ('every' in schedule) {
+    return { every: schedule.every };
+  }
+  if ('daily' in schedule) {
+    return { daily: schedule.daily };
+  }
+  if ('cron' in schedule) {
+    const result: import('@openaidy/shared-types').ScheduleInput = {
+      cron: schedule.cron.expression,
+    };
+    if (schedule.cron.tz !== undefined) {
+      (result as { cron: string; tz?: string }).tz = schedule.cron.tz;
+    }
+    return result;
+  }
+  if ('at' in schedule) {
+    return { at: schedule.at };
+  }
+  throw new Error('Invalid schedule format');
+}

--- a/apps/server/src/routes/channels.ts
+++ b/apps/server/src/routes/channels.ts
@@ -1,20 +1,10 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { requireAuth } from '../middleware/require-auth.js';
-import type { IChannel } from '../channels/interface.js';
-import type { ChannelStatusResponse } from '@openaidy/shared-types';
 import type { ChannelRoutesOptions } from '../types.js';
 import { createLogger } from '../lib/logger.js';
+import { toStatusResponse } from '../channels/status.js';
 
 const log = createLogger('channel-routes');
-
-function toStatusResponse(channel: IChannel): ChannelStatusResponse {
-  return {
-    id: channel.id,
-    type: channel.type,
-    status: channel.getStatus(),
-    agentId: channel.agentId,
-  };
-}
 
 export const channelRoutes: FastifyPluginAsync<ChannelRoutesOptions> = async (
   app,

--- a/apps/server/src/routes/pulses.ts
+++ b/apps/server/src/routes/pulses.ts
@@ -1,5 +1,4 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { z } from 'zod';
 import type { JobsStore, JobRunsStore, SessionsStore } from '@openaidy/db';
 import type { SessionMessageService } from '../sessions/service';
 import { triggerPulseNow } from '../scheduler';
@@ -7,108 +6,15 @@ import type { AuthMiddleware } from '../websocket/middleware/auth';
 import { requireAuth } from '../middleware/require-auth';
 import { PulseService } from '../pulses/service.js';
 import { createLogger } from '../lib/logger';
+import {
+  createPulseSchema,
+  updatePulseSchema,
+  listPulsesSchema,
+  listRunsSchema,
+  toScheduleInput,
+} from '../pulses/schemas.js';
 
 const log = createLogger('pulse-routes');
-
-// ========================================
-// Schemas (API input validation only)
-// ========================================
-
-const createPulseSchema = z.object({
-  name: z.string().min(1),
-  prompt: z.string().min(1),
-  schedule: z.union([
-    z.object({
-      every: z.enum(['15m', '30m', '1h', '6h', '12h', '1d', '1w']),
-    }),
-    z.object({
-      daily: z.object({
-        hour: z.number().int().min(0).max(23),
-        minute: z.number().int().min(0).max(59),
-      }),
-    }),
-    z.object({
-      cron: z.object({
-        expression: z.string(),
-        tz: z.string().optional(),
-      }),
-    }),
-    z.object({
-      at: z.string(),
-    }),
-  ]),
-  agentId: z.string().optional(),
-  sessionId: z.string().uuid().optional(),
-});
-
-const updatePulseSchema = z.object({
-  name: z.string().min(1).optional(),
-  prompt: z.string().min(1).optional(),
-  schedule: z
-    .union([
-      z.object({
-        every: z.enum(['15m', '30m', '1h', '6h', '12h', '1d', '1w']),
-      }),
-      z.object({
-        daily: z.object({
-          hour: z.number().int().min(0).max(23),
-          minute: z.number().int().min(0).max(59),
-        }),
-      }),
-      z.object({
-        cron: z.object({
-          expression: z.string(),
-          tz: z.string().optional(),
-        }),
-      }),
-      z.object({
-        at: z.string(),
-      }),
-    ])
-    .optional(),
-  status: z.enum(['active', 'paused']).optional(),
-  agentId: z.string().optional(),
-  sessionId: z.string().uuid().optional(),
-});
-
-const listPulsesSchema = z.object({
-  status: z.enum(['active', 'paused', 'completed', 'failed']).optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(50),
-  offset: z.coerce.number().int().min(0).default(0),
-});
-
-const listRunsSchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).default(50),
-  offset: z.coerce.number().int().min(0).default(0),
-});
-
-// ========================================
-// API → Service input converters
-// ========================================
-
-function toScheduleInput(
-  schedule: z.infer<typeof createPulseSchema>['schedule'],
-): import('@openaidy/shared-types').ScheduleInput {
-  if ('every' in schedule) {
-    return { every: schedule.every };
-  }
-  if ('daily' in schedule) {
-    return { daily: schedule.daily };
-  }
-  if ('cron' in schedule) {
-    const result: import('@openaidy/shared-types').ScheduleInput = {
-      cron: schedule.cron.expression,
-    };
-    if (schedule.cron.tz !== undefined) {
-      (result as { cron: string; tz?: string }).tz = schedule.cron.tz;
-    }
-    return result;
-  }
-  if ('at' in schedule) {
-    return { at: schedule.at };
-  }
-  throw new Error('Invalid schedule format');
-}
 
 // ========================================
 // Route options

--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -535,6 +535,141 @@
       },
     },
 
+    // ── Tasks ─────────────────────────────────────────────────────────────
+    // Requires `tasks.list` / `tasks.read` / `tasks.write` / `tasks.invoke`.
+    // A deliberately narrower surface than the web UI's task API: no agent
+    // assignment, no scheduling, no subtask CRUD.
+    tasks: {
+      /** List tasks, optionally filtered by status. Resolves {items}. */
+      list: function (status) {
+        return request(
+          'GET',
+          '/api/addon-proxy/tasks' +
+            (status ? '?status=' + encodeURIComponent(status) : ''),
+        );
+      },
+      /** Get a task with its subtasks and progress. Resolves {task}. */
+      get: function (id) {
+        return request('GET', '/api/addon-proxy/tasks/' + id);
+      },
+      /** Create a task. `input` is {title?, description, priority?}. Resolves {task}. */
+      create: function (input) {
+        return request('POST', '/api/addon-proxy/tasks', input);
+      },
+      /** Update a task's status. Resolves {task}. */
+      updateStatus: function (id, status) {
+        return request('PATCH', '/api/addon-proxy/tasks/' + id + '/status', {
+          status: status,
+        });
+      },
+      /** List a task's subtasks. Resolves {items}. */
+      listSubtasks: function (id) {
+        return request('GET', '/api/addon-proxy/tasks/' + id + '/subtasks');
+      },
+      /** Start executing a task. Blocks on real work — allow the long timeout. */
+      execute: function (id) {
+        return request(
+          'POST',
+          '/api/addon-proxy/tasks/' + id + '/execute',
+          undefined,
+          AGENT_REQUEST_TIMEOUT_MS,
+        );
+      },
+    },
+
+    // ── Pulses ────────────────────────────────────────────────────────────
+    // Requires `pulses.list` / `pulses.read` / `pulses.write` /
+    // `pulses.delete` / `pulses.invoke`.
+    pulses: {
+      /** List pulses. `filters` is {status?, limit?, offset?}. Resolves {pulses,total,limit,offset}. */
+      list: function (filters) {
+        filters = filters || {};
+        var params = [];
+        if (filters.status) {
+          params.push('status=' + encodeURIComponent(filters.status));
+        }
+        if (filters.limit != null) params.push('limit=' + filters.limit);
+        if (filters.offset != null) params.push('offset=' + filters.offset);
+        return request(
+          'GET',
+          '/api/addon-proxy/pulses' +
+            (params.length ? '?' + params.join('&') : ''),
+        );
+      },
+      /** Get a single pulse. Resolves {pulse}. */
+      get: function (id) {
+        return request('GET', '/api/addon-proxy/pulses/' + id);
+      },
+      /** Create a pulse. `input` is {name, prompt, schedule, agentId?, sessionId?}. Resolves {pulse}. */
+      create: function (input) {
+        return request('POST', '/api/addon-proxy/pulses', input);
+      },
+      /** Partially update a pulse. Resolves {pulse}. */
+      update: function (id, input) {
+        return request('PATCH', '/api/addon-proxy/pulses/' + id, input);
+      },
+      /** Delete a pulse. */
+      delete: function (id) {
+        return request('DELETE', '/api/addon-proxy/pulses/' + id);
+      },
+      /** Trigger a pulse to run right now. Blocks on the run — allow the long timeout. Resolves {run}. */
+      trigger: function (id) {
+        return request(
+          'POST',
+          '/api/addon-proxy/pulses/' + id + '/trigger',
+          undefined,
+          AGENT_REQUEST_TIMEOUT_MS,
+        );
+      },
+      /** List a pulse's run history. `pagination` is {limit?, offset?}. Resolves {runs,total,limit,offset}. */
+      history: function (id, pagination) {
+        pagination = pagination || {};
+        var params = [];
+        if (pagination.limit != null) params.push('limit=' + pagination.limit);
+        if (pagination.offset != null) {
+          params.push('offset=' + pagination.offset);
+        }
+        return request(
+          'GET',
+          '/api/addon-proxy/pulses/' +
+            id +
+            '/history' +
+            (params.length ? '?' + params.join('&') : ''),
+        );
+      },
+    },
+
+    // ── Channels (read-only) ──────────────────────────────────────────────
+    // Requires `channels.list` / `channels.read` / `channels.manage`. There
+    // is no "send a message" capability — channels only auto-reply to
+    // inbound messages via the agent they're configured with.
+    channels: {
+      /** List configured channels and their connection status. Resolves {items}. */
+      list: function () {
+        return request('GET', '/api/addon-proxy/channels');
+      },
+      /** Get a single channel's connection status. */
+      getStatus: function (id) {
+        return request('GET', '/api/addon-proxy/channels/' + id + '/status');
+      },
+      /** Start connecting a channel (may take time for a QR flow). */
+      connect: function (id) {
+        return request(
+          'POST',
+          '/api/addon-proxy/channels/' + id + '/connect',
+          undefined,
+          AGENT_REQUEST_TIMEOUT_MS,
+        );
+      },
+      /** Disconnect a channel. */
+      disconnect: function (id) {
+        return request(
+          'POST',
+          '/api/addon-proxy/channels/' + id + '/disconnect',
+        );
+      },
+    },
+
     // ── UI (Tailwind-styled component library) ─────────────────────────────
     // Pure client-side DOM builders — no server round-trip, no permission
     // required. Every component returns a real HTMLElement so it can be

--- a/docs/addons/addon-permissions.md
+++ b/docs/addons/addon-permissions.md
@@ -44,33 +44,84 @@ When using `agents.invoke:<agentId>`, the addon can only invoke the named agent.
 | ------------- | ------------- | -------------------------- |
 | `config.read` | `getConfig()` | Read the app configuration |
 
+### Storage (per-addon SQLite)
+
+Each addon gets its own private SQLite database, schema declared in `addon.json` under `storage.migrations`.
+
+| Permission      | SDK Method                             | What It Does                           |
+| --------------- | -------------------------------------- | -------------------------------------- |
+| `storage.read`  | `storage.kv.get(key)`                  | Read a key/value pair                  |
+| `storage.read`  | `storage.kv.list(prefix?)`             | List key/value pairs                   |
+| `storage.write` | `storage.kv.set(key, value)`           | Write a key/value pair                 |
+| `storage.write` | `storage.kv.delete(key)`               | Delete a key/value pair                |
+| `storage.read`  | `storage.query(sql, params?)`          | Run a read (`SELECT`) query            |
+| `storage.write` | `storage.exec(sql, params?)`           | Run a write statement                  |
+| `storage.read`  | `storage.search(table, match, limit?)` | Full-text search over a declared table |
+
+### Tasks
+
+Deliberately narrower than the web UI's task API — no agent assignment, no scheduling, no subtask CRUD.
+
+| Permission     | SDK Method                                       | What It Does                              |
+| -------------- | ------------------------------------------------ | ----------------------------------------- |
+| `tasks.list`   | `tasks.list(status?)`                            | List tasks, optionally filtered by status |
+| `tasks.read`   | `tasks.get(id)`                                  | Get a task with its subtasks and progress |
+| `tasks.write`  | `tasks.create({title?, description, priority?})` | Create a task                             |
+| `tasks.write`  | `tasks.updateStatus(id, status)`                 | Update a task's status                    |
+| `tasks.read`   | `tasks.listSubtasks(id)`                         | List a task's subtasks                    |
+| `tasks.invoke` | `tasks.execute(id)`                              | Start executing a task                    |
+
+### Pulses
+
+Scheduled prompts (one-off or recurring) that run against an agent, optionally inside an existing session. Addons can fully drive pulses — create, read, update, delete, trigger, and inspect run history.
+
+| Permission      | SDK Method                                                      | What It Does                     |
+| --------------- | --------------------------------------------------------------- | -------------------------------- |
+| `pulses.list`   | `pulses.list(filters?)`                                         | List pulses                      |
+| `pulses.read`   | `pulses.get(id)`                                                | Get a single pulse               |
+| `pulses.write`  | `pulses.create({name, prompt, schedule, agentId?, sessionId?})` | Create a pulse                   |
+| `pulses.write`  | `pulses.update(id, input)`                                      | Partially update a pulse         |
+| `pulses.delete` | `pulses.delete(id)`                                             | Delete a pulse                   |
+| `pulses.invoke` | `pulses.trigger(id)`                                            | Trigger a pulse to run right now |
+| `pulses.read`   | `pulses.history(id, pagination?)`                               | List a pulse's run history       |
+
+### Channels (read-only)
+
+WhatsApp/Discord integrations. There is currently no "send a message" capability — channels only auto-reply to inbound messages via the agent they're configured with, so addon access is limited to visibility and connection lifecycle.
+
+| Permission        | SDK Method                | What It Does                              |
+| ----------------- | ------------------------- | ----------------------------------------- |
+| `channels.list`   | `channels.list()`         | List configured channels and their status |
+| `channels.read`   | `channels.getStatus(id)`  | Get a single channel's connection status  |
+| `channels.manage` | `channels.connect(id)`    | Start connecting a channel                |
+| `channels.manage` | `channels.disconnect(id)` | Disconnect a channel                      |
+
 ## Planned Permissions (Not Yet Implemented)
 
 The following resources exist in the permission schema but **have no SDK methods or backend endpoints for addons yet**. Declaring them in `addon.json` is valid (the manifest validator accepts them) but they have no effect.
 
 | Resource    | Status  | Description                                       |
 | ----------- | ------- | ------------------------------------------------- |
-| `tasks`     | Planned | Task management — no addon API exists yet         |
 | `runs`      | Planned | Session execution runs — no addon API exists yet  |
 | `mcp`       | Planned | MCP server integrations — no addon API exists yet |
 | `workspace` | Planned | Workspace settings — no addon API exists yet      |
 | `logs`      | Planned | System logs — no addon API exists yet             |
 | `system`    | Planned | System-level operations — no addon API exists yet |
 
-These will be implemented in future releases as addon capabilities expand.
+These will be implemented in future releases as addon capabilities expand. Memories, skills, and MCP server access are intentionally reached indirectly — through whatever agent the addon is permitted to invoke — rather than exposed as their own addon-proxy resources.
 
 ## Available Actions
 
 Not every action applies to every resource. The table below shows which actions are valid for the currently implemented resources.
 
-| Action   | sessions                   | agents           | config         |
-| -------- | -------------------------- | ---------------- | -------------- |
-| `list`   | ✅ List sessions           | ✅ List agents   | —              |
-| `read`   | ✅ Get session by ID       | ✅ Get agent     | ✅ Read config |
-| `write`  | ✅ Send message to session | —                | —              |
-| `delete` | ✅ Delete sessions         | —                | —              |
-| `invoke` | —                          | ✅ Invoke agents | —              |
-| `manage` | —                          | —                | —              |
+| Action   | sessions                   | agents           | config         | storage              | tasks                   | pulses               | channels              |
+| -------- | -------------------------- | ---------------- | -------------- | -------------------- | ----------------------- | -------------------- | --------------------- |
+| `list`   | ✅ List sessions           | ✅ List agents   | —              | —                    | ✅ List tasks           | ✅ List pulses       | ✅ List channels      |
+| `read`   | ✅ Get session by ID       | ✅ Get agent     | ✅ Read config | ✅ Read/query/search | ✅ Get task/subtasks    | ✅ Get pulse/history | ✅ Get channel status |
+| `write`  | ✅ Send message to session | —                | —              | ✅ Write/exec        | ✅ Create/update status | ✅ Create/update     | —                     |
+| `delete` | ✅ Delete sessions         | —                | —              | —                    | —                       | ✅ Delete pulse      | —                     |
+| `invoke` | —                          | ✅ Invoke agents | —              | —                    | ✅ Execute task         | ✅ Trigger pulse     | —                     |
+| `manage` | —                          | —                | —              | —                    | —                       | —                    | ✅ Connect/disconnect |
 
 Actions marked with **—** are not implemented for that resource.
 
@@ -120,6 +171,23 @@ Can list sessions and invoke only the `price-analyzer` agent. Cannot invoke any 
 ```
 
 Can only read the app configuration. No access to sessions or agents.
+
+### Pulse automation addon
+
+```json
+{
+  "permissions": [
+    "pulses.list",
+    "pulses.read",
+    "pulses.write",
+    "pulses.invoke",
+    "tasks.list",
+    "tasks.write"
+  ]
+}
+```
+
+Can create and manage its own pulses (scheduled prompts), trigger them on demand, and create tasks to track the work. Cannot delete pulses or execute tasks directly.
 
 ## Escape Hatch
 

--- a/packages/shared-types/src/addon.ts
+++ b/packages/shared-types/src/addon.ts
@@ -569,6 +569,8 @@ export const PERMISSION_RESOURCES = [
   'workspace',
   'logs',
   'storage',
+  'channels',
+  'pulses',
 ] as const;
 
 export type PermissionResource = (typeof PERMISSION_RESOURCES)[number];


### PR DESCRIPTION
## Summary
Extends the addon permission/proxy system (previously `agents`/`sessions`/`storage` only) to three more resources:

- **Tasks** (`tasks.list/read/write/invoke`): list, get, create, update status, list subtasks, execute — deliberately narrower than the web UI's task API (no agent assignment, scheduling, or subtask CRUD).
- **Pulses** (`pulses.list/read/write/delete/invoke`): full CRUD + trigger-now + run history, mirroring the existing `/api/pulses` routes almost 1:1.
- **Channels** (`channels.list/read/manage`): list, status, connect, disconnect — read-only. There is currently no "send a message" capability anywhere in the codebase (channels only auto-reply to inbound messages), so that's out of scope here.

Also:
- Extracted `createPulseSchema`/`updatePulseSchema`/`toScheduleInput` → `apps/server/src/pulses/schemas.ts` and `toStatusResponse` → `apps/server/src/channels/status.ts`, so the web-facing routes and the new addon-proxy routes share one source of truth instead of duplicating validation/projection logic.
- Added `sdk.tasks.*`, `sdk.pulses.*`, `sdk.channels.*` namespaces to the addon-facing SDK (`apps/server/src/sdk/openaidy-sdk.js`).
- Updated `docs/addons/addon-permissions.md`: moved these three resources from "Planned" to "Implemented", added a `storage` section that was previously undocumented despite already being implemented, refreshed the actions matrix, and added a pulse-automation example manifest.

## Test plan
- [x] `packages/shared-types` and `apps/server` build clean (`tsc`)
- [x] `eslint` clean on all changed files
- [x] 34 new tests added (`proxy-routes-tasks.test.ts`, `proxy-routes-pulses.test.ts`, `proxy-routes-channels.test.ts`), mirroring the existing `proxy-routes-sessions.test.ts` harness — covering permission-denied (403), success paths, and not-found (404) mapping per resource
- [x] Full `apps/server` test suite passes (3592 tests; the 1 failure is the pre-existing Windows-only `spawn shell` flake in `src/update/service.test.ts`, unrelated to this change)
- [x] `packages/shared-types` test suite passes (214 tests)
- [x] `apps/web` typechecks clean (no web changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)