### PR TITLE
fix(addons): stop the SDK from crashing on load, allow declaring style/font CSP domains

### DIFF
--- a/apps/server/src/routes/addons.test.ts
+++ b/apps/server/src/routes/addons.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rewriteAddonHtml } from './addons';
+import { rewriteAddonHtml, buildAddonCsp } from './addons';
 
 describe('rewriteAddonHtml', () => {
   it('adds crossorigin to a local script and appends the asset token', () => {
@@ -49,5 +49,76 @@ describe('rewriteAddonHtml', () => {
     expect(out).toContain(
       '<script crossorigin="anonymous" src="index.js?at=TOKEN"></script>',
     );
+  });
+});
+
+describe('buildAddonCsp', () => {
+  const scriptSrcOrigins = ["'unsafe-inline'", 'http://localhost:3001'];
+
+  it('defaults style-src/font-src/img-src/connect-src to the platform baseline when the manifest declares nothing', () => {
+    const csp = buildAddonCsp(null, scriptSrcOrigins);
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("font-src 'self'");
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain(`script-src ${scriptSrcOrigins.join(' ')}`);
+    // Fixed directives are always present regardless of manifest.
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("default-src 'none'");
+  });
+
+  it('extends style-src and font-src for a Google Fonts manifest', () => {
+    const csp = buildAddonCsp(
+      {
+        externalStyleDomains: ['fonts.googleapis.com'],
+        externalFontDomains: ['fonts.gstatic.com'],
+      },
+      scriptSrcOrigins,
+    );
+    expect(csp).toContain(
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    );
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
+  });
+
+  it('still extends connect-src/img-src from externalDomains/externalImageDomains (regression check)', () => {
+    const csp = buildAddonCsp(
+      {
+        externalDomains: ['api.open-meteo.com'],
+        externalImageDomains: ['raw.githubusercontent.com'],
+      },
+      scriptSrcOrigins,
+    );
+    expect(csp).toContain("connect-src 'self' https://api.open-meteo.com");
+    expect(csp).toContain(
+      "img-src 'self' data: https://raw.githubusercontent.com",
+    );
+  });
+
+  it('normalizes a domain entry that already has a scheme prefix', () => {
+    const csp = buildAddonCsp(
+      { externalStyleDomains: ['https://fonts.googleapis.com'] },
+      scriptSrcOrigins,
+    );
+    expect(csp).toContain('https://fonts.googleapis.com');
+    // No double scheme.
+    expect(csp).not.toContain('https://https://');
+  });
+
+  it('drops non-string and malformed entries instead of throwing', () => {
+    const csp = buildAddonCsp(
+      {
+        externalStyleDomains: [
+          'fonts.googleapis.com',
+          123,
+          null,
+          'not a valid host!',
+        ],
+      },
+      scriptSrcOrigins,
+    );
+    expect(csp).toContain('https://fonts.googleapis.com');
+    expect(csp).not.toContain('not a valid host');
   });
 });

--- a/apps/server/src/routes/addons.ts
+++ b/apps/server/src/routes/addons.ts
@@ -79,6 +79,63 @@ export function rewriteAddonHtml(html: string, token: string): string {
   );
 }
 
+/**
+ * Build the Content-Security-Policy header for an addon's static assets.
+ *
+ * `connect-src`/`img-src`/`style-src`/`font-src` are each extended per-addon
+ * from the manifest's `externalDomains`/`externalImageDomains`/
+ * `externalStyleDomains`/`externalFontDomains` fields (declared but unset
+ * entries default to just the platform baseline). `script-src` is left to
+ * the caller — it depends on the request host/env, not just the manifest
+ * (see TAILWIND_CDN_ORIGIN above for why it's never manifest-extensible).
+ */
+export function buildAddonCsp(
+  manifest: Record<string, unknown> | null,
+  scriptSrcOrigins: string[],
+): string {
+  const stringArray = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value.filter((d): d is string => typeof d === 'string')
+      : [];
+
+  const externalDomains = stringArray(manifest?.['externalDomains']);
+  const externalImageDomains = stringArray(manifest?.['externalImageDomains']);
+  const externalStyleDomains = stringArray(manifest?.['externalStyleDomains']);
+  const externalFontDomains = stringArray(manifest?.['externalFontDomains']);
+
+  const normalizeHosts = (hosts: string[]) =>
+    hosts
+      .map((d) => d.replace(/^https?:\/\//i, '').split('/')[0] ?? '')
+      .filter((d) => /^[a-zA-Z0-9.-]+(:\d+)?$/.test(d))
+      .map((d) => `https://${d}`);
+
+  const connectSrc = ["'self'", ...normalizeHosts(externalDomains)].join(' ');
+  const imgSrc = [
+    "'self'",
+    'data:',
+    ...normalizeHosts(externalImageDomains),
+  ].join(' ');
+  const styleSrc = [
+    "'self'",
+    "'unsafe-inline'",
+    ...normalizeHosts(externalStyleDomains),
+  ].join(' ');
+  const fontSrc = ["'self'", ...normalizeHosts(externalFontDomains)].join(' ');
+
+  return [
+    "default-src 'none'",
+    `script-src ${scriptSrcOrigins.join(' ')}`,
+    `style-src ${styleSrc}`,
+    `img-src ${imgSrc}`,
+    `font-src ${fontSrc}`,
+    `connect-src ${connectSrc}`,
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+  ].join('; ');
+}
+
 /** Extract the `at` asset-token query param from a request. */
 function getAssetToken(request: FastifyRequest): string | null {
   const query = request.query as Record<string, unknown> | undefined;
@@ -496,44 +553,20 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
       };
       const contentType = mimeTypes[ext] ?? 'application/octet-stream';
 
-      // Read externalDomains from the addon manifest to extend connect-src.
+      // Read the addon manifest to extend connect-src/img-src/style-src/
+      // font-src per its declared externalDomains/externalImageDomains/
+      // externalStyleDomains/externalFontDomains.
       // TODO: In the future, prompt the user to approve these domains before
       // the addon is enabled — similar to the permissions approval flow.
       const manifestPath = path.join(addonsDir, addonId, 'addon.json');
-      let externalDomains: string[] = [];
-      let externalImageDomains: string[] = [];
+      let manifestRaw: Record<string, unknown> | null = null;
       try {
-        const manifestRaw = JSON.parse(
+        manifestRaw = JSON.parse(
           fs.readFileSync(manifestPath, 'utf-8'),
         ) as Record<string, unknown>;
-        if (Array.isArray(manifestRaw['externalDomains'])) {
-          externalDomains = (
-            manifestRaw['externalDomains'] as unknown[]
-          ).filter((d): d is string => typeof d === 'string');
-        }
-        if (Array.isArray(manifestRaw['externalImageDomains'])) {
-          externalImageDomains = (
-            manifestRaw['externalImageDomains'] as unknown[]
-          ).filter((d): d is string => typeof d === 'string');
-        }
       } catch {
         // manifest unreadable — proceed with no external domains
       }
-
-      const normalizeHosts = (hosts: string[]) =>
-        hosts
-          .map((d) => d.replace(/^https?:\/\//i, '').split('/')[0] ?? '')
-          .filter((d) => /^[a-zA-Z0-9.-]+(:\d+)?$/.test(d))
-          .map((d) => `https://${d}`);
-
-      const connectSrc = ["'self'", ...normalizeHosts(externalDomains)].join(
-        ' ',
-      );
-      const imgSrc = [
-        "'self'",
-        'data:',
-        ...normalizeHosts(externalImageDomains),
-      ].join(' ');
 
       // The addon HTML is loaded inside a sandboxed iframe WITHOUT
       // allow-same-origin, which gives the document an opaque origin.
@@ -551,20 +584,8 @@ export const addonRoutes: FastifyPluginAsync<AddonRoutesOptions> = async (
         `http://localhost:${env.PORT}`,
         TAILWIND_CDN_ORIGIN,
       ];
-      const scriptSrc = scriptSrcOrigins.join(' ');
 
-      const csp = [
-        "default-src 'none'",
-        `script-src ${scriptSrc}`,
-        "style-src 'self' 'unsafe-inline'",
-        `img-src ${imgSrc}`,
-        "font-src 'self'",
-        `connect-src ${connectSrc}`,
-        "frame-src 'none'",
-        "object-src 'none'",
-        "base-uri 'none'",
-        "form-action 'none'",
-      ].join('; ');
+      const csp = buildAddonCsp(manifestRaw, scriptSrcOrigins);
 
       // The addon iframe is sandboxed WITHOUT `allow-same-origin`, so its
       // document has an opaque origin and EVERY subresource request counts

--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -96,22 +96,18 @@
   }
 
   // Paint something reasonable immediately, before OPENAIDY_INIT arrives.
-  // Probe for the host's likely mode instead of assuming dark, so a
-  // light-mode host doesn't see a dark flash that snaps to light once the
-  // real INIT lands. Same-origin localStorage works because this script only
-  // ever loads inside an OpenAidy-hosted addon iframe, and mirrors the
-  // host's own resolution (apps/web/src/lib/theme.tsx): an explicit
-  // 'dark'/'light' choice wins, 'system' (or no choice yet) falls back to
-  // the OS preference.
-  var _storedTheme =
-    typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
+  // The iframe is sandboxed WITHOUT allow-same-origin (opaque origin) by
+  // design (see commit c5a8073) — localStorage/sessionStorage are
+  // inaccessible and throw a SecurityError on access, not just return
+  // undefined, so we can't read the host's explicit theme choice here.
+  // Fall back to the OS preference only; the real host-resolved theme
+  // (including any explicit override) arrives moments later via
+  // OPENAIDY_INIT and corrects this via _applyTheme().
   var _prefersDark =
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-color-scheme: dark)').matches;
   var _initialMode =
-    document.documentElement.classList.contains('dark') ||
-    _storedTheme === 'dark' ||
-    ((_storedTheme === 'system' || !_storedTheme) && _prefersDark)
+    document.documentElement.classList.contains('dark') || _prefersDark
       ? 'dark'
       : 'light';
   _applyTheme({ mode: _initialMode, tokens: FALLBACK_THEME_TOKENS });

--- a/apps/server/src/sdk/openaidy-sdk.test.ts
+++ b/apps/server/src/sdk/openaidy-sdk.test.ts
@@ -205,19 +205,35 @@ describe('openaidy-sdk.js theme sync', () => {
     expect(isDark(window)).toBe(false);
   });
 
-  it('picks a dark initial paint from a stored theme preference, before any INIT arrives', () => {
+  it('picks a dark initial paint from the OS preference, before any INIT arrives', () => {
     const { window } = loadSdk((w) => {
-      w.matchMedia = () => ({ matches: false });
-      w.localStorage.setItem('theme', 'dark');
+      w.matchMedia = () => ({ matches: true });
     });
     expect(isDark(window)).toBe(true);
   });
 
-  it('falls back to the OS preference for a stored "system" theme', () => {
-    const { window } = loadSdk((w) => {
-      w.matchMedia = () => ({ matches: true });
-      w.localStorage.setItem('theme', 'system');
+  it('does not touch localStorage for the initial paint, and still exposes window.OpenAidy', () => {
+    // Regression test: the addon iframe is sandboxed WITHOUT
+    // allow-same-origin, so *accessing* localStorage throws a SecurityError
+    // synchronously (not just returns undefined). jsdom's own localStorage
+    // doesn't model that, so this simulates it directly — if any code path
+    // in the SDK still touched localStorage at load time, this would throw
+    // before `global.OpenAidy = sdk` (the file's last statement) ever runs,
+    // exactly like the real bug reported in production.
+    const { window, vmContext } = loadSdk((w) => {
+      w.matchMedia = () => ({ matches: false });
+      Object.defineProperty(w, 'localStorage', {
+        get() {
+          throw new DOMException(
+            "Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.",
+            'SecurityError',
+          );
+        },
+      });
     });
-    expect(isDark(window)).toBe(true);
+    expect(
+      (vmContext as unknown as { OpenAidy?: unknown }).OpenAidy,
+    ).toBeDefined();
+    expect(isDark(window)).toBe(false);
   });
 });

--- a/packages/shared-types/src/addon.ts
+++ b/packages/shared-types/src/addon.ts
@@ -276,6 +276,46 @@ export const AddonManifestSchema = z.object({
     )
     .max(20)
     .optional(),
+  /**
+   * External domains this addon is allowed to load stylesheets from (browser-side).
+   * Each entry must be a bare hostname or hostname:port (e.g. "fonts.googleapis.com").
+   * Enforced via CSP style-src. Use this for <link rel="stylesheet" href="https://...">.
+   *
+   * TODO: Before an addon with externalStyleDomains is enabled, prompt the user to
+   * review and approve the listed domains — similar to the permissions approval flow.
+   */
+  externalStyleDomains: z
+    .array(
+      z
+        .string()
+        .regex(
+          /^[a-zA-Z0-9.-]+(:\d+)?$/,
+          'externalStyleDomains entries must be bare hostnames (e.g. "fonts.googleapis.com")',
+        ),
+    )
+    .max(20)
+    .optional(),
+  /**
+   * External domains this addon is allowed to load font files from (browser-side).
+   * Each entry must be a bare hostname or hostname:port (e.g. "fonts.gstatic.com").
+   * Enforced via CSP font-src. Google Fonts needs BOTH externalStyleDomains
+   * (fonts.googleapis.com, for the CSS) and this field (fonts.gstatic.com,
+   * for the actual font files that CSS references).
+   *
+   * TODO: Before an addon with externalFontDomains is enabled, prompt the user to
+   * review and approve the listed domains — similar to the permissions approval flow.
+   */
+  externalFontDomains: z
+    .array(
+      z
+        .string()
+        .regex(
+          /^[a-zA-Z0-9.-]+(:\d+)?$/,
+          'externalFontDomains entries must be bare hostnames (e.g. "fonts.gstatic.com")',
+        ),
+    )
+    .max(20)
+    .optional(),
   icons: z
     .object({
       16: z.string().url().optional(),


### PR DESCRIPTION
## Summary

Two independent bugs reported breaking most/all addons:

### 1. `SecurityError` on `localStorage` access → crashed every addon's SDK
`openaidy-sdk.js` unconditionally read `localStorage.getItem('theme')` at top-level (added in #500) to guess the pre-init paint theme. The addon iframe is deliberately sandboxed **without** `allow-same-origin` (so a malicious addon can't steal the auth token) — in that context, *accessing* `localStorage` throws a `SecurityError` synchronously rather than returning `undefined`. The existing `typeof localStorage !== 'undefined'` guard doesn't catch that (it only guards against an undeclared identifier, not a throwing property getter). The uncaught exception aborted the SDK's IIFE before `window.OpenAidy = sdk` (its last statement) ever ran — which is exactly why every addon's own script then threw `ReferenceError: OpenAidy is not defined`. This reproduced on 100% of loads, not an edge case.

**Fix:** removed the `localStorage` probe entirely. The pre-init fallback now only uses `matchMedia('(prefers-color-scheme: dark)')` (safe inside a sandboxed iframe) until the real host-resolved theme arrives moments later via `OPENAIDY_INIT`.

### 2. CSP blocked Google Fonts (and any other external style/font host)
`style-src`/`font-src` in the addon CSP (`apps/server/src/routes/addons.ts`) were hardcoded literal strings with no way for an addon to declare an external stylesheet/font host — unlike `connect-src`/`img-src`, which already read `externalDomains`/`externalImageDomains` off the manifest.

**Fix:** added `externalStyleDomains`/`externalFontDomains` manifest fields (same pattern as the two existing ones), and extracted the CSP construction into a pure, unit-tested `buildAddonCsp` function (mirroring the file's existing `rewriteAddonHtml` export). An addon using Google Fonts can now declare:
```json
{
  "externalStyleDomains": ["fonts.googleapis.com"],
  "externalFontDomains": ["fonts.gstatic.com"]
}
```
(Google Fonts needs both — one for the CSS host, one for the font files that CSS references.)

## Test plan
- [x] `packages/shared-types` and `apps/server` build clean (`tsc`)
- [x] `eslint` clean on all changed files
- [x] New/updated tests: `openaidy-sdk.test.ts` replaces the now-invalid localStorage-based theme tests and adds a regression test that simulates a throwing `localStorage` getter (mirroring the real sandboxed behavior jsdom doesn't model) and asserts `window.OpenAidy` still gets defined; `addons.test.ts` adds 5 new cases for `buildAddonCsp` (default baseline, Google Fonts extension, connect-src/img-src regression check, scheme-prefix normalization, malformed-entry filtering)
- [x] Full `apps/server` test suite passes (3563 tests; the 1 failure is the pre-existing Windows-only `spawn shell` flake in `src/update/service.test.ts`, unrelated to this change)
- [x] `packages/shared-types` test suite passes (214 tests)
- [x] `apps/web` typechecks clean (no web changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)