### PR TITLE
fix(tools): make agents_list report tools, skills, and MCP servers

### DIFF
--- a/apps/server/src/tools/agents/list.test.ts
+++ b/apps/server/src/tools/agents/list.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createAgentsListTool } from './list.js';
+import type { AgentRegistry } from '../../agents/registry.js';
+
+function makeAgentRegistry(agents: unknown[]): AgentRegistry {
+  return {
+    listAgents: vi.fn().mockReturnValue(agents),
+  } as unknown as AgentRegistry;
+}
+
+describe('agents_list tool', () => {
+  it('reports "no enabled agents" when the registry is empty', async () => {
+    const tool = createAgentsListTool(makeAgentRegistry([]));
+    const result = await tool.execute({}, { agentId: 'caller' });
+    expect(result).toEqual({ ok: true, content: 'No enabled agents found.' });
+  });
+
+  it('includes tools, skills, and mcpServers for an agent that has them', async () => {
+    const tool = createAgentsListTool(
+      makeAgentRegistry([
+        {
+          id: 'researcher',
+          name: 'Researcher',
+          model: 'openai/gpt-4o',
+          description: 'Digs up facts.',
+          tools: ['web_search', 'web_fetch'],
+          skills: ['deep-research'],
+          mcpServers: [
+            { id: 'github', tools: ['search_code'] },
+            { id: 'context7' },
+          ],
+        },
+      ]),
+    );
+    const result = await tool.execute({}, { agentId: 'caller' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.content).toContain('id: "researcher"');
+    expect(result.content).toContain('model: openai/gpt-4o');
+    expect(result.content).toContain('desc: Digs up facts.');
+    expect(result.content).toContain('tools: web_search, web_fetch');
+    expect(result.content).toContain('skills: deep-research');
+    // Scoped MCP tools are shown inline; an unscoped server ref is shown bare.
+    expect(result.content).toContain(
+      'mcpServers: github (search_code), context7',
+    );
+  });
+
+  it('shows "(none)" for tools/skills/mcpServers an agent does not have', async () => {
+    const tool = createAgentsListTool(
+      makeAgentRegistry([
+        { id: 'plain', name: 'Plain Agent', model: 'openai/gpt-4o-mini' },
+      ]),
+    );
+    const result = await tool.execute({}, { agentId: 'caller' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.content).toContain('tools: (none)');
+    expect(result.content).toContain('skills: (none)');
+    expect(result.content).toContain('mcpServers: (none)');
+  });
+
+  it('lists multiple agents, one block per agent', async () => {
+    const tool = createAgentsListTool(
+      makeAgentRegistry([
+        { id: 'a', name: 'A', model: 'openai/gpt-4o' },
+        { id: 'b', name: 'B', model: 'openai/gpt-4o-mini' },
+      ]),
+    );
+    const result = await tool.execute({}, { agentId: 'caller' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.content).toContain('2 agent(s):');
+    expect(result.content).toContain('id: "a"');
+    expect(result.content).toContain('id: "b"');
+  });
+});

--- a/apps/server/src/tools/agents/list.ts
+++ b/apps/server/src/tools/agents/list.ts
@@ -1,6 +1,21 @@
 import type { BuiltinTool } from '@openaidy/runtime';
 import type { AgentRegistry } from '../../agents/registry.js';
+import type { McpServerRef } from '@openaidy/shared-types';
 import { agentsListMeta } from '../catalog.js';
+
+function formatList(value: string[] | undefined): string {
+  if (!value || value.length === 0) return '(none)';
+  return value.join(', ');
+}
+
+function formatMcpServers(mcpServers: McpServerRef[] | undefined): string {
+  if (!mcpServers || mcpServers.length === 0) return '(none)';
+  return mcpServers
+    .map((m) =>
+      m.tools && m.tools.length > 0 ? `${m.id} (${m.tools.join(', ')})` : m.id,
+    )
+    .join(', ');
+}
 
 export function createAgentsListTool(
   agentRegistry: AgentRegistry,
@@ -18,7 +33,10 @@ export function createAgentsListTool(
       const agents = agentRegistry.listAgents();
       const lines = agents.map(
         (a) =>
-          `- id: "${a.id}"  name: "${a.name}"  model: ${a.model}${a.description ? `  desc: ${a.description}` : ''}`,
+          `- id: "${a.id}"  name: "${a.name}"  model: ${a.model}${a.description ? `  desc: ${a.description}` : ''}\n` +
+          `  tools: ${formatList(a.tools)}\n` +
+          `  skills: ${formatList(a.skills)}\n` +
+          `  mcpServers: ${formatMcpServers(a.mcpServers)}`,
       );
       return {
         ok: true,

--- a/apps/server/src/tools/catalog.ts
+++ b/apps/server/src/tools/catalog.ts
@@ -7,8 +7,10 @@ export const agentsListMeta: ToolMeta = {
   category: 'Agents',
   description:
     'List all enabled agents available in this OpenAidy instance. ' +
-    "Returns each agent's id, name, description, and model. " +
-    'Use this before creating an addon that invokes an agent — never hardcode an agent ID.',
+    "Returns each agent's id, name, description, model, and the tools, " +
+    'skills, and MCP servers it has access to. ' +
+    'Use this before creating an addon that invokes an agent, or before ' +
+    'delegating to another agent, to check what it can actually do — never hardcode an agent ID.',
 };
 
 export const agentsCreateMeta: ToolMeta = {


### PR DESCRIPTION
## Summary

The `agents_list` builtin tool only formatted `id`/`name`/`model`/`description` into its output, even though `AgentRegistry.listAgents()` already returns an `AgentSummary` with `tools`/`skills`/`mcpServers` populated. An agent calling `agents_list` to decide who to delegate to (or which agent to wire into a new addon) had no way to see what that agent could actually do.

- `apps/server/src/tools/agents/list.ts`: each agent's block now also lists `tools`, `skills`, and `mcpServers` (falling back to `(none)`), with per-server scoped tools shown inline (e.g. `github (search_code)`).
- `apps/server/src/tools/catalog.ts`: updated the tool's description to match, and to call out its use for delegation decisions, not just addon creation.

## Test plan
- [x] `apps/server` builds clean (`tsc`)
- [x] `eslint` clean on all changed files
- [x] New `apps/server/src/tools/agents/list.test.ts` (4 tests: empty registry, an agent with tools/skills/mcpServers, an agent with none of them, multiple agents)
- [x] Full `apps/server` test suite passes (3604 tests; the 1 failure is the pre-existing Windows-only `spawn shell` flake in `src/update/service.test.ts`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)