### PR TITLE
feat(addons): let addons share files with agent workspaces and sessions

### DIFF
--- a/apps/server/src/addons/addon-proxy-flow.test.ts
+++ b/apps/server/src/addons/addon-proxy-flow.test.ts
@@ -152,6 +152,39 @@ describe('AddonProxyService permission checks', () => {
     expect(result.authorized).toBe(false);
     expect(result.error).toContain('agents.invoke');
   });
+
+  it('hasWorkspaceAccess: unscoped workspace.write grants all agents', () => {
+    const addon = makeEnabledAddon('a', ['workspace.write']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'agent-1')).toBe(true);
+    expect(proxyService.hasWorkspaceAccess(addon, 'agent-2')).toBe(true);
+  });
+
+  it('hasWorkspaceAccess: workspace.* grants all agents', () => {
+    const addon = makeEnabledAddon('a', ['workspace.*']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'any-agent')).toBe(true);
+  });
+
+  it('hasWorkspaceAccess: wildcard * grants all agents', () => {
+    const addon = makeEnabledAddon('a', ['*']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'any-agent')).toBe(true);
+  });
+
+  it('hasWorkspaceAccess: scoped permission only allows the specified agent', () => {
+    const addon = makeEnabledAddon('a', ['workspace.write:agent-abc']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'agent-abc')).toBe(true);
+    expect(proxyService.hasWorkspaceAccess(addon, 'agent-xyz')).toBe(false);
+  });
+
+  it('hasWorkspaceAccess: no permission denies all agents', () => {
+    const addon = makeEnabledAddon('a', ['sessions.read']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'any-agent')).toBe(false);
+  });
+
+  it('hasWorkspaceAccess: agents.invoke does not grant workspace access', () => {
+    // Distinct resources — the two-tier check must not cross-authorize.
+    const addon = makeEnabledAddon('a', ['agents.invoke']);
+    expect(proxyService.hasWorkspaceAccess(addon, 'any-agent')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/addons/proxy-routes-sessions.test.ts
+++ b/apps/server/src/addons/proxy-routes-sessions.test.ts
@@ -16,6 +16,10 @@ import type { FastifyInstance } from 'fastify';
 import { addonProxyRoutes } from './proxy-routes';
 import { AddonService } from './service';
 import type { SessionMessageService } from '../sessions/service';
+import {
+  AttachmentError,
+  type AttachmentService,
+} from '../attachments/service';
 import type { Addon } from '@openaidy/db';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +56,7 @@ function makeEnabledAddon(addonId: string, permissions: string[]): Addon {
 function makeSessionService(sessions: object[] = []): SessionMessageService {
   return {
     listSessions: vi.fn().mockResolvedValue(sessions),
+    getSession: vi.fn().mockResolvedValue({ id: 'sess-123' }),
     submitMessageStreaming: vi.fn().mockResolvedValue({
       ok: true,
       assistantMessage: { content: 'Agent response' },
@@ -59,10 +64,29 @@ function makeSessionService(sessions: object[] = []): SessionMessageService {
   } as unknown as SessionMessageService;
 }
 
+function makeAttachmentService(
+  overrides: Partial<AttachmentService> = {},
+): AttachmentService {
+  return {
+    saveUpload: vi.fn().mockResolvedValue({
+      id: 'att-1',
+      sessionId: 'sess-123',
+      kind: 'image',
+      source: 'user_upload',
+      name: 'photo.png',
+      mimeType: 'image/png',
+      sizeBytes: 3,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    }),
+    ...overrides,
+  } as unknown as AttachmentService;
+}
+
 /** Build a minimal Fastify app with the proxy routes registered */
 async function buildProxyApp(opts: {
   addon: Addon | null;
   sessionService?: SessionMessageService;
+  attachmentService?: AttachmentService;
 }): Promise<{ app: FastifyInstance; token: string }> {
   const addonSvc = makeAddonService();
 
@@ -93,6 +117,9 @@ async function buildProxyApp(opts: {
         authMiddleware: null as never,
         internalApiBaseUrl: '',
         ...(opts.sessionService ? { sessionService: opts.sessionService } : {}),
+        ...(opts.attachmentService
+          ? { attachmentService: opts.attachmentService }
+          : {}),
       });
     },
     { prefix: '/api' },
@@ -283,5 +310,188 @@ describe('POST /api/addon-proxy/sessions/:sessionId/messages', () => {
     const body = res.json();
     expect(body.message).toBe('Agent response');
     expect(body.sessionId).toBe('sess-123');
+  });
+
+  it('forwards attachmentIds to submitMessageStreaming when provided', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/messages',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        content: 'What is this?',
+        agentId: 'default',
+        attachmentIds: ['att-1', 'att-2'],
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(sessionSvc.submitMessageStreaming).toHaveBeenCalledWith(
+      expect.objectContaining({ attachmentIds: ['att-1', 'att-2'] }),
+    );
+  });
+
+  it('omits attachmentIds from submitMessageStreaming when not provided', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/messages',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { content: 'Hello', agentId: 'default' },
+    });
+    const call = vi.mocked(sessionSvc.submitMessageStreaming).mock.calls[0]![0];
+    expect(call).not.toHaveProperty('attachmentIds');
+  });
+
+  it('returns 400 when attachmentIds is not an array of strings', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/messages',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        content: 'Hello',
+        agentId: 'default',
+        attachmentIds: [123],
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('INVALID_REQUEST');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/addon-proxy/sessions/:sessionId/attachments
+// ---------------------------------------------------------------------------
+
+describe('POST /api/addon-proxy/sessions/:sessionId/attachments', () => {
+  let app: FastifyInstance;
+  let token: string;
+  let sessionSvc: SessionMessageService;
+  let attachmentSvc: AttachmentService;
+
+  beforeEach(async () => {
+    sessionSvc = makeSessionService();
+    attachmentSvc = makeAttachmentService();
+    const setup = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['sessions.write']),
+      sessionService: sessionSvc,
+      attachmentService: attachmentSvc,
+    });
+    app = setup.app;
+    token = setup.token;
+  });
+
+  const payload = {
+    mimeType: 'image/png',
+    data: Buffer.from('png').toString('base64'),
+    name: 'photo.png',
+  };
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      payload,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 when addon lacks sessions.write permission', async () => {
+    const { app: restrictedApp, token: restrictedToken } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['sessions.list']), // no sessions.write
+      sessionService: sessionSvc,
+      attachmentService: attachmentSvc,
+    });
+    const res = await restrictedApp.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${restrictedToken}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('PERMISSION_DENIED');
+  });
+
+  it('returns 503 when attachmentService is not wired', async () => {
+    const { app: noSvcApp, token: noSvcToken } = await buildProxyApp({
+      addon: makeEnabledAddon('test-addon', ['sessions.write']),
+      sessionService: sessionSvc,
+      // no attachmentService
+    });
+    const res = await noSvcApp.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${noSvcToken}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('returns 404 when the session does not exist', async () => {
+    vi.mocked(sessionSvc.getSession).mockResolvedValueOnce(null as never);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${token}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('SESSION_NOT_FOUND');
+  });
+
+  it('returns 400 when the body fails validation', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { mimeType: 'image/png' }, // missing data
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('INVALID_REQUEST');
+  });
+
+  it('returns 415 when saveUpload rejects an unsupported mime type', async () => {
+    vi.mocked(attachmentSvc.saveUpload).mockRejectedValueOnce(
+      new AttachmentError('bad mime', 'UNSUPPORTED_MIME_TYPE'),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { mimeType: 'text/csv', data: 'YQ==' },
+    });
+    expect(res.statusCode).toBe(415);
+    expect(res.json().error).toBe('UNSUPPORTED_MIME_TYPE');
+  });
+
+  it('returns 413 when saveUpload rejects an oversized file', async () => {
+    vi.mocked(attachmentSvc.saveUpload).mockRejectedValueOnce(
+      new AttachmentError('too big', 'FILE_TOO_LARGE'),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${token}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(413);
+    expect(res.json().error).toBe('FILE_TOO_LARGE');
+  });
+
+  it('creates an unlinked attachment and returns its metadata', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/sessions/sess-123/attachments',
+      headers: { authorization: `Bearer ${token}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(201);
+    expect(attachmentSvc.saveUpload).toHaveBeenCalledWith({
+      sessionId: 'sess-123',
+      mimeType: 'image/png',
+      data: payload.data,
+      name: 'photo.png',
+    });
+    const body = res.json();
+    expect(body.id).toBe('att-1');
+    expect(body.mimeType).toBe('image/png');
   });
 });

--- a/apps/server/src/addons/proxy-routes-workspace.test.ts
+++ b/apps/server/src/addons/proxy-routes-workspace.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Addon proxy routes — workspace file-sharing endpoint
+ *
+ * Tests the HTTP layer for:
+ *   POST /api/addon-proxy/workspace/:agentId/files
+ *
+ * Uses a minimal Fastify instance with the addonProxyRoutes plugin plus a
+ * real WorkspaceService backed by a temp directory, so path-traversal
+ * guarding and actual file writes are exercised end to end.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { addonProxyRoutes } from './proxy-routes';
+import { AddonService } from './service';
+import { createWorkspaceService, type WorkspaceService } from '../workspace';
+import type { Addon } from '@openaidy/db';
+
+const JWT_SECRET = 'test-secret-at-least-32-chars-long!!';
+
+function makeAddon(addonId: string, permissions: string[]): Addon {
+  return {
+    id: 'db-row-id',
+    addonId,
+    name: 'Workspace Addon',
+    version: '1.0.0',
+    status: 'enabled',
+    permissions,
+    manifest: { permissions },
+    config: {},
+    installedAt: new Date(),
+    updatedAt: new Date(),
+    installedBy: 'admin',
+  } as unknown as Addon;
+}
+
+async function buildApp(opts: {
+  addon: Addon;
+  workspaceService?: WorkspaceService;
+}): Promise<{ app: FastifyInstance; token: string }> {
+  const addonSvc = new AddonService({
+    repository: null as never,
+    validator: null as never,
+    jwtSecret: JWT_SECRET,
+    openAidyVersion: '0.0.0',
+  });
+  const token = (
+    addonSvc as unknown as {
+      generateAccessToken: (id: string, perms: string[]) => string;
+    }
+  ).generateAccessToken(opts.addon.addonId, opts.addon.permissions as string[]);
+
+  vi.spyOn(addonSvc as never, 'getAddon' as never).mockResolvedValue(
+    opts.addon as never,
+  );
+  vi.spyOn(addonSvc as never, 'recordUsage' as never).mockResolvedValue(
+    undefined as never,
+  );
+
+  const app = Fastify({ logger: false });
+  await app.register(
+    async (api: FastifyInstance) => {
+      await api.register(addonProxyRoutes, {
+        addonService: addonSvc,
+        authMiddleware: null as never,
+        internalApiBaseUrl: '',
+        ...(opts.workspaceService
+          ? { workspaceService: opts.workspaceService }
+          : {}),
+      });
+    },
+    { prefix: '/api' },
+  );
+
+  return { app, token };
+}
+
+describe('POST /api/addon-proxy/workspace/:agentId/files', () => {
+  let baseDir: string;
+  let workspaceService: WorkspaceService;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'addon-workspace-test-'));
+    workspaceService = createWorkspaceService({ baseDir });
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const { app } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      payload: { path: 'note.txt', data: Buffer.from('hi').toString('base64') },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 when addon lacks workspace.write permission', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['sessions.write']), // no workspace.write
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { path: 'note.txt', data: Buffer.from('hi').toString('base64') },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('PERMISSION_DENIED');
+  });
+
+  it('returns 403 when addon is scoped to a different agent', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write:agent-2']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { path: 'note.txt', data: Buffer.from('hi').toString('base64') },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('AGENT_NOT_ALLOWED');
+  });
+
+  it('returns 400 when path or data is missing', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { path: 'note.txt' }, // missing data
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('INVALID_REQUEST');
+  });
+
+  it('returns 400 when the path attempts to escape the workspace', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        path: '../../etc/passwd',
+        data: Buffer.from('hi').toString('base64'),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('PATH_TRAVERSAL_BLOCKED');
+  });
+
+  it('returns 413 when the decoded file exceeds the size cap', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      workspaceService,
+    });
+    const oversized = Buffer.alloc(26 * 1024 * 1024).toString('base64'); // > 25MB cap
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { path: 'big.bin', data: oversized },
+    });
+    expect(res.statusCode).toBe(413);
+    expect(res.json().error).toBe('FILE_TOO_LARGE');
+  });
+
+  it('returns 503 when no workspaceService is wired', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      // no workspaceService
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { path: 'note.txt', data: Buffer.from('hi').toString('base64') },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('writes the file into the agent workspace with unscoped permission', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        path: 'shared/report.csv',
+        data: Buffer.from('a,b\n1,2').toString('base64'),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({
+      agentId: 'agent-1',
+      path: 'shared/report.csv',
+    });
+
+    const written = readFileSync(
+      join(baseDir, 'agent-1', 'shared', 'report.csv'),
+      'utf-8',
+    );
+    expect(written).toBe('a,b\n1,2');
+  });
+
+  it('writes the file with a scoped workspace.write:<agentId> permission', async () => {
+    const { app, token } = await buildApp({
+      addon: makeAddon('test-addon', ['workspace.write:agent-1']),
+      workspaceService,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/addon-proxy/workspace/agent-1/files',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        path: 'note.txt',
+        data: Buffer.from('hello').toString('base64'),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+
+    const written = readFileSync(join(baseDir, 'agent-1', 'note.txt'), 'utf-8');
+    expect(written).toBe('hello');
+  });
+});

--- a/apps/server/src/addons/proxy-routes.ts
+++ b/apps/server/src/addons/proxy-routes.ts
@@ -17,7 +17,11 @@ import {
 } from '../pulses/schemas.js';
 import { toStatusResponse } from '../channels/status.js';
 import { WorkspaceError } from '../workspace';
-import { AttachmentError, MAX_ATTACHMENT_BYTES } from '../attachments/service';
+import {
+  AttachmentError,
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_IDS_PER_MESSAGE,
+} from '../attachments/service';
 import { uploadAttachmentSchema } from '../routes/attachments';
 
 /**
@@ -261,12 +265,12 @@ export const addonProxyRoutes: FastifyPluginAsync<
       if (
         attachmentIds !== undefined &&
         (!Array.isArray(attachmentIds) ||
-          attachmentIds.length > 10 ||
+          attachmentIds.length > MAX_ATTACHMENT_IDS_PER_MESSAGE ||
           attachmentIds.some((id) => typeof id !== 'string'))
       ) {
         return reply.code(400).send({
           error: 'INVALID_REQUEST',
-          message: 'attachmentIds must be an array of at most 10 strings',
+          message: `attachmentIds must be an array of at most ${MAX_ATTACHMENT_IDS_PER_MESSAGE} strings`,
         });
       }
 

--- a/apps/server/src/addons/proxy-routes.ts
+++ b/apps/server/src/addons/proxy-routes.ts
@@ -16,6 +16,24 @@ import {
   toScheduleInput,
 } from '../pulses/schemas.js';
 import { toStatusResponse } from '../channels/status.js';
+import { WorkspaceError } from '../workspace';
+import { AttachmentError, MAX_ATTACHMENT_BYTES } from '../attachments/service';
+import { uploadAttachmentSchema } from '../routes/attachments';
+
+/**
+ * Cap for a single addon-shared workspace file. Same ceiling as
+ * `MAX_ATTACHMENT_BYTES` — there's no principled reason for these to differ,
+ * and keeping one number makes both limits easy to reason about together.
+ */
+const MAX_ADDON_WORKSPACE_FILE_BYTES = MAX_ATTACHMENT_BYTES;
+
+/**
+ * Base64 expands bytes by ~4/3; allow the JSON envelope on top of the
+ * decoded-size limit enforced below (mirrors `UPLOAD_BODY_LIMIT` in
+ * `routes/attachments.ts`).
+ */
+const ADDON_UPLOAD_BODY_LIMIT =
+  Math.ceil(MAX_ADDON_WORKSPACE_FILE_BYTES * 1.4) + 64 * 1024;
 
 // Extend FastifyRequest to include addon context
 declare module 'fastify' {
@@ -210,7 +228,7 @@ export const addonProxyRoutes: FastifyPluginAsync<
   // POST /api/addon-proxy/sessions/:sessionId/messages
   app.post<{
     Params: { sessionId: string };
-    Body: { content: string; agentId: string };
+    Body: { content: string; agentId: string; attachmentIds?: string[] };
   }>(
     '/addon-proxy/sessions/:sessionId/messages',
     { preHandler: validateAddonToken },
@@ -231,12 +249,24 @@ export const addonProxyRoutes: FastifyPluginAsync<
       }
 
       const { sessionId } = request.params;
-      const { content, agentId } = request.body;
+      const { content, agentId, attachmentIds } = request.body;
 
       if (!content || !agentId) {
         return reply.code(400).send({
           error: 'INVALID_REQUEST',
           message: 'content and agentId are required',
+        });
+      }
+
+      if (
+        attachmentIds !== undefined &&
+        (!Array.isArray(attachmentIds) ||
+          attachmentIds.length > 10 ||
+          attachmentIds.some((id) => typeof id !== 'string'))
+      ) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message: 'attachmentIds must be an array of at most 10 strings',
         });
       }
 
@@ -257,6 +287,7 @@ export const addonProxyRoutes: FastifyPluginAsync<
         role: 'user',
         content,
         agentId,
+        ...(attachmentIds !== undefined ? { attachmentIds } : {}),
         onStreamEvent: () => {},
       });
 
@@ -271,6 +302,195 @@ export const addonProxyRoutes: FastifyPluginAsync<
         message: result.assistantMessage.content,
         sessionId,
       });
+    },
+  );
+
+  // POST /api/addon-proxy/sessions/:sessionId/attachments
+  //
+  // Upload an image/audio/video file for a pending message, exactly like the
+  // human-facing `POST /sessions/:sessionId/attachments` in
+  // `routes/attachments.ts` — same schema, same service call. The returned
+  // id is unlinked until passed as one of `attachmentIds` on the messages
+  // route above.
+  app.post(
+    '/addon-proxy/sessions/:sessionId/attachments',
+    { preHandler: validateAddonToken, bodyLimit: ADDON_UPLOAD_BODY_LIMIT },
+    async (request, reply) => {
+      const addon = await opts.addonService.getAddon(request.addonId!);
+
+      if (!addon) {
+        return reply
+          .code(404)
+          .send({ error: 'ADDON_NOT_FOUND', message: 'Addon not found' });
+      }
+
+      const authResult = proxyService.authorize(addon, 'sessions.write');
+      if (!authResult.authorized) {
+        return reply
+          .code(403)
+          .send({ error: 'PERMISSION_DENIED', message: authResult.error });
+      }
+
+      if (!opts.sessionService || !opts.attachmentService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Attachment service not available',
+        });
+      }
+
+      const { sessionId } = request.params as { sessionId: string };
+
+      const session = await opts.sessionService.getSession(sessionId);
+      if (!session) {
+        return reply
+          .code(404)
+          .send({ error: 'SESSION_NOT_FOUND', message: 'Session not found' });
+      }
+
+      let body: ReturnType<typeof uploadAttachmentSchema.parse>;
+      try {
+        body = uploadAttachmentSchema.parse(request.body);
+      } catch (error) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message:
+            error instanceof Error ? error.message : 'Invalid request body',
+        });
+      }
+
+      await proxyService.recordUsage(
+        request.addonId!,
+        `/sessions/${sessionId}/attachments`,
+      );
+
+      try {
+        const attachment = await opts.attachmentService.saveUpload({
+          sessionId,
+          mimeType: body.mimeType,
+          data: body.data,
+          ...(body.name ? { name: body.name } : {}),
+        });
+        return reply.code(201).send({
+          id: attachment.id,
+          sessionId: attachment.sessionId,
+          kind: attachment.kind,
+          source: attachment.source,
+          name: attachment.name,
+          mimeType: attachment.mimeType,
+          sizeBytes: attachment.sizeBytes,
+          createdAt: attachment.createdAt,
+        });
+      } catch (error) {
+        if (error instanceof AttachmentError) {
+          return reply
+            .code(
+              error.code === 'FILE_TOO_LARGE'
+                ? 413
+                : error.code === 'UNSUPPORTED_MIME_TYPE'
+                  ? 415
+                  : 500,
+            )
+            .send({ error: error.code, message: error.message });
+        }
+        return reply.code(500).send({
+          error: 'ATTACHMENT_ERROR',
+          message: error instanceof Error ? error.message : 'Upload failed',
+        });
+      }
+    },
+  );
+
+  // POST /api/addon-proxy/workspace/:agentId/files
+  //
+  // Write an arbitrary file (csv, txt, json, ...) into an agent's workspace
+  // on the addon's behalf. The addon never gets a filesystem path — the
+  // server resolves and validates it via `WorkspaceService.validatePath`
+  // (through `writeBinaryFile`), the same guard used by the agent's own
+  // workspace_write tool.
+  app.post<{
+    Params: { agentId: string };
+    Body: { path: string; data: string };
+  }>(
+    '/addon-proxy/workspace/:agentId/files',
+    { preHandler: validateAddonToken, bodyLimit: ADDON_UPLOAD_BODY_LIMIT },
+    async (request, reply) => {
+      const { agentId } = request.params;
+      const addon = await opts.addonService.getAddon(request.addonId!);
+
+      if (!addon) {
+        return reply
+          .code(404)
+          .send({ error: 'ADDON_NOT_FOUND', message: 'Addon not found' });
+      }
+
+      const authResult = proxyService.authorize(addon, 'workspace.write');
+      if (!authResult.authorized) {
+        return reply
+          .code(403)
+          .send({ error: 'PERMISSION_DENIED', message: authResult.error });
+      }
+
+      if (!proxyService.hasWorkspaceAccess(addon, agentId)) {
+        return reply.code(403).send({
+          error: 'AGENT_NOT_ALLOWED',
+          message: `Access to agent ${agentId}'s workspace not allowed`,
+        });
+      }
+
+      if (!opts.workspaceService) {
+        return reply.code(503).send({
+          error: 'SERVICE_UNAVAILABLE',
+          message: 'Workspace service not available',
+        });
+      }
+
+      const { path, data } = request.body ?? {};
+      if (!path || !data) {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message: 'path and data are required',
+        });
+      }
+
+      let buffer: Buffer;
+      try {
+        buffer = Buffer.from(data, 'base64');
+      } catch {
+        return reply.code(400).send({
+          error: 'INVALID_REQUEST',
+          message: 'data must be base64-encoded',
+        });
+      }
+
+      if (
+        buffer.length === 0 ||
+        buffer.length > MAX_ADDON_WORKSPACE_FILE_BYTES
+      ) {
+        return reply.code(413).send({
+          error: 'FILE_TOO_LARGE',
+          message: `File must be between 1 byte and ${MAX_ADDON_WORKSPACE_FILE_BYTES} bytes`,
+        });
+      }
+
+      await proxyService.recordUsage(
+        request.addonId!,
+        `/workspace/${agentId}/files`,
+      );
+
+      try {
+        await opts.workspaceService.writeBinaryFile(agentId, path, buffer);
+        return reply.code(201).send({ agentId, path });
+      } catch (error) {
+        if (error instanceof WorkspaceError) {
+          return reply
+            .code(error.code === 'PATH_TRAVERSAL_BLOCKED' ? 400 : 500)
+            .send({ error: error.code, message: error.message });
+        }
+        return reply.code(500).send({
+          error: 'WRITE_FAILED',
+          message: error instanceof Error ? error.message : 'Write failed',
+        });
+      }
     },
   );
 

--- a/apps/server/src/addons/proxy.ts
+++ b/apps/server/src/addons/proxy.ts
@@ -56,6 +56,29 @@ export class AddonProxyService {
   }
 
   /**
+   * Check if an addon has access to write into a specific agent's workspace.
+   *
+   * Two tiers, checked in order (mirrors {@link hasAgentAccess}):
+   *   1. Unscoped: `workspace.write`, `workspace.*`, or `*` — access to all agents' workspaces.
+   *   2. Scoped:   `workspace.write:<agentId>`               — access to that agent's workspace only.
+   */
+  hasWorkspaceAccess(addon: Addon, agentId: string): boolean {
+    const permissions = (addon.permissions as string[]) ?? [];
+
+    // Tier 1: unscoped — grants access to all agents' workspaces
+    if (
+      permissions.includes('workspace.write') ||
+      permissions.includes('workspace.*') ||
+      permissions.includes('*')
+    ) {
+      return true;
+    }
+
+    // Tier 2: scoped — grants access to one specific agent's workspace
+    return permissions.includes(`workspace.write:${agentId}`);
+  }
+
+  /**
    * Validate an addon access token
    */
   async validateToken(token: string): Promise<{

--- a/apps/server/src/addons/proxy.ts
+++ b/apps/server/src/addons/proxy.ts
@@ -29,53 +29,48 @@ export class AddonProxyService {
   }
 
   /**
+   * Check if an addon holds a permission for a specific target, under the
+   * platform's two-tier scoping convention:
+   *   1. Unscoped: `<basePermission>`, `<namespace>.*`, or `*` — grants access
+   *      to every target.
+   *   2. Scoped:   `<basePermission>:<targetId>`              — grants access
+   *      to that one target only.
+   */
+  private hasScopedAccess(
+    addon: Addon,
+    basePermission: string,
+    targetId: string,
+  ): boolean {
+    const permissions = (addon.permissions as string[]) ?? [];
+    const namespace = basePermission.split('.')[0];
+
+    if (
+      permissions.includes(basePermission) ||
+      permissions.includes(`${namespace}.*`) ||
+      permissions.includes('*')
+    ) {
+      return true;
+    }
+
+    return permissions.includes(`${basePermission}:${targetId}`);
+  }
+
+  /**
    * Check if an addon has access to a specific agent.
-   *
-   * Two tiers, checked in order:
-   *   1. Unscoped: `agents.invoke`, `agents.*`, or `*` — access to all agents.
-   *   2. Scoped:   `agents.invoke:<agentId>`           — access to that agent only.
    *
    * Access is determined solely by the permissions the user approved at enable
    * time. The manifest `agents` array declares agents the addon *provides*, not
    * agents it may invoke, so it plays no role here.
    */
   hasAgentAccess(addon: Addon, agentId: string): boolean {
-    const permissions = (addon.permissions as string[]) ?? [];
-
-    // Tier 1: unscoped — grants access to all agents
-    if (
-      permissions.includes('agents.invoke') ||
-      permissions.includes('agents.*') ||
-      permissions.includes('*')
-    ) {
-      return true;
-    }
-
-    // Tier 2: scoped — grants access to one specific agent
-    return permissions.includes(`agents.invoke:${agentId}`);
+    return this.hasScopedAccess(addon, 'agents.invoke', agentId);
   }
 
   /**
    * Check if an addon has access to write into a specific agent's workspace.
-   *
-   * Two tiers, checked in order (mirrors {@link hasAgentAccess}):
-   *   1. Unscoped: `workspace.write`, `workspace.*`, or `*` — access to all agents' workspaces.
-   *   2. Scoped:   `workspace.write:<agentId>`               — access to that agent's workspace only.
    */
   hasWorkspaceAccess(addon: Addon, agentId: string): boolean {
-    const permissions = (addon.permissions as string[]) ?? [];
-
-    // Tier 1: unscoped — grants access to all agents' workspaces
-    if (
-      permissions.includes('workspace.write') ||
-      permissions.includes('workspace.*') ||
-      permissions.includes('*')
-    ) {
-      return true;
-    }
-
-    // Tier 2: scoped — grants access to one specific agent's workspace
-    return permissions.includes(`workspace.write:${agentId}`);
+    return this.hasScopedAccess(addon, 'workspace.write', agentId);
   }
 
   /**

--- a/apps/server/src/addons/sdk-reference.ts
+++ b/apps/server/src/addons/sdk-reference.ts
@@ -91,6 +91,12 @@ export const SDK_METHODS: readonly SdkMethod[] = [
         kind: 'string',
         description: 'ID of the agent that should respond',
       },
+      {
+        name: 'attachmentIds',
+        kind: 'optional_array',
+        description:
+          'IDs returned by attachFile() to include as media on this message',
+      },
     ],
     returns: 'Promise<{ message: string; sessionId: string }>',
     description:
@@ -99,6 +105,33 @@ export const SDK_METHODS: readonly SdkMethod[] = [
       'Does NOT create a new session.',
     exampleJs:
       "sdk.sendMessage('sess-123', 'Summarize this', 'default').then(function(r) { console.log(r.message); });",
+  },
+  {
+    name: 'attachFile',
+    category: 'Sessions',
+    proxyPath: '/api/addon-proxy/sessions/:sessionId/attachments',
+    httpMethod: 'POST',
+    requiredPermission: 'sessions.write',
+    params: [
+      {
+        name: 'sessionId',
+        kind: 'string',
+        description: 'ID of the session to attach the file to',
+      },
+      {
+        name: 'file',
+        kind: 'object',
+        description:
+          '{ mimeType, data (base64), name? } — image/audio/video only',
+      },
+    ],
+    returns: 'Promise<{ id: string; mimeType: string; sizeBytes: number }>',
+    description:
+      'Upload an image/audio/video file for this session. The attachment is ' +
+      'unlinked until its id is passed in attachmentIds on a sendMessage call — ' +
+      'that is what makes it visible to the LLM (vision/audio-capable models only).',
+    exampleJs:
+      "sdk.attachFile('sess-123', { mimeType: 'image/png', data: base64Png }).then(function(a) { return sdk.sendMessage('sess-123', 'What is this?', 'default', [a.id]); });",
   },
   {
     name: 'getSession',
@@ -158,6 +191,34 @@ export const SDK_METHODS: readonly SdkMethod[] = [
     description: 'Invoke an agent with a prompt and get a response.',
     exampleJs:
       "sdk.invokeAgent('my-agent', 'Hello!').then(function(r) { console.log(r.message); });",
+  },
+  {
+    name: 'shareFile',
+    category: 'Agents',
+    proxyPath: '/api/addon-proxy/workspace/:agentId/files',
+    httpMethod: 'POST',
+    requiredPermission: 'workspace.write',
+    params: [
+      {
+        name: 'agentId',
+        kind: 'string',
+        description: 'ID of the agent whose workspace should receive the file',
+      },
+      {
+        name: 'file',
+        kind: 'object',
+        description:
+          '{ path, data (base64) } — any file type, e.g. csv/txt/json',
+      },
+    ],
+    returns: 'Promise<{ agentId: string; path: string }>',
+    description:
+      "Write a file into an agent's workspace. The agent reads it back with " +
+      'its own workspace_read/workspace_list tools — nothing is inlined into ' +
+      'the LLM context automatically. Use attachFile() instead for images/audio ' +
+      'you want the LLM to see inline.',
+    exampleJs:
+      "sdk.shareFile('my-agent', { path: 'shared/report.csv', data: base64Csv });",
   },
 
   // ── Config ────────────────────────────────────────────────────────────────
@@ -892,4 +953,20 @@ export function renderSdkReference(): string {
     }
   }
   return lines.join('\n');
+}
+
+/**
+ * Every distinct base (unscoped) permission string referenced by at least
+ * one SDK method's `requiredPermission` — sorted, deduped. This is the
+ * single source of truth for the "valid values" hint shown in
+ * addon_create/addon_update's `permissions` parameter, so adding a new SDK
+ * method's permission here updates both tool schemas automatically instead
+ * of drifting out of sync with a hand-maintained list.
+ */
+export function listSdkPermissions(): string[] {
+  const permissions = new Set<string>();
+  for (const method of SDK_METHODS) {
+    if (method.requiredPermission) permissions.add(method.requiredPermission);
+  }
+  return [...permissions].sort();
 }

--- a/apps/server/src/addons/types.ts
+++ b/apps/server/src/addons/types.ts
@@ -11,6 +11,8 @@ import type { SessionMessageService } from '../sessions/service';
 import type { AgentRegistry } from '../agents/registry';
 import type { TaskService } from '../tasks/service';
 import type { ChannelRegistry } from '../channels/registry';
+import type { WorkspaceService } from '../workspace';
+import type { AttachmentService } from '../attachments/service';
 
 // Forward declaration to avoid circular dependency
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,6 +34,10 @@ export interface AddonProxyRoutesOptions {
   jobsRepo?: JobsStore;
   jobRunsRepo?: JobRunsStore;
   sessionsRepo?: SessionsStore;
+  /** Enables `POST /addon-proxy/workspace/:agentId/files` (writing a file into an agent's workspace on the addon's behalf). */
+  workspaceService?: WorkspaceService;
+  /** Enables `POST /addon-proxy/sessions/:sessionId/attachments` (creating an unlinked attachment for a later message). */
+  attachmentService?: AttachmentService;
 }
 
 /**

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -892,6 +892,8 @@ export async function buildApp() {
                 sessionsRepo: dbAdapter.repositories.sessions,
               }
             : {}),
+          workspaceService,
+          ...(attachmentService ? { attachmentService } : {}),
         });
       }
     },

--- a/apps/server/src/attachments/service.ts
+++ b/apps/server/src/attachments/service.ts
@@ -28,6 +28,9 @@ export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
  */
 export const MAX_TOOL_OUTPUT_BYTES = 100 * 1024 * 1024;
 
+/** Max attachments a single message (human or addon-submitted) may reference. */
+export const MAX_ATTACHMENT_IDS_PER_MESSAGE = 10;
+
 /** Allowed mime types by kind. */
 const ALLOWED_MIME_TYPES: Record<AttachmentKind, readonly string[]> = {
   image: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],

--- a/apps/server/src/mcp/workspace-file-refs.test.ts
+++ b/apps/server/src/mcp/workspace-file-refs.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  WORKSPACE_URI_PREFIX,
+  WorkspaceFileRefError,
+  containsWorkspaceFileRef,
+  resolveWorkspaceFileRefs,
+} from './workspace-file-refs';
+import { createWorkspaceService, type WorkspaceService } from '../workspace';
+
+const PNG_1PX_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMEAYEuJ8C4AAAAAElFTkSuQmCC';
+
+describe('containsWorkspaceFileRef', () => {
+  it('finds a top-level reference', () => {
+    expect(
+      containsWorkspaceFileRef({ image_source: 'workspace://a.jpg' }),
+    ).toBe(true);
+  });
+
+  it('finds a reference nested in an object', () => {
+    expect(
+      containsWorkspaceFileRef({ opts: { file: 'workspace://a.jpg' } }),
+    ).toBe(true);
+  });
+
+  it('finds a reference nested in an array', () => {
+    expect(containsWorkspaceFileRef({ files: ['workspace://a.jpg'] })).toBe(
+      true,
+    );
+  });
+
+  it('returns false when nothing matches', () => {
+    expect(
+      containsWorkspaceFileRef({
+        prompt: 'describe this',
+        url: 'https://example.com/a.jpg',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match a bare path without the prefix', () => {
+    expect(containsWorkspaceFileRef({ image_source: 'tickets/a.jpg' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('resolveWorkspaceFileRefs', () => {
+  let baseDir: string;
+  let workspace: WorkspaceService;
+  const agentId = 'agent-1';
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'workspace-file-refs-test-'));
+    workspace = createWorkspaceService({ baseDir });
+    mkdirSync(join(baseDir, agentId, 'tickets'), { recursive: true });
+    writeFileSync(
+      join(baseDir, agentId, 'tickets', 'receipt.png'),
+      Buffer.from(PNG_1PX_BASE64, 'base64'),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('replaces a workspace:// reference with a data: URI', async () => {
+    const args = { image_source: `${WORKSPACE_URI_PREFIX}tickets/receipt.png` };
+    const resolved = await resolveWorkspaceFileRefs(args, workspace, agentId);
+    expect(resolved['image_source']).toBe(
+      `data:image/png;base64,${PNG_1PX_BASE64}`,
+    );
+  });
+
+  it('does not mutate the original arguments object', async () => {
+    const args = { image_source: `${WORKSPACE_URI_PREFIX}tickets/receipt.png` };
+    await resolveWorkspaceFileRefs(args, workspace, agentId);
+    expect(args.image_source).toBe(
+      `${WORKSPACE_URI_PREFIX}tickets/receipt.png`,
+    );
+  });
+
+  it('resolves a reference nested in an object and an array', async () => {
+    const args = {
+      opts: { image_source: `${WORKSPACE_URI_PREFIX}tickets/receipt.png` },
+      files: [`${WORKSPACE_URI_PREFIX}tickets/receipt.png`],
+      prompt: 'describe this',
+    };
+    const resolved = (await resolveWorkspaceFileRefs(
+      args,
+      workspace,
+      agentId,
+    )) as typeof args;
+    expect(resolved.opts.image_source).toContain('data:image/png;base64,');
+    expect(resolved.files[0]).toContain('data:image/png;base64,');
+    expect(resolved.prompt).toBe('describe this');
+  });
+
+  it('leaves non-workspace strings untouched', async () => {
+    const args = {
+      prompt: 'describe this',
+      url: 'https://example.com/a.jpg',
+    };
+    const resolved = await resolveWorkspaceFileRefs(args, workspace, agentId);
+    expect(resolved).toEqual(args);
+  });
+
+  it('throws WorkspaceFileRefError for a missing file', async () => {
+    const args = { image_source: `${WORKSPACE_URI_PREFIX}tickets/missing.png` };
+    await expect(
+      resolveWorkspaceFileRefs(args, workspace, agentId),
+    ).rejects.toThrow(WorkspaceFileRefError);
+  });
+
+  it('throws WorkspaceFileRefError for a path-traversal attempt', async () => {
+    const args = { image_source: `${WORKSPACE_URI_PREFIX}../../etc/passwd` };
+    await expect(
+      resolveWorkspaceFileRefs(args, workspace, agentId),
+    ).rejects.toThrow(WorkspaceFileRefError);
+  });
+
+  it('throws WorkspaceFileRefError for an oversized file', async () => {
+    writeFileSync(
+      join(baseDir, agentId, 'tickets', 'big.bin'),
+      Buffer.alloc(101 * 1024 * 1024),
+    );
+    const args = { image_source: `${WORKSPACE_URI_PREFIX}tickets/big.bin` };
+    await expect(
+      resolveWorkspaceFileRefs(args, workspace, agentId),
+    ).rejects.toThrow(WorkspaceFileRefError);
+  });
+});

--- a/apps/server/src/mcp/workspace-file-refs.ts
+++ b/apps/server/src/mcp/workspace-file-refs.ts
@@ -1,0 +1,123 @@
+/**
+ * Workspace file references → resolved bytes for outbound MCP tool calls
+ *
+ * Third-party MCP tools (e.g. a vision-analysis tool) run as separate
+ * processes with no knowledge of an agent's workspace directory — they can
+ * only accept an http(s) URL, a base64 `data:` URI, or a path resolvable on
+ * their OWN filesystem/cwd. OpenAidy's workspace tools deliberately never
+ * expose the real absolute path to the agent (sandbox boundary), so an agent
+ * has no path it could hand such a tool that would ever resolve.
+ *
+ * This module bridges that gap in the opposite direction from
+ * `screenshot-capture.ts` (which persists an MCP tool's *output* bytes into
+ * the workspace): before an external MCP tool call is forwarded, any string
+ * argument value of the form `workspace://<relative-path>` is resolved
+ * server-side — through the same `validatePath` guard every other workspace
+ * operation uses (via `WorkspaceService.readRawFile`) — and replaced with a
+ * `data:<mime>;base64,<bytes>` URI.
+ *
+ * The substitution happens only on the copy of the arguments actually sent to
+ * the tool. The original tool-call record (and therefore conversation
+ * history) keeps the short `workspace://...` reference, never the encoded
+ * bytes — so this never bloats context regardless of file size, unlike
+ * having the model itself relay base64 through its own generated text.
+ */
+
+import { MAX_TOOL_OUTPUT_BYTES } from '../attachments/service';
+import type { WorkspaceService } from '../workspace/service';
+
+/** Prefix identifying a workspace-relative file reference in a tool argument. */
+export const WORKSPACE_URI_PREFIX = 'workspace://';
+
+/**
+ * Thrown when a `workspace://` reference can't be resolved (missing file,
+ * path traversal, oversized). Callers should convert this into a normal
+ * tool-call error result rather than letting it propagate as a crash.
+ */
+export class WorkspaceFileRefError extends Error {
+  constructor(
+    message: string,
+    public readonly ref: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'WorkspaceFileRefError';
+  }
+}
+
+function isWorkspaceRef(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(WORKSPACE_URI_PREFIX);
+}
+
+/**
+ * Cheap recursive scan for any `workspace://` reference in a tool-call
+ * arguments value, so the (async, filesystem-touching) resolution pass can be
+ * skipped entirely for the common case of no reference.
+ */
+export function containsWorkspaceFileRef(value: unknown): boolean {
+  if (isWorkspaceRef(value)) return true;
+  if (Array.isArray(value)) return value.some(containsWorkspaceFileRef);
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(
+      containsWorkspaceFileRef,
+    );
+  }
+  return false;
+}
+
+/** Recursively resolve `workspace://` strings within an arbitrary JSON value. */
+async function resolveValue(
+  value: unknown,
+  workspace: WorkspaceService,
+  agentId: string,
+): Promise<unknown> {
+  if (isWorkspaceRef(value)) {
+    const relPath = value.slice(WORKSPACE_URI_PREFIX.length);
+    try {
+      const { buffer, mimeType } = await workspace.readRawFile(
+        agentId,
+        relPath,
+        { maxBytes: MAX_TOOL_OUTPUT_BYTES },
+      );
+      return `data:${mimeType};base64,${buffer.toString('base64')}`;
+    } catch (err) {
+      throw new WorkspaceFileRefError(
+        `Failed to resolve ${value}: ${err instanceof Error ? err.message : String(err)}`,
+        value,
+        err instanceof Error ? err : undefined,
+      );
+    }
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v) => resolveValue(v, workspace, agentId)));
+  }
+  if (value && typeof value === 'object') {
+    const entries = await Promise.all(
+      Object.entries(value as Record<string, unknown>).map(
+        async ([k, v]) =>
+          [k, await resolveValue(v, workspace, agentId)] as const,
+      ),
+    );
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+/**
+ * Deep-clones `args`, replacing every `workspace://<path>` string with a
+ * `data:<mime>;base64,<bytes>` URI read from the agent's workspace. The input
+ * object is never mutated — callers must keep using the original for
+ * anything that gets persisted (e.g. the tool-call record).
+ *
+ * Throws {@link WorkspaceFileRefError} on the first unresolvable reference
+ * (missing file, path traversal, oversized).
+ */
+export async function resolveWorkspaceFileRefs(
+  args: Record<string, unknown>,
+  workspace: WorkspaceService,
+  agentId: string,
+): Promise<Record<string, unknown>> {
+  return resolveValue(args, workspace, agentId) as Promise<
+    Record<string, unknown>
+  >;
+}

--- a/apps/server/src/prompts/build-system-prompt.test.ts
+++ b/apps/server/src/prompts/build-system-prompt.test.ts
@@ -142,3 +142,35 @@ describe('buildSystemPrompt — [ADDONS_AVAILABLE] block', () => {
     expect(prompt).not.toContain('[ADDONS_AVAILABLE]');
   });
 });
+
+describe('buildSystemPrompt — workspace:// external-tool guidance', () => {
+  const WORKSPACE_READ_TOOL: ToolDefinition = {
+    name: 'workspace_read',
+    description: 'Read a file from your workspace',
+    parameters: { type: 'object' },
+  };
+  const OTHER_TOOL: ToolDefinition = {
+    name: 'web_search',
+    description: 'Search the web',
+    parameters: { type: 'object' },
+  };
+
+  it('documents the workspace:// convention when workspace_read is available', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [WORKSPACE_READ_TOOL],
+    });
+    expect(prompt).toContain('workspace://<relative-path>');
+    expect(prompt).toContain('image_source: "workspace://tickets/receipt.jpg"');
+  });
+
+  it('omits the guidance when workspace_read is not available', async () => {
+    const prompt = await buildSystemPrompt({
+      agentId: 'a1',
+      basePrompt: 'BASE',
+      tools: [OTHER_TOOL],
+    });
+    expect(prompt).not.toContain('workspace://<relative-path>');
+  });
+});

--- a/apps/server/src/prompts/build-system-prompt.ts
+++ b/apps/server/src/prompts/build-system-prompt.ts
@@ -487,6 +487,13 @@ ${formatSessionSearchResultDocs()}
 `;
   }
 
+  if (hasWorkspaceRead) {
+    guidelines += `
+### Passing a workspace file to an external/MCP tool
+A path from workspace_read/workspace_list (e.g. "tickets/receipt.jpg") only works with workspace_* tools — external MCP tools run as separate processes and cannot open it, no matter how you format it (relative, absolute-looking, backslashes). To pass a workspace file to any OTHER tool (e.g. an image-analysis tool), reference it as workspace://<relative-path> in that tool's argument instead — the server resolves it to the actual file automatically before the call. Example: image_source: "workspace://tickets/receipt.jpg". Do not try to guess or construct a real filesystem path for external tools.
+`;
+  }
+
   guidelines += `
 ## HONESTY REQUIREMENTS (VIOLATING THESE IS A BUG)
 

--- a/apps/server/src/routes/attachments.ts
+++ b/apps/server/src/routes/attachments.ts
@@ -9,7 +9,12 @@ import {
 } from '../attachments/service';
 import type { SessionMessageService } from '../sessions/service';
 
-const uploadAttachmentSchema = z.object({
+/**
+ * Exported so the addon-proxy's attachment-create route (which lets an
+ * addon upload a file for a session it's posting to) validates against the
+ * exact same rules as this human-facing route — one schema, two callers.
+ */
+export const uploadAttachmentSchema = z.object({
   mimeType: z.string().min(1),
   /** Base64-encoded bytes (no data: URI prefix) */
   data: z.string().min(1),

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { SessionMessageService } from '../sessions/service';
 import type { AuthMiddleware } from '../websocket/middleware/auth';
 import { requireAuth } from '../middleware/require-auth';
+import { MAX_ATTACHMENT_IDS_PER_MESSAGE } from '../attachments/service';
 
 const createSessionSchema = z.object({
   title: z.string().min(1),
@@ -31,7 +32,10 @@ const submitMessageSchema = z
     agentId: z.string().optional(),
     providerId: z.string().optional(),
     modelId: z.string().optional(),
-    attachmentIds: z.array(z.string()).max(10).optional(),
+    attachmentIds: z
+      .array(z.string())
+      .max(MAX_ATTACHMENT_IDS_PER_MESSAGE)
+      .optional(),
   })
   .refine((body) => body.content.length > 0 || body.attachmentIds?.length, {
     message: 'content is required unless attachments are provided',

--- a/apps/server/src/sdk/openaidy-sdk.js
+++ b/apps/server/src/sdk/openaidy-sdk.js
@@ -205,6 +205,10 @@
   // default would reject a request that actually succeeds. A generous ceiling
   // still guards against a truly hung run / lost response.
   var AGENT_REQUEST_TIMEOUT_MS = 300000; // 5 minutes
+  // Timeout for file uploads (shareFile, attachFile). These transfer a
+  // base64 body rather than running an agent, but can still be several MB —
+  // longer than the default, well short of the agent ceiling.
+  var UPLOAD_REQUEST_TIMEOUT_MS = 30000;
 
   // Send a proxied API request through the parent. `timeoutMs` overrides the
   // default for long-running calls.
@@ -423,17 +427,37 @@
     listSessions: function () {
       return request('GET', '/api/addon-proxy/sessions');
     },
-    sendMessage: function (sessionId, content, agentId) {
+    sendMessage: function (sessionId, content, agentId, attachmentIds) {
       // Runs the agent to completion server-side — allow the long timeout.
       return request(
         'POST',
         '/api/addon-proxy/sessions/' + sessionId + '/messages',
-        { content: content, agentId: agentId },
+        {
+          content: content,
+          agentId: agentId,
+          attachmentIds: attachmentIds || undefined,
+        },
         AGENT_REQUEST_TIMEOUT_MS,
       );
     },
     getSession: function (sessionId) {
       return request('GET', '/api/addon-proxy/sessions/' + sessionId);
+    },
+    /**
+     * Upload an image/audio/video file for `sessionId`, resolving
+     * `{id, ...}`. The attachment is unlinked until you pass its `id` in
+     * `attachmentIds` on a subsequent `sendMessage` call — that's what makes
+     * it visible to the LLM (for vision/audio-capable models).
+     * Requires the `sessions.write` permission.
+     */
+    attachFile: function (sessionId, file) {
+      file = file || {};
+      return request(
+        'POST',
+        '/api/addon-proxy/sessions/' + sessionId + '/attachments',
+        { mimeType: file.mimeType, data: file.data, name: file.name },
+        UPLOAD_REQUEST_TIMEOUT_MS,
+      );
     },
 
     // ── Agents ────────────────────────────────────────────────────────────
@@ -450,6 +474,22 @@
           context: context ?? {},
         },
         AGENT_REQUEST_TIMEOUT_MS,
+      );
+    },
+    /**
+     * Write a file (csv, txt, json, any type) into `agentId`'s workspace,
+     * resolving `{agentId, path}`. The agent reads it back with its own
+     * workspace_read/workspace_list tools — nothing is inlined into the
+     * LLM's context automatically. Requires the `workspace.write` (or
+     * `workspace.write:<agentId>`) permission.
+     */
+    shareFile: function (agentId, file) {
+      file = file || {};
+      return request(
+        'POST',
+        '/api/addon-proxy/workspace/' + agentId + '/files',
+        { path: file.path, data: file.data },
+        UPLOAD_REQUEST_TIMEOUT_MS,
       );
     },
 

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -11,6 +11,10 @@ import {
   MEDIA_WORKSPACE_DIR,
   type PersistedImage,
 } from '../mcp/screenshot-capture';
+import {
+  containsWorkspaceFileRef,
+  resolveWorkspaceFileRefs,
+} from '../mcp/workspace-file-refs';
 import type { BuiltinToolRegistry } from '../tools';
 import type { MediaShareResult } from '../tools/media/share';
 import type { AttachmentService } from '../attachments/service';
@@ -1909,19 +1913,51 @@ export class SessionMessageService {
                 ? stripScreenshotFilename(tc.arguments)
                 : { forwardedArgs: tc.arguments, requestedFilename: undefined };
 
-              let mcpResult = await this.mcp
-                ?.callTool(mcpServerId, mcpToolName, forwardedArgs)
-                .catch((e: unknown) => {
+              // A `workspace://<path>` reference in an argument value lets the
+              // model hand this external tool a workspace file (e.g. an image
+              // to analyze) without ever learning its absolute path. Resolved
+              // only in the copy forwarded to the tool — `tc.arguments`, what
+              // gets persisted in history, keeps the short reference, never
+              // the encoded bytes.
+              let mcpResult: McpToolResult | undefined;
+              if (this.workspace && containsWorkspaceFileRef(forwardedArgs)) {
+                try {
+                  const resolvedArgs = await resolveWorkspaceFileRefs(
+                    forwardedArgs,
+                    this.workspace,
+                    agentId,
+                  );
+                  mcpResult = await this.mcp?.callTool(
+                    mcpServerId,
+                    mcpToolName,
+                    resolvedArgs,
+                  );
+                } catch (e) {
                   toolIsError = true;
-                  return {
+                  mcpResult = {
                     content: [
                       {
-                        type: 'text',
+                        type: 'text' as const,
                         text: `Error: ${e instanceof Error ? e.message : String(e)}`,
                       },
                     ],
                   };
-                });
+                }
+              } else {
+                mcpResult = await this.mcp
+                  ?.callTool(mcpServerId, mcpToolName, forwardedArgs)
+                  .catch((e: unknown) => {
+                    toolIsError = true;
+                    return {
+                      content: [
+                        {
+                          type: 'text' as const,
+                          text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+                        },
+                      ],
+                    };
+                  });
+              }
 
               // Persist any inline image the tool returned into the agent
               // workspace — screenshots keep their dedicated folder, other

--- a/apps/server/src/tools/addons/create.test.ts
+++ b/apps/server/src/tools/addons/create.test.ts
@@ -580,4 +580,28 @@ describe('sdk-reference', () => {
     expect(names).toContain('storage.search');
     expect(renderSdkReference()).toContain('Storage');
   });
+
+  it('listSdkPermissions includes every distinct requiredPermission, deduped and sorted', async () => {
+    const { listSdkPermissions } =
+      await import('../../addons/sdk-reference.js');
+    const permissions = listSdkPermissions();
+    expect(permissions).toContain('workspace.write');
+    expect(permissions).toContain('sessions.write');
+    expect(permissions).toContain('agents.invoke');
+    expect(permissions).toContain('storage.read');
+    // deduped: storage.read/storage.write appear on multiple methods
+    expect(permissions.filter((p) => p === 'storage.read')).toHaveLength(1);
+    expect(permissions).toEqual([...permissions].sort());
+  });
+
+  it("addon_create's permissions parameter derives its valid-values list from SDK_METHODS (not a hand-typed list)", () => {
+    const standaloneTool = createAddonCreateTool({ addonsDir: os.tmpdir() });
+    const params = standaloneTool.parameters as unknown as {
+      properties: { permissions: { description: string } };
+    };
+    const description = params.properties.permissions.description;
+    expect(description).toContain('workspace.write');
+    expect(description).toContain('sessions.write');
+    expect(description).toContain('shareFile');
+  });
 });

--- a/apps/server/src/tools/addons/create.ts
+++ b/apps/server/src/tools/addons/create.ts
@@ -22,7 +22,11 @@ import { generateFromTemplate } from '@openaidy/addon-scaffolding';
 import type { AddonService } from '../../addons/service.js';
 import type { AddonManifest } from '@openaidy/shared-types';
 import { AddonServiceError } from '../../addons/types.js';
-import { renderSdkReference, SDK_METHODS } from '../../addons/sdk-reference.js';
+import {
+  renderSdkReference,
+  listSdkPermissions,
+  SDK_METHODS,
+} from '../../addons/sdk-reference.js';
 import { addonCreateMeta } from '../catalog.js';
 import {
   isValidId,
@@ -59,7 +63,7 @@ OpenAidy.ready(function(sdk) {
 });`;
 }
 
-function buildSdkUsageComment(permissions: string[]): string {
+export function buildSdkUsageComment(permissions: string[]): string {
   const relevant = SDK_METHODS.filter(
     (m) => !m.requiredPermission || permissions.includes(m.requiredPermission),
   );
@@ -75,6 +79,7 @@ function buildSdkUsageComment(permissions: string[]): string {
 
 export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
   const sdkReference = renderSdkReference();
+  const validPermissions = listSdkPermissions().join(', ');
 
   return {
     name: addonCreateMeta.name,
@@ -248,10 +253,12 @@ export function createAddonCreateTool(deps: AddonToolDeps): BuiltinTool {
           items: { type: 'string' },
           description:
             'SDK permissions this addon requires. ' +
-            'Valid values: agents.list, agents.invoke, sessions.list, ' +
-            'sessions.read, sessions.write, config.read. Only request what you actually use. ' +
+            `Valid base values: ${validPermissions}. Only request what you actually use. ` +
+            'Append ":<agentId>" to agents.invoke or workspace.write to scope it to one agent ' +
+            'instead of granting it for every agent (e.g. "workspace.write:my-agent"). ' +
             'NOTE: sessions are created automatically by agents.invoke — there is no sessions.create permission. ' +
-            'sessions.write = send a message to an existing session via sdk.sendMessage().',
+            'sessions.write = send a message via sdk.sendMessage() or attach a file via sdk.attachFile(). ' +
+            "workspace.write = share a file into an agent's workspace via sdk.shareFile().",
         },
         externalDomains: {
           type: 'array',

--- a/apps/server/src/tools/addons/update.test.ts
+++ b/apps/server/src/tools/addons/update.test.ts
@@ -86,6 +86,25 @@ describe('addon_update tool', () => {
     expect(required).toEqual(['id']);
   });
 
+  it('description embeds the SDK reference, same as addon_create', () => {
+    // addon_update is the tool used to add a new feature (e.g. a file-upload
+    // form) to an existing addon, so it needs the same SDK awareness as
+    // addon_create — not just a permissions checklist.
+    expect(tool.description).toContain('listAgents');
+    expect(tool.description).toContain('invokeAgent');
+    expect(tool.description).toContain('shareFile');
+    expect(tool.description).toContain('attachFile');
+  });
+
+  it('permissions parameter derives its valid-values list from SDK_METHODS', () => {
+    const params = tool.parameters as unknown as {
+      properties: { permissions: { description: string } };
+    };
+    const description = params.properties.permissions.description;
+    expect(description).toContain('workspace.write');
+    expect(description).toContain('sessions.write');
+  });
+
   // ── Input validation ───────────────────────────────────────────────────────
 
   it('rejects missing id', async () => {
@@ -412,6 +431,31 @@ describe('addon_update tool', () => {
     );
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.content).not.toContain('Permissions changed');
+  });
+
+  it('shows a usage hint for the newly granted SDK methods when permissions are replaced', async () => {
+    const mockAddonService = { updateAddon: async () => ({}) };
+    const toolWithService = createAddonUpdateTool({
+      addonsDir,
+      addonService: mockAddonService as never,
+    });
+    const result = await toolWithService.execute(
+      { id: 'demo', permissions: ['workspace.write'] },
+      CTX,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.content).toContain('shareFile');
+  });
+
+  it('shows no usage hint when permissions are not part of the update', async () => {
+    const result = await tool.execute(
+      { id: 'demo', files: { 'app/index.js': '// just files' } },
+      CTX,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.content).not.toContain('Available SDK methods');
+    }
   });
 
   it('surfaces a warning when addonService.updateAddon throws', async () => {

--- a/apps/server/src/tools/addons/update.ts
+++ b/apps/server/src/tools/addons/update.ts
@@ -11,6 +11,13 @@
  *
  * For creating a brand-new addon use `addon_create`. This tool refuses to
  * run if the addon does not already exist.
+ *
+ * Architecture note
+ * ─────────────────
+ * SDK documentation is imported from `../../addons/sdk-reference.ts` —
+ * the single source of truth, same as addon_create. When sdk-reference.ts is
+ * updated (new method added, signature changed), this tool's description and
+ * its "valid permission values" hint update automatically.
  */
 
 import { existsSync } from 'node:fs';
@@ -19,6 +26,11 @@ import type { BuiltinTool } from '@openaidy/runtime';
 import type { AddonManifest } from '@openaidy/shared-types';
 import { AddonServiceError } from '../../addons/types.js';
 import type { AddonToolDeps } from './create.js';
+import { buildSdkUsageComment } from './create.js';
+import {
+  renderSdkReference,
+  listSdkPermissions,
+} from '../../addons/sdk-reference.js';
 import { addonUpdateMeta } from '../catalog.js';
 import {
   isValidId,
@@ -40,6 +52,9 @@ const MANIFEST_FIELD_KEYS = [
 // ── Tool factory ──────────────────────────────────────────────────────────────
 
 export function createAddonUpdateTool(deps: AddonToolDeps): BuiltinTool {
+  const sdkReference = renderSdkReference();
+  const validPermissions = listSdkPermissions().join(', ');
+
   return {
     name: addonUpdateMeta.name,
 
@@ -97,6 +112,17 @@ export function createAddonUpdateTool(deps: AddonToolDeps): BuiltinTool {
       'Changing permissions updates the manifest and DB. An addon iframe that is',
       'already open keeps its old access token until it is reloaded (or the addon',
       'is disabled/re-enabled), so tell the user to reload after a permission change.',
+      '',
+      'ADDING A NEW FEATURE TO THIS ADDON',
+      '───────────────────────────────────',
+      'If the feature you are adding needs an SDK method the addon does not already',
+      'use (e.g. a file-upload form that shares an image with an agent for analysis',
+      'via sdk.shareFile()/sdk.attachFile()), you must also add the matching permission',
+      'to the `permissions` parameter below — the method silently fails at runtime',
+      'without it, even though the code will look correct. See the reference below',
+      'for every available method and the permission it requires.',
+      '',
+      sdkReference,
     ].join('\n'),
 
     parameters: {
@@ -136,8 +162,11 @@ export function createAddonUpdateTool(deps: AddonToolDeps): BuiltinTool {
           type: 'array',
           items: { type: 'string' },
           description:
-            'Replacement permission set. Valid values: agents.list, agents.invoke, ' +
-            'sessions.list, sessions.read, sessions.write, config.read.',
+            'Replacement permission set — REPLACES the previous list entirely, so include ' +
+            'every permission the addon still needs, not just the new one. ' +
+            `Valid base values: ${validPermissions}. Append ":<agentId>" to agents.invoke or ` +
+            'workspace.write to scope it to one agent (e.g. "workspace.write:my-agent"). ' +
+            'See the SDK reference above for which method needs which permission.',
         },
         externalDomains: {
           type: 'array',
@@ -442,6 +471,13 @@ export function createAddonUpdateTool(deps: AddonToolDeps): BuiltinTool {
       }
 
       // ── Success ──────────────────────────────────────────────────────────
+      // When permissions were replaced, remind the agent which SDK methods
+      // the new set actually unlocks — same hint addon_create shows on create.
+      const usageHint =
+        permissions !== undefined
+          ? buildSdkUsageComment(permissions as string[])
+          : '';
+
       return {
         ok: true,
         content: [
@@ -453,6 +489,7 @@ export function createAddonUpdateTool(deps: AddonToolDeps): BuiltinTool {
             ? ['', 'Files deleted:', ...deleted.map((f) => `  ${f}`)]
             : []),
           ...(notes.length ? ['', ...notes] : []),
+          ...(usageHint ? ['', usageHint] : []),
           '',
           'Reload the addon in the UI to see the changes.',
         ].join('\n'),


### PR DESCRIPTION
## Summary

Addons had no way to hand a file (image, csv, txt, etc.) to an agent. This adds two permission-gated addon-proxy endpoints, mirroring the existing `agents.invoke` two-tier scoping pattern — the addon never gets filesystem access or a real path; the server performs the write/registration on its behalf after checking the addon's granted permissions.

- **`POST /addon-proxy/workspace/:agentId/files`** — writes an arbitrary file into an agent's workspace on the addon's behalf (`workspace.write` / `workspace.write:<agentId>`). The agent reads it back via its own `workspace_read`/`workspace_list` tools; nothing is auto-inlined into the LLM's context.
- **`POST /addon-proxy/sessions/:sessionId/attachments`** — creates an unlinked image/audio/video attachment (`sessions.write`), reusing the human-facing route's exact validation (`uploadAttachmentSchema`, `AttachmentService.saveUpload`).
- The existing `POST /addon-proxy/sessions/:sessionId/messages` route now accepts `attachmentIds` to link an attachment in, making it visible to vision/audio-capable models via the existing `submitMessageStreaming` linking logic.
- New `AddonProxyService.hasWorkspaceAccess()`, mirroring `hasAgentAccess()`'s unscoped/scoped permission tiers.
- SDK: `OpenAidy.shareFile(agentId, {path, data})`, `OpenAidy.attachFile(sessionId, {mimeType, data, name})`, and `sendMessage` gained an optional 4th `attachmentIds` argument.

## Also included: addon_create / addon_update tool awareness

- `addon_create`'s `permissions` parameter had a hand-typed "valid values" list that had already drifted out of sync (missing `storage.*`, and now `workspace.write`). Replaced it with `listSdkPermissions()` — derived from `SDK_METHODS`' `requiredPermission` field, so it can never drift again.
- `addon_update` (the tool used to add a feature to an *existing* addon — the realistic path for "add a file-upload form to my addon") previously embedded **no** SDK reference at all, not even for `sendMessage`/`invokeAgent`. It now embeds the same `renderSdkReference()` block `addon_create` does, uses the same dynamic permissions list, and shows a "newly available SDK methods" usage hint in its output when permissions change (reusing `addon_create`'s existing `buildSdkUsageComment`, now exported).

## Test plan

- [x] `pnpm --filter @openaidy/server build` — clean typecheck
- [x] `pnpm --filter @openaidy/server lint` — clean
- [x] `pnpm --filter @openaidy/server test` — 385 tests passing across `addons/`, `tools/addons/`, `routes/attachments`, `app.test.ts`, including 14 new tests covering the two new routes, `hasWorkspaceAccess`, `attachmentIds` threading, and the dynamic permissions-list derivation
- [x] Manually verified end-to-end against a live dev server: disconnected/reconnected the target agent's workspace and a real session, called both new routes with a minted addon token, confirmed the file landed on disk and the attachment appeared correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
