### PR TITLE
chore(release): bump version to 0.3.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaidy",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Minor version bump, `0.3.14` → `0.3.15`. Carries since 0.3.14:

- Addons can share files into an agent's workspace via `sdk.shareFile()` (#509).
- `docs/` rebuilt from scratch as real user-facing documentation, with the old mixed dev-planning content moved to `plans/` (#510).
- Addons can record audio and take photos via the host (`sdk.media.*`), with the browser's own Web Speech API providing a free transcript — no LLM call needed just to get text out of a voice note (#511).

Once merged, tagging `v0.3.15` on `main` will trigger `.github/workflows/release.yml` (gate → publish to npm → GitHub Release).

## Test plan

- [x] Version-only change — no code touched, existing test suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)